### PR TITLE
pyfdb in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 - jupyterlab
 - pip:
   - git+https://github.com/ecmwf/multiurl
+  - pyfdb
 - tqdm
 - make
 - mypy


### PR DESCRIPTION
[pyfdb](https://github.com/ecmwf/pyfdb) is required by [fdb_stream.ipynb](https://github.com/ecmwf/earthkit-data/blob/main/docs/examples/fdb_stream.ipynb).

It is not a conda package but it is on PyPI (i.e. can be installed using pip)