### PR TITLE
updated environment.yml with explicit pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
 - eccodes=>2.19.0
 - python-eccodes
+- pip
 - numpy
 - pandas
 - xarray>=0.19.0


### PR DESCRIPTION
Conda "nags" users to add pip to environment.yml if using pip to install dependencies alongside conda packages.

```
$ mamba env create -f environment.yml

Retrieving notices: ...working... done
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```