### PR TITLE
add link to eccodes grib namespace in grib_metadata.ipynb

### DIFF
--- a/docs/examples/grib_metadata.ipynb
+++ b/docs/examples/grib_metadata.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!test -f test6.grib || wget https://get.ecmwf.int/repository/test-data/emohawk/examples/test6.grib"
@@ -26,7 +28,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import earthkit.data\n",
@@ -69,7 +73,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -175,8 +181,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "2   ecmf         v  isobaricInhPa   1000  20180801      1200         0   \n",
        "3   ecmf         t  isobaricInhPa    850  20180801      1200         0   \n",
@@ -209,7 +215,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -276,8 +284,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "\n",
        "  dataType  number    gridType  \n",
@@ -297,7 +305,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -364,8 +374,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "\n",
        "  dataType  number    gridType  \n",
@@ -386,12 +396,122 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The keys can be taken from an ecCodes GRIB namespace:"
+    "The keys can be taken from an [ecCodes GRIB namespace](https://user-images.githubusercontent.com/16657983/236216946-9fea8461-1d43-4986-a258-2c81faee482c.png):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>max</th>\n",
+       "      <th>min</th>\n",
+       "      <th>avg</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>skew</th>\n",
+       "      <th>kurt</th>\n",
+       "      <th>const</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>320.564178</td>\n",
+       "      <td>240.564178</td>\n",
+       "      <td>279.707036</td>\n",
+       "      <td>19.674217</td>\n",
+       "      <td>-0.731230</td>\n",
+       "      <td>-0.169046</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>17.713120</td>\n",
+       "      <td>-6.286880</td>\n",
+       "      <td>-0.382119</td>\n",
+       "      <td>5.605310</td>\n",
+       "      <td>1.139004</td>\n",
+       "      <td>1.018780</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>11.833481</td>\n",
+       "      <td>-16.166519</td>\n",
+       "      <td>-0.071281</td>\n",
+       "      <td>6.140457</td>\n",
+       "      <td>-0.217654</td>\n",
+       "      <td>-0.839983</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>304.539169</td>\n",
+       "      <td>232.539169</td>\n",
+       "      <td>272.729646</td>\n",
+       "      <td>19.241867</td>\n",
+       "      <td>-0.998189</td>\n",
+       "      <td>0.135718</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>27.101624</td>\n",
+       "      <td>-12.898376</td>\n",
+       "      <td>0.339719</td>\n",
+       "      <td>8.141047</td>\n",
+       "      <td>1.542573</td>\n",
+       "      <td>1.864089</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          max         min         avg         sd      skew      kurt  const\n",
+       "0  320.564178  240.564178  279.707036  19.674217 -0.731230 -0.169046    0.0\n",
+       "1   17.713120   -6.286880   -0.382119   5.605310  1.139004  1.018780    0.0\n",
+       "2   11.833481  -16.166519   -0.071281   6.140457 -0.217654 -0.839983    0.0\n",
+       "3  304.539169  232.539169  272.729646  19.241867 -0.998189  0.135718    0.0\n",
+       "4   27.101624  -12.898376    0.339719   8.141047  1.542573  1.864089    0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fs.head(namespace=\"statistics\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -476,7 +596,7 @@
        "4   ecmf      131  m s**-1  U component of wind         u"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -494,7 +614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -543,7 +663,7 @@
        "1             4  grid_simple"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -561,7 +681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -674,8 +794,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "2   ecmf         v  isobaricInhPa   1000  20180801      1200         0   \n",
        "3   ecmf         t  isobaricInhPa    850  20180801      1200         0   \n",
@@ -689,7 +809,7 @@
        "4       an       0  regular_ll      131  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -714,7 +834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -821,8 +941,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         u  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         v  isobaricInhPa   1000  20180801      1200         0   \n",
        "2   ecmf         t  isobaricInhPa    850  20180801      1200         0   \n",
        "3   ecmf         u  isobaricInhPa    850  20180801      1200         0   \n",
@@ -836,7 +956,7 @@
        "4       an       0  regular_ll  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -861,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -981,8 +1101,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "2   ecmf         v  isobaricInhPa   1000  20180801      1200         0   \n",
        "3   ecmf         t  isobaricInhPa    850  20180801      1200         0   \n",
@@ -998,7 +1118,7 @@
        "5       an       0  regular_ll  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1016,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1084,8 +1204,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         t  isobaricInhPa   1000  20180801      1200         0  \\\n",
        "1   ecmf         u  isobaricInhPa   1000  20180801      1200         0   \n",
        "\n",
        "  dataType  number    gridType  \n",
@@ -1093,7 +1213,7 @@
        "1       an       0  regular_ll  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1104,7 +1224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1172,8 +1292,8 @@
        "</div>"
       ],
       "text/plain": [
-       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange  \\\n",
-       "0   ecmf         u  isobaricInhPa    850  20180801      1200         0   \n",
+       "  centre shortName    typeOfLevel  level  dataDate  dataTime stepRange   \n",
+       "0   ecmf         u  isobaricInhPa    850  20180801      1200         0  \\\n",
        "1   ecmf         v  isobaricInhPa    850  20180801      1200         0   \n",
        "\n",
        "  dataType  number    gridType  \n",
@@ -1181,7 +1301,7 @@
        "1       an       0  regular_ll  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1206,34 +1326,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_02b8c th {\n",
+       "#T_8ae4e th {\n",
        "  text-align: left;\n",
        "}\n",
-       "#T_02b8c_row0_col0, #T_02b8c_row0_col1, #T_02b8c_row0_col2, #T_02b8c_row0_col3, #T_02b8c_row0_col4, #T_02b8c_row0_col5, #T_02b8c_row0_col6, #T_02b8c_row0_col7, #T_02b8c_row0_col8, #T_02b8c_row1_col0, #T_02b8c_row1_col1, #T_02b8c_row1_col2, #T_02b8c_row1_col3, #T_02b8c_row1_col4, #T_02b8c_row1_col5, #T_02b8c_row1_col6, #T_02b8c_row1_col7, #T_02b8c_row1_col8, #T_02b8c_row2_col0, #T_02b8c_row2_col1, #T_02b8c_row2_col2, #T_02b8c_row2_col3, #T_02b8c_row2_col4, #T_02b8c_row2_col5, #T_02b8c_row2_col6, #T_02b8c_row2_col7, #T_02b8c_row2_col8 {\n",
+       "#T_8ae4e_row0_col0, #T_8ae4e_row0_col1, #T_8ae4e_row0_col2, #T_8ae4e_row0_col3, #T_8ae4e_row0_col4, #T_8ae4e_row0_col5, #T_8ae4e_row0_col6, #T_8ae4e_row0_col7, #T_8ae4e_row0_col8, #T_8ae4e_row1_col0, #T_8ae4e_row1_col1, #T_8ae4e_row1_col2, #T_8ae4e_row1_col3, #T_8ae4e_row1_col4, #T_8ae4e_row1_col5, #T_8ae4e_row1_col6, #T_8ae4e_row1_col7, #T_8ae4e_row1_col8, #T_8ae4e_row2_col0, #T_8ae4e_row2_col1, #T_8ae4e_row2_col2, #T_8ae4e_row2_col3, #T_8ae4e_row2_col4, #T_8ae4e_row2_col5, #T_8ae4e_row2_col6, #T_8ae4e_row2_col7, #T_8ae4e_row2_col8 {\n",
        "  text-align: left;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_02b8c\">\n",
+       "<table id=\"T_8ae4e\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank\" >&nbsp;</th>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_02b8c_level0_col0\" class=\"col_heading level0 col0\" >level</th>\n",
-       "      <th id=\"T_02b8c_level0_col1\" class=\"col_heading level0 col1\" >date</th>\n",
-       "      <th id=\"T_02b8c_level0_col2\" class=\"col_heading level0 col2\" >time</th>\n",
-       "      <th id=\"T_02b8c_level0_col3\" class=\"col_heading level0 col3\" >step</th>\n",
-       "      <th id=\"T_02b8c_level0_col4\" class=\"col_heading level0 col4\" >paramId</th>\n",
-       "      <th id=\"T_02b8c_level0_col5\" class=\"col_heading level0 col5\" >class</th>\n",
-       "      <th id=\"T_02b8c_level0_col6\" class=\"col_heading level0 col6\" >stream</th>\n",
-       "      <th id=\"T_02b8c_level0_col7\" class=\"col_heading level0 col7\" >type</th>\n",
-       "      <th id=\"T_02b8c_level0_col8\" class=\"col_heading level0 col8\" >experimentVersionNumber</th>\n",
+       "      <th id=\"T_8ae4e_level0_col0\" class=\"col_heading level0 col0\" >level</th>\n",
+       "      <th id=\"T_8ae4e_level0_col1\" class=\"col_heading level0 col1\" >date</th>\n",
+       "      <th id=\"T_8ae4e_level0_col2\" class=\"col_heading level0 col2\" >time</th>\n",
+       "      <th id=\"T_8ae4e_level0_col3\" class=\"col_heading level0 col3\" >step</th>\n",
+       "      <th id=\"T_8ae4e_level0_col4\" class=\"col_heading level0 col4\" >paramId</th>\n",
+       "      <th id=\"T_8ae4e_level0_col5\" class=\"col_heading level0 col5\" >class</th>\n",
+       "      <th id=\"T_8ae4e_level0_col6\" class=\"col_heading level0 col6\" >stream</th>\n",
+       "      <th id=\"T_8ae4e_level0_col7\" class=\"col_heading level0 col7\" >type</th>\n",
+       "      <th id=\"T_8ae4e_level0_col8\" class=\"col_heading level0 col8\" >experimentVersionNumber</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >shortName</th>\n",
@@ -1251,52 +1371,52 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_02b8c_level0_row0\" class=\"row_heading level0 row0\" >t</th>\n",
-       "      <th id=\"T_02b8c_level1_row0\" class=\"row_heading level1 row0\" >isobaricInhPa</th>\n",
-       "      <td id=\"T_02b8c_row0_col0\" class=\"data row0 col0\" >1000,850</td>\n",
-       "      <td id=\"T_02b8c_row0_col1\" class=\"data row0 col1\" >20180801</td>\n",
-       "      <td id=\"T_02b8c_row0_col2\" class=\"data row0 col2\" >1200</td>\n",
-       "      <td id=\"T_02b8c_row0_col3\" class=\"data row0 col3\" >0</td>\n",
-       "      <td id=\"T_02b8c_row0_col4\" class=\"data row0 col4\" >130</td>\n",
-       "      <td id=\"T_02b8c_row0_col5\" class=\"data row0 col5\" >od</td>\n",
-       "      <td id=\"T_02b8c_row0_col6\" class=\"data row0 col6\" >oper</td>\n",
-       "      <td id=\"T_02b8c_row0_col7\" class=\"data row0 col7\" >an</td>\n",
-       "      <td id=\"T_02b8c_row0_col8\" class=\"data row0 col8\" >0001</td>\n",
+       "      <th id=\"T_8ae4e_level0_row0\" class=\"row_heading level0 row0\" >t</th>\n",
+       "      <th id=\"T_8ae4e_level1_row0\" class=\"row_heading level1 row0\" >isobaricInhPa</th>\n",
+       "      <td id=\"T_8ae4e_row0_col0\" class=\"data row0 col0\" >1000,850</td>\n",
+       "      <td id=\"T_8ae4e_row0_col1\" class=\"data row0 col1\" >20180801</td>\n",
+       "      <td id=\"T_8ae4e_row0_col2\" class=\"data row0 col2\" >1200</td>\n",
+       "      <td id=\"T_8ae4e_row0_col3\" class=\"data row0 col3\" >0</td>\n",
+       "      <td id=\"T_8ae4e_row0_col4\" class=\"data row0 col4\" >130</td>\n",
+       "      <td id=\"T_8ae4e_row0_col5\" class=\"data row0 col5\" >od</td>\n",
+       "      <td id=\"T_8ae4e_row0_col6\" class=\"data row0 col6\" >oper</td>\n",
+       "      <td id=\"T_8ae4e_row0_col7\" class=\"data row0 col7\" >an</td>\n",
+       "      <td id=\"T_8ae4e_row0_col8\" class=\"data row0 col8\" >0001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_02b8c_level0_row1\" class=\"row_heading level0 row1\" >u</th>\n",
-       "      <th id=\"T_02b8c_level1_row1\" class=\"row_heading level1 row1\" >isobaricInhPa</th>\n",
-       "      <td id=\"T_02b8c_row1_col0\" class=\"data row1 col0\" >1000,850</td>\n",
-       "      <td id=\"T_02b8c_row1_col1\" class=\"data row1 col1\" >20180801</td>\n",
-       "      <td id=\"T_02b8c_row1_col2\" class=\"data row1 col2\" >1200</td>\n",
-       "      <td id=\"T_02b8c_row1_col3\" class=\"data row1 col3\" >0</td>\n",
-       "      <td id=\"T_02b8c_row1_col4\" class=\"data row1 col4\" >131</td>\n",
-       "      <td id=\"T_02b8c_row1_col5\" class=\"data row1 col5\" >od</td>\n",
-       "      <td id=\"T_02b8c_row1_col6\" class=\"data row1 col6\" >oper</td>\n",
-       "      <td id=\"T_02b8c_row1_col7\" class=\"data row1 col7\" >an</td>\n",
-       "      <td id=\"T_02b8c_row1_col8\" class=\"data row1 col8\" >0001</td>\n",
+       "      <th id=\"T_8ae4e_level0_row1\" class=\"row_heading level0 row1\" >u</th>\n",
+       "      <th id=\"T_8ae4e_level1_row1\" class=\"row_heading level1 row1\" >isobaricInhPa</th>\n",
+       "      <td id=\"T_8ae4e_row1_col0\" class=\"data row1 col0\" >1000,850</td>\n",
+       "      <td id=\"T_8ae4e_row1_col1\" class=\"data row1 col1\" >20180801</td>\n",
+       "      <td id=\"T_8ae4e_row1_col2\" class=\"data row1 col2\" >1200</td>\n",
+       "      <td id=\"T_8ae4e_row1_col3\" class=\"data row1 col3\" >0</td>\n",
+       "      <td id=\"T_8ae4e_row1_col4\" class=\"data row1 col4\" >131</td>\n",
+       "      <td id=\"T_8ae4e_row1_col5\" class=\"data row1 col5\" >od</td>\n",
+       "      <td id=\"T_8ae4e_row1_col6\" class=\"data row1 col6\" >oper</td>\n",
+       "      <td id=\"T_8ae4e_row1_col7\" class=\"data row1 col7\" >an</td>\n",
+       "      <td id=\"T_8ae4e_row1_col8\" class=\"data row1 col8\" >0001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_02b8c_level0_row2\" class=\"row_heading level0 row2\" >v</th>\n",
-       "      <th id=\"T_02b8c_level1_row2\" class=\"row_heading level1 row2\" >isobaricInhPa</th>\n",
-       "      <td id=\"T_02b8c_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
-       "      <td id=\"T_02b8c_row2_col1\" class=\"data row2 col1\" >20180801</td>\n",
-       "      <td id=\"T_02b8c_row2_col2\" class=\"data row2 col2\" >1200</td>\n",
-       "      <td id=\"T_02b8c_row2_col3\" class=\"data row2 col3\" >0</td>\n",
-       "      <td id=\"T_02b8c_row2_col4\" class=\"data row2 col4\" >132</td>\n",
-       "      <td id=\"T_02b8c_row2_col5\" class=\"data row2 col5\" >od</td>\n",
-       "      <td id=\"T_02b8c_row2_col6\" class=\"data row2 col6\" >oper</td>\n",
-       "      <td id=\"T_02b8c_row2_col7\" class=\"data row2 col7\" >an</td>\n",
-       "      <td id=\"T_02b8c_row2_col8\" class=\"data row2 col8\" >0001</td>\n",
+       "      <th id=\"T_8ae4e_level0_row2\" class=\"row_heading level0 row2\" >v</th>\n",
+       "      <th id=\"T_8ae4e_level1_row2\" class=\"row_heading level1 row2\" >isobaricInhPa</th>\n",
+       "      <td id=\"T_8ae4e_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
+       "      <td id=\"T_8ae4e_row2_col1\" class=\"data row2 col1\" >20180801</td>\n",
+       "      <td id=\"T_8ae4e_row2_col2\" class=\"data row2 col2\" >1200</td>\n",
+       "      <td id=\"T_8ae4e_row2_col3\" class=\"data row2 col3\" >0</td>\n",
+       "      <td id=\"T_8ae4e_row2_col4\" class=\"data row2 col4\" >132</td>\n",
+       "      <td id=\"T_8ae4e_row2_col5\" class=\"data row2 col5\" >od</td>\n",
+       "      <td id=\"T_8ae4e_row2_col6\" class=\"data row2 col6\" >oper</td>\n",
+       "      <td id=\"T_8ae4e_row2_col7\" class=\"data row2 col7\" >an</td>\n",
+       "      <td id=\"T_8ae4e_row2_col8\" class=\"data row2 col8\" >0001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x11e4d8280>"
+       "<pandas.io.formats.style.Styler at 0x1412bdb10>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1314,76 +1434,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_d6942 th {\n",
+       "#T_ed832 th {\n",
        "  text-align: left;\n",
        "}\n",
-       "#T_d6942_row0_col0, #T_d6942_row1_col0, #T_d6942_row2_col0, #T_d6942_row3_col0, #T_d6942_row4_col0, #T_d6942_row5_col0, #T_d6942_row6_col0, #T_d6942_row7_col0, #T_d6942_row8_col0, #T_d6942_row9_col0, #T_d6942_row10_col0 {\n",
+       "#T_ed832_row0_col0, #T_ed832_row1_col0, #T_ed832_row2_col0, #T_ed832_row3_col0, #T_ed832_row4_col0, #T_ed832_row5_col0, #T_ed832_row6_col0, #T_ed832_row7_col0, #T_ed832_row8_col0, #T_ed832_row9_col0, #T_ed832_row10_col0 {\n",
        "  text-align: left;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_d6942\">\n",
+       "<table id=\"T_ed832\">\n",
        "  <thead>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row0\" class=\"row_heading level0 row0\" >shortName</th>\n",
-       "      <td id=\"T_d6942_row0_col0\" class=\"data row0 col0\" >t</td>\n",
+       "      <th id=\"T_ed832_level0_row0\" class=\"row_heading level0 row0\" >shortName</th>\n",
+       "      <td id=\"T_ed832_row0_col0\" class=\"data row0 col0\" >t</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row1\" class=\"row_heading level0 row1\" >typeOfLevel</th>\n",
-       "      <td id=\"T_d6942_row1_col0\" class=\"data row1 col0\" >isobaricInhPa</td>\n",
+       "      <th id=\"T_ed832_level0_row1\" class=\"row_heading level0 row1\" >typeOfLevel</th>\n",
+       "      <td id=\"T_ed832_row1_col0\" class=\"data row1 col0\" >isobaricInhPa</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row2\" class=\"row_heading level0 row2\" >level</th>\n",
-       "      <td id=\"T_d6942_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
+       "      <th id=\"T_ed832_level0_row2\" class=\"row_heading level0 row2\" >level</th>\n",
+       "      <td id=\"T_ed832_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row3\" class=\"row_heading level0 row3\" >date</th>\n",
-       "      <td id=\"T_d6942_row3_col0\" class=\"data row3 col0\" >20180801</td>\n",
+       "      <th id=\"T_ed832_level0_row3\" class=\"row_heading level0 row3\" >date</th>\n",
+       "      <td id=\"T_ed832_row3_col0\" class=\"data row3 col0\" >20180801</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row4\" class=\"row_heading level0 row4\" >time</th>\n",
-       "      <td id=\"T_d6942_row4_col0\" class=\"data row4 col0\" >1200</td>\n",
+       "      <th id=\"T_ed832_level0_row4\" class=\"row_heading level0 row4\" >time</th>\n",
+       "      <td id=\"T_ed832_row4_col0\" class=\"data row4 col0\" >1200</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row5\" class=\"row_heading level0 row5\" >step</th>\n",
-       "      <td id=\"T_d6942_row5_col0\" class=\"data row5 col0\" >0</td>\n",
+       "      <th id=\"T_ed832_level0_row5\" class=\"row_heading level0 row5\" >step</th>\n",
+       "      <td id=\"T_ed832_row5_col0\" class=\"data row5 col0\" >0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row6\" class=\"row_heading level0 row6\" >paramId</th>\n",
-       "      <td id=\"T_d6942_row6_col0\" class=\"data row6 col0\" >130</td>\n",
+       "      <th id=\"T_ed832_level0_row6\" class=\"row_heading level0 row6\" >paramId</th>\n",
+       "      <td id=\"T_ed832_row6_col0\" class=\"data row6 col0\" >130</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row7\" class=\"row_heading level0 row7\" >class</th>\n",
-       "      <td id=\"T_d6942_row7_col0\" class=\"data row7 col0\" >od</td>\n",
+       "      <th id=\"T_ed832_level0_row7\" class=\"row_heading level0 row7\" >class</th>\n",
+       "      <td id=\"T_ed832_row7_col0\" class=\"data row7 col0\" >od</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row8\" class=\"row_heading level0 row8\" >stream</th>\n",
-       "      <td id=\"T_d6942_row8_col0\" class=\"data row8 col0\" >oper</td>\n",
+       "      <th id=\"T_ed832_level0_row8\" class=\"row_heading level0 row8\" >stream</th>\n",
+       "      <td id=\"T_ed832_row8_col0\" class=\"data row8 col0\" >oper</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row9\" class=\"row_heading level0 row9\" >type</th>\n",
-       "      <td id=\"T_d6942_row9_col0\" class=\"data row9 col0\" >an</td>\n",
+       "      <th id=\"T_ed832_level0_row9\" class=\"row_heading level0 row9\" >type</th>\n",
+       "      <td id=\"T_ed832_row9_col0\" class=\"data row9 col0\" >an</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_d6942_level0_row10\" class=\"row_heading level0 row10\" >experimentVersionNumber</th>\n",
-       "      <td id=\"T_d6942_row10_col0\" class=\"data row10 col0\" >0001</td>\n",
+       "      <th id=\"T_ed832_level0_row10\" class=\"row_heading level0 row10\" >experimentVersionNumber</th>\n",
+       "      <td id=\"T_ed832_row10_col0\" class=\"data row10 col0\" >0001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x11e4d9250>"
+       "<pandas.io.formats.style.Styler at 0x155bf6d50>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1394,76 +1514,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_9660a th {\n",
+       "#T_f5ed5 th {\n",
        "  text-align: left;\n",
        "}\n",
-       "#T_9660a_row0_col0, #T_9660a_row1_col0, #T_9660a_row2_col0, #T_9660a_row3_col0, #T_9660a_row4_col0, #T_9660a_row5_col0, #T_9660a_row6_col0, #T_9660a_row7_col0, #T_9660a_row8_col0, #T_9660a_row9_col0, #T_9660a_row10_col0 {\n",
+       "#T_f5ed5_row0_col0, #T_f5ed5_row1_col0, #T_f5ed5_row2_col0, #T_f5ed5_row3_col0, #T_f5ed5_row4_col0, #T_f5ed5_row5_col0, #T_f5ed5_row6_col0, #T_f5ed5_row7_col0, #T_f5ed5_row8_col0, #T_f5ed5_row9_col0, #T_f5ed5_row10_col0 {\n",
        "  text-align: left;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_9660a\">\n",
+       "<table id=\"T_f5ed5\">\n",
        "  <thead>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row0\" class=\"row_heading level0 row0\" >shortName</th>\n",
-       "      <td id=\"T_9660a_row0_col0\" class=\"data row0 col0\" >u</td>\n",
+       "      <th id=\"T_f5ed5_level0_row0\" class=\"row_heading level0 row0\" >shortName</th>\n",
+       "      <td id=\"T_f5ed5_row0_col0\" class=\"data row0 col0\" >u</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row1\" class=\"row_heading level0 row1\" >typeOfLevel</th>\n",
-       "      <td id=\"T_9660a_row1_col0\" class=\"data row1 col0\" >isobaricInhPa</td>\n",
+       "      <th id=\"T_f5ed5_level0_row1\" class=\"row_heading level0 row1\" >typeOfLevel</th>\n",
+       "      <td id=\"T_f5ed5_row1_col0\" class=\"data row1 col0\" >isobaricInhPa</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row2\" class=\"row_heading level0 row2\" >level</th>\n",
-       "      <td id=\"T_9660a_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
+       "      <th id=\"T_f5ed5_level0_row2\" class=\"row_heading level0 row2\" >level</th>\n",
+       "      <td id=\"T_f5ed5_row2_col0\" class=\"data row2 col0\" >1000,850</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row3\" class=\"row_heading level0 row3\" >date</th>\n",
-       "      <td id=\"T_9660a_row3_col0\" class=\"data row3 col0\" >20180801</td>\n",
+       "      <th id=\"T_f5ed5_level0_row3\" class=\"row_heading level0 row3\" >date</th>\n",
+       "      <td id=\"T_f5ed5_row3_col0\" class=\"data row3 col0\" >20180801</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row4\" class=\"row_heading level0 row4\" >time</th>\n",
-       "      <td id=\"T_9660a_row4_col0\" class=\"data row4 col0\" >1200</td>\n",
+       "      <th id=\"T_f5ed5_level0_row4\" class=\"row_heading level0 row4\" >time</th>\n",
+       "      <td id=\"T_f5ed5_row4_col0\" class=\"data row4 col0\" >1200</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row5\" class=\"row_heading level0 row5\" >step</th>\n",
-       "      <td id=\"T_9660a_row5_col0\" class=\"data row5 col0\" >0</td>\n",
+       "      <th id=\"T_f5ed5_level0_row5\" class=\"row_heading level0 row5\" >step</th>\n",
+       "      <td id=\"T_f5ed5_row5_col0\" class=\"data row5 col0\" >0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row6\" class=\"row_heading level0 row6\" >paramId</th>\n",
-       "      <td id=\"T_9660a_row6_col0\" class=\"data row6 col0\" >131</td>\n",
+       "      <th id=\"T_f5ed5_level0_row6\" class=\"row_heading level0 row6\" >paramId</th>\n",
+       "      <td id=\"T_f5ed5_row6_col0\" class=\"data row6 col0\" >131</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row7\" class=\"row_heading level0 row7\" >class</th>\n",
-       "      <td id=\"T_9660a_row7_col0\" class=\"data row7 col0\" >od</td>\n",
+       "      <th id=\"T_f5ed5_level0_row7\" class=\"row_heading level0 row7\" >class</th>\n",
+       "      <td id=\"T_f5ed5_row7_col0\" class=\"data row7 col0\" >od</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row8\" class=\"row_heading level0 row8\" >stream</th>\n",
-       "      <td id=\"T_9660a_row8_col0\" class=\"data row8 col0\" >oper</td>\n",
+       "      <th id=\"T_f5ed5_level0_row8\" class=\"row_heading level0 row8\" >stream</th>\n",
+       "      <td id=\"T_f5ed5_row8_col0\" class=\"data row8 col0\" >oper</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row9\" class=\"row_heading level0 row9\" >type</th>\n",
-       "      <td id=\"T_9660a_row9_col0\" class=\"data row9 col0\" >an</td>\n",
+       "      <th id=\"T_f5ed5_level0_row9\" class=\"row_heading level0 row9\" >type</th>\n",
+       "      <td id=\"T_f5ed5_row9_col0\" class=\"data row9 col0\" >an</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_9660a_level0_row10\" class=\"row_heading level0 row10\" >experimentVersionNumber</th>\n",
-       "      <td id=\"T_9660a_row10_col0\" class=\"data row10 col0\" >0001</td>\n",
+       "      <th id=\"T_f5ed5_level0_row10\" class=\"row_heading level0 row10\" >experimentVersionNumber</th>\n",
+       "      <td id=\"T_f5ed5_row10_col0\" class=\"data row10 col0\" >0001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x11f9d1fa0>"
+       "<pandas.io.formats.style.Styler at 0x1558ef190>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1488,7 +1608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1502,7 +1622,7 @@
        " 'isobaricInhPa']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1513,7 +1633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1522,7 +1642,7 @@
        "('isobaricInhPa', 1000, 'ecmf', 98)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1540,7 +1660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1549,7 +1669,7 @@
        "'t'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1567,7 +1687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1580,7 +1700,7 @@
        " 'shortName': 't'}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1605,8 +1725,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1746,8 +1868,8 @@
        "<div class=\"eh-tabs-block\">\n",
        "<div class=\"eh-tabs\">\n",
        "\n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"9d595129-d2f8-45d2-acb4-b5c18dd92135\"  />\n",
-       "<label for=\"9d595129-d2f8-45d2-acb4-b5c18dd92135\" title=\"Keys in the ecCodes None namespace\">default</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"bd2ba442-d557-48ff-b3a1-ba0971c1f9e7\"  />\n",
+       "<label for=\"bd2ba442-d557-48ff-b3a1-ba0971c1f9e7\" title=\"Keys in the ecCodes None namespace\">default</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1755,12 +1877,12 @@
        "}\n",
        "</style>\n",
        "<table class=\"eh-table\">\n",
-       "<tr><td><b>globalDomain</b></td><td>g</td></tr> <tr><td><b>GRIBEditionNumber</b></td><td>1</td></tr> <tr><td><b>eps</b></td><td>0</td></tr> <tr><td><b>offsetSection0</b></td><td>0</td></tr> <tr><td><b>section0Length</b></td><td>8</td></tr> <tr><td><b>totalLength</b></td><td>150</td></tr> <tr><td><b>editionNumber</b></td><td>1</td></tr> <tr><td><b>WMO</b></td><td>0</td></tr> <tr><td><b>productionStatusOfProcessedData</b></td><td>0</td></tr> <tr><td><b>section1Length</b></td><td>52</td></tr> <tr><td><b>wrongPadding</b></td><td>0</td></tr> <tr><td><b>table2Version</b></td><td>128</td></tr> <tr><td><b>centre</b></td><td>ecmf</td></tr> <tr><td><b>centreDescription</b></td><td>European Centre for Medium-Range Weather Forecasts</td></tr> <tr><td><b>generatingProcessIdentifier</b></td><td>254</td></tr> <tr><td><b>gridDefinition</b></td><td>255</td></tr> <tr><td><b>indicatorOfParameter</b></td><td>130</td></tr> <tr><td><b>parameterName</b></td><td>Temperature</td></tr> <tr><td><b>parameterUnits</b></td><td>K</td></tr> <tr><td><b>indicatorOfTypeOfLevel</b></td><td>pl</td></tr> <tr><td><b>pressureUnits</b></td><td>hPa</td></tr> <tr><td><b>typeOfLevelECMF</b></td><td>isobaricInhPa</td></tr> <tr><td><b>typeOfLevel</b></td><td>isobaricInhPa</td></tr> <tr><td><b>level</b></td><td>1000</td></tr> <tr><td><b>yearOfCentury</b></td><td>18</td></tr> <tr><td><b>month</b></td><td>8</td></tr> <tr><td><b>day</b></td><td>1</td></tr> <tr><td><b>hour</b></td><td>12</td></tr> <tr><td><b>minute</b></td><td>0</td></tr> <tr><td><b>second</b></td><td>0</td></tr> <tr><td><b>unitOfTimeRange</b></td><td>1</td></tr> <tr><td><b>P1</b></td><td>0</td></tr> <tr><td><b>P2</b></td><td>0</td></tr> <tr><td><b>timeRangeIndicator</b></td><td>0</td></tr> <tr><td><b>numberIncludedInAverage</b></td><td>0</td></tr> <tr><td><b>mybits</b></td><td>None</td></tr> <tr><td><b>numberMissingFromAveragesOrAccumulations</b></td><td>0</td></tr> <tr><td><b>centuryOfReferenceTimeOfData</b></td><td>21</td></tr> <tr><td><b>subCentre</b></td><td>0</td></tr> <tr><td><b>paramIdECMF</b></td><td>130</td></tr> <tr><td><b>paramId</b></td><td>130</td></tr> <tr><td><b>cfNameECMF</b></td><td>air_temperature</td></tr> <tr><td><b>cfName</b></td><td>air_temperature</td></tr> <tr><td><b>cfVarNameECMF</b></td><td>t</td></tr> <tr><td><b>cfVarName</b></td><td>t</td></tr> <tr><td><b>unitsECMF</b></td><td>K</td></tr> <tr><td><b>units</b></td><td>K</td></tr> <tr><td><b>nameECMF</b></td><td>Temperature</td></tr> <tr><td><b>name</b></td><td>Temperature</td></tr> <tr><td><b>decimalScaleFactor</b></td><td>0</td></tr> <tr><td><b>setLocalDefinition</b></td><td>0</td></tr> <tr><td><b>optimizeScaleFactor</b></td><td>0</td></tr> <tr><td><b>dataDate</b></td><td>20180801</td></tr> <tr><td><b>year</b></td><td>2018</td></tr> <tr><td><b>dataTime</b></td><td>1200</td></tr> <tr><td><b>julianDay</b></td><td>2458332.0</td></tr> <tr><td><b>stepUnits</b></td><td>1</td></tr> <tr><td><b>stepType</b></td><td>instant</td></tr> <tr><td><b>stepRange</b></td><td>0</td></tr> <tr><td><b>startStep</b></td><td>0</td></tr> <tr><td><b>endStep</b></td><td>0</td></tr> <tr><td><b>marsParam</b></td><td>130.128</td></tr> <tr><td><b>validityDate</b></td><td>20180801</td></tr> <tr><td><b>validityTime</b></td><td>1200</td></tr> <tr><td><b>deleteLocalDefinition</b></td><td>0</td></tr> <tr><td><b>localUsePresent</b></td><td>1</td></tr> <tr><td><b>reservedNeedNotBePresent</b></td><td>None</td></tr> <tr><td><b>localDefinitionNumber</b></td><td>1</td></tr> <tr><td><b>GRIBEXSection1Problem</b></td><td>0</td></tr> <tr><td><b>marsClass</b></td><td>od</td></tr> <tr><td><b>marsType</b></td><td>an</td></tr> <tr><td><b>marsStream</b></td><td>oper</td></tr> <tr><td><b>experimentVersionNumber</b></td><td>0001</td></tr> <tr><td><b>perturbationNumber</b></td><td>0</td></tr> <tr><td><b>numberOfForecastsInEnsemble</b></td><td>0</td></tr> <tr><td><b>padding_local1_1</b></td><td>None</td></tr> <tr><td><b>grib2LocalSectionNumber</b></td><td>1</td></tr> <tr><td><b>localExtensionPadding</b></td><td>None</td></tr> <tr><td><b>_x</b></td><td>None</td></tr> <tr><td><b>section1Padding</b></td><td>None</td></tr> <tr><td><b>shortNameECMF</b></td><td>t</td></tr> <tr><td><b>shortName</b></td><td>t</td></tr> <tr><td><b>ifsParam</b></td><td>130</td></tr> <tr><td><b>stepTypeForConversion</b></td><td>unknown</td></tr> <tr><td><b>md5Section1</b></td><td>3ae6b1f6f34f431c6134c40ec42f27fa</td></tr> <tr><td><b>md5Product</b></td><td>54697e1d910c88b76a8759b67e5c7a9c</td></tr> <tr><td><b>gridDescriptionSectionPresent</b></td><td>1</td></tr> <tr><td><b>bitmapPresent</b></td><td>0</td></tr> <tr><td><b>angleSubdivisions</b></td><td>1000</td></tr> <tr><td><b>section2Length</b></td><td>32</td></tr> <tr><td><b>radius</b></td><td>6367470</td></tr> <tr><td><b>numberOfVerticalCoordinateValues</b></td><td>0</td></tr> <tr><td><b>neitherPresent</b></td><td>255</td></tr> <tr><td><b>pvlLocation</b></td><td>255</td></tr> <tr><td><b>dataRepresentationType</b></td><td>0</td></tr> <tr><td><b>gridDefinitionDescription</b></td><td>Latitude/Longitude Grid</td></tr> <tr><td><b>gridDefinitionTemplateNumber</b></td><td>0</td></tr> <tr><td><b>Ni</b></td><td>12</td></tr> <tr><td><b>Nj</b></td><td>7</td></tr> <tr><td><b>latitudeOfFirstGridPoint</b></td><td>90000</td></tr> <tr><td><b>latitudeOfFirstGridPointInDegrees</b></td><td>90.0</td></tr> <tr><td><b>longitudeOfFirstGridPoint</b></td><td>0</td></tr> <tr><td><b>longitudeOfFirstGridPointInDegrees</b></td><td>0.0</td></tr> <tr><td><b>resolutionAndComponentFlags</b></td><td>128</td></tr> <tr><td><b>ijDirectionIncrementGiven</b></td><td>1</td></tr> <tr><td><b>earthIsOblate</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags3</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags4</b></td><td>0</td></tr> <tr><td><b>uvRelativeToGrid</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags6</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags7</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags8</b></td><td>0</td></tr> <tr><td><b>latitudeOfLastGridPoint</b></td><td>-90000</td></tr> <tr><td><b>latitudeOfLastGridPointInDegrees</b></td><td>-90.0</td></tr> <tr><td><b>longitudeOfLastGridPoint</b></td><td>330000</td></tr> <tr><td><b>longitudeOfLastGridPointInDegrees</b></td><td>330.0</td></tr> <tr><td><b>iDirectionIncrement</b></td><td>30000</td></tr> <tr><td><b>jDirectionIncrement</b></td><td>30000</td></tr> <tr><td><b>scanningMode</b></td><td>0</td></tr> <tr><td><b>iScansNegatively</b></td><td>0</td></tr> <tr><td><b>jScansPositively</b></td><td>0</td></tr> <tr><td><b>jPointsAreConsecutive</b></td><td>0</td></tr> <tr><td><b>alternativeRowScanning</b></td><td>0</td></tr> <tr><td><b>iScansPositively</b></td><td>1</td></tr> <tr><td><b>scanningMode4</b></td><td>0</td></tr> <tr><td><b>scanningMode5</b></td><td>0</td></tr> <tr><td><b>scanningMode6</b></td><td>0</td></tr> <tr><td><b>scanningMode7</b></td><td>0</td></tr> <tr><td><b>scanningMode8</b></td><td>0</td></tr> <tr><td><b>swapScanningAlternativeRows</b></td><td>0</td></tr> <tr><td><b>jDirectionIncrementInDegrees</b></td><td>30.0</td></tr> <tr><td><b>iDirectionIncrementInDegrees</b></td><td>30.0</td></tr> <tr><td><b>numberOfDataPoints</b></td><td>84</td></tr> <tr><td><b>numberOfValues</b></td><td>84</td></tr> <tr><td><b>zeros</b></td><td></td></tr> <tr><td><b>PVPresent</b></td><td>0</td></tr> <tr><td><b>padding_sec2_2</b></td><td>None</td></tr> <tr><td><b>PLPresent</b></td><td>0</td></tr> <tr><td><b>padding_sec2_1</b></td><td>None</td></tr> <tr><td><b>deletePV</b></td><td>1</td></tr> <tr><td><b>padding_sec2_3</b></td><td>None</td></tr> <tr><td><b>md5Section2</b></td><td>e09e4d6171c0ac85da1d256b2f8acf88</td></tr> <tr><td><b>lengthOfHeaders</b></td><td>85</td></tr> <tr><td><b>md5Headers</b></td><td>9160fb809a9d7b1efc95163bf36e6b51</td></tr> <tr><td><b>missingValue</b></td><td>9999</td></tr> <tr><td><b>tableReference</b></td><td>0</td></tr> <tr><td><b>section4Length</b></td><td>54</td></tr> <tr><td><b>halfByte</b></td><td>8</td></tr> <tr><td><b>dataFlag</b></td><td>8</td></tr> <tr><td><b>binaryScaleFactor</b></td><td>3</td></tr> <tr><td><b>referenceValue</b></td><td>240.56417846679688</td></tr> <tr><td><b>referenceValueError</b></td><td>1.52587890625e-05</td></tr> <tr><td><b>sphericalHarmonics</b></td><td>0</td></tr> <tr><td><b>complexPacking</b></td><td>0</td></tr> <tr><td><b>integerPointValues</b></td><td>0</td></tr> <tr><td><b>additionalFlagPresent</b></td><td>0</td></tr> <tr><td><b>orderOfSPD</b></td><td>2</td></tr> <tr><td><b>boustrophedonic</b></td><td>0</td></tr> <tr><td><b>hideThis</b></td><td>0</td></tr> <tr><td><b>packingType</b></td><td>grid_simple</td></tr> <tr><td><b>bitsPerValue</b></td><td>4</td></tr> <tr><td><b>constantFieldHalfByte</b></td><td>8</td></tr> <tr><td><b>bitMapIndicator</b></td><td>255</td></tr> <tr><td><b>numberOfCodedValues</b></td><td>84</td></tr> <tr><td><b>packingError</b></td><td>4.000007629394531</td></tr> <tr><td><b>unpackedError</b></td><td>1.52587890625e-05</td></tr> <tr><td><b>maximum</b></td><td>320.5641784667969</td></tr> <tr><td><b>minimum</b></td><td>240.56417846679688</td></tr> <tr><td><b>average</b></td><td>279.70703560965404</td></tr> <tr><td><b>numberOfMissing</b></td><td>0</td></tr> <tr><td><b>standardDeviation</b></td><td>19.67421739058438</td></tr> <tr><td><b>skewness</b></td><td>-0.7312302105044429</td></tr> <tr><td><b>kurtosis</b></td><td>-0.16904561574741717</td></tr> <tr><td><b>isConstant</b></td><td>0.0</td></tr> <tr><td><b>dataLength</b></td><td>5</td></tr> <tr><td><b>changeDecimalPrecision</b></td><td>0</td></tr> <tr><td><b>decimalPrecision</b></td><td>0</td></tr> <tr><td><b>bitsPerValueAndRepack</b></td><td>4</td></tr> <tr><td><b>scaleValuesBy</b></td><td>1.0</td></tr> <tr><td><b>offsetValuesBy</b></td><td>0.0</td></tr> <tr><td><b>gridType</b></td><td>regular_ll</td></tr> <tr><td><b>getNumberOfValues</b></td><td>84</td></tr> <tr><td><b>padding_sec4_1</b></td><td>None</td></tr> <tr><td><b>md5Section4</b></td><td>7ea3331d80a962b5dc99276b76451eac</td></tr> <tr><td><b>section5Length</b></td><td>4</td></tr> <tr><td><b>7777</b></td><td>7777</td></tr>\n",
+       "<tr><td><b>globalDomain</b></td><td>g</td></tr> <tr><td><b>GRIBEditionNumber</b></td><td>1</td></tr> <tr><td><b>eps</b></td><td>0</td></tr> <tr><td><b>offsetSection0</b></td><td>0</td></tr> <tr><td><b>section0Length</b></td><td>8</td></tr> <tr><td><b>totalLength</b></td><td>150</td></tr> <tr><td><b>editionNumber</b></td><td>1</td></tr> <tr><td><b>WMO</b></td><td>0</td></tr> <tr><td><b>productionStatusOfProcessedData</b></td><td>0</td></tr> <tr><td><b>section1Length</b></td><td>52</td></tr> <tr><td><b>wrongPadding</b></td><td>0</td></tr> <tr><td><b>table2Version</b></td><td>128</td></tr> <tr><td><b>centre</b></td><td>ecmf</td></tr> <tr><td><b>centreDescription</b></td><td>European Centre for Medium-Range Weather Forecasts</td></tr> <tr><td><b>generatingProcessIdentifier</b></td><td>254</td></tr> <tr><td><b>gridDefinition</b></td><td>255</td></tr> <tr><td><b>indicatorOfParameter</b></td><td>130</td></tr> <tr><td><b>parameterName</b></td><td>Temperature</td></tr> <tr><td><b>parameterUnits</b></td><td>K</td></tr> <tr><td><b>indicatorOfTypeOfLevel</b></td><td>pl</td></tr> <tr><td><b>pressureUnits</b></td><td>hPa</td></tr> <tr><td><b>typeOfLevelECMF</b></td><td>isobaricInhPa</td></tr> <tr><td><b>typeOfLevel</b></td><td>isobaricInhPa</td></tr> <tr><td><b>level</b></td><td>1000</td></tr> <tr><td><b>yearOfCentury</b></td><td>18</td></tr> <tr><td><b>month</b></td><td>8</td></tr> <tr><td><b>day</b></td><td>1</td></tr> <tr><td><b>hour</b></td><td>12</td></tr> <tr><td><b>minute</b></td><td>0</td></tr> <tr><td><b>second</b></td><td>0</td></tr> <tr><td><b>unitOfTimeRange</b></td><td>1</td></tr> <tr><td><b>P1</b></td><td>0</td></tr> <tr><td><b>P2</b></td><td>0</td></tr> <tr><td><b>timeRangeIndicator</b></td><td>0</td></tr> <tr><td><b>numberIncludedInAverage</b></td><td>0</td></tr> <tr><td><b>numberMissingFromAveragesOrAccumulations</b></td><td>0</td></tr> <tr><td><b>centuryOfReferenceTimeOfData</b></td><td>21</td></tr> <tr><td><b>subCentre</b></td><td>0</td></tr> <tr><td><b>paramIdECMF</b></td><td>130</td></tr> <tr><td><b>paramId</b></td><td>130</td></tr> <tr><td><b>cfNameECMF</b></td><td>air_temperature</td></tr> <tr><td><b>cfName</b></td><td>air_temperature</td></tr> <tr><td><b>cfVarNameECMF</b></td><td>t</td></tr> <tr><td><b>cfVarName</b></td><td>t</td></tr> <tr><td><b>unitsECMF</b></td><td>K</td></tr> <tr><td><b>units</b></td><td>K</td></tr> <tr><td><b>nameECMF</b></td><td>Temperature</td></tr> <tr><td><b>name</b></td><td>Temperature</td></tr> <tr><td><b>decimalScaleFactor</b></td><td>0</td></tr> <tr><td><b>setLocalDefinition</b></td><td>0</td></tr> <tr><td><b>optimizeScaleFactor</b></td><td>0</td></tr> <tr><td><b>dataDate</b></td><td>20180801</td></tr> <tr><td><b>year</b></td><td>2018</td></tr> <tr><td><b>dataTime</b></td><td>1200</td></tr> <tr><td><b>julianDay</b></td><td>2458332.0</td></tr> <tr><td><b>stepUnits</b></td><td>1</td></tr> <tr><td><b>stepType</b></td><td>instant</td></tr> <tr><td><b>stepRange</b></td><td>0</td></tr> <tr><td><b>startStep</b></td><td>0</td></tr> <tr><td><b>endStep</b></td><td>0</td></tr> <tr><td><b>marsParam</b></td><td>130.128</td></tr> <tr><td><b>validityDate</b></td><td>20180801</td></tr> <tr><td><b>validityTime</b></td><td>1200</td></tr> <tr><td><b>deleteLocalDefinition</b></td><td>0</td></tr> <tr><td><b>localUsePresent</b></td><td>1</td></tr> <tr><td><b>reservedNeedNotBePresent</b></td><td>None</td></tr> <tr><td><b>localDefinitionNumber</b></td><td>1</td></tr> <tr><td><b>GRIBEXSection1Problem</b></td><td>0</td></tr> <tr><td><b>marsClass</b></td><td>od</td></tr> <tr><td><b>marsType</b></td><td>an</td></tr> <tr><td><b>marsStream</b></td><td>oper</td></tr> <tr><td><b>experimentVersionNumber</b></td><td>0001</td></tr> <tr><td><b>perturbationNumber</b></td><td>0</td></tr> <tr><td><b>numberOfForecastsInEnsemble</b></td><td>0</td></tr> <tr><td><b>padding_local1_1</b></td><td>None</td></tr> <tr><td><b>grib2LocalSectionNumber</b></td><td>1</td></tr> <tr><td><b>localExtensionPadding</b></td><td>None</td></tr> <tr><td><b>_x</b></td><td>None</td></tr> <tr><td><b>section1Padding</b></td><td>None</td></tr> <tr><td><b>shortNameECMF</b></td><td>t</td></tr> <tr><td><b>shortName</b></td><td>t</td></tr> <tr><td><b>ifsParam</b></td><td>130</td></tr> <tr><td><b>stepTypeForConversion</b></td><td>unknown</td></tr> <tr><td><b>md5Section1</b></td><td>3ae6b1f6f34f431c6134c40ec42f27fa</td></tr> <tr><td><b>md5Product</b></td><td>54697e1d910c88b76a8759b67e5c7a9c</td></tr> <tr><td><b>gridDescriptionSectionPresent</b></td><td>1</td></tr> <tr><td><b>bitmapPresent</b></td><td>0</td></tr> <tr><td><b>angleSubdivisions</b></td><td>1000</td></tr> <tr><td><b>section2Length</b></td><td>32</td></tr> <tr><td><b>radius</b></td><td>6367470</td></tr> <tr><td><b>numberOfVerticalCoordinateValues</b></td><td>0</td></tr> <tr><td><b>neitherPresent</b></td><td>255</td></tr> <tr><td><b>pvlLocation</b></td><td>255</td></tr> <tr><td><b>dataRepresentationType</b></td><td>0</td></tr> <tr><td><b>gridDefinitionDescription</b></td><td>Latitude/Longitude Grid</td></tr> <tr><td><b>gridDefinitionTemplateNumber</b></td><td>0</td></tr> <tr><td><b>Ni</b></td><td>12</td></tr> <tr><td><b>Nj</b></td><td>7</td></tr> <tr><td><b>latitudeOfFirstGridPoint</b></td><td>90000</td></tr> <tr><td><b>latitudeOfFirstGridPointInDegrees</b></td><td>90.0</td></tr> <tr><td><b>longitudeOfFirstGridPoint</b></td><td>0</td></tr> <tr><td><b>longitudeOfFirstGridPointInDegrees</b></td><td>0.0</td></tr> <tr><td><b>resolutionAndComponentFlags</b></td><td>128</td></tr> <tr><td><b>ijDirectionIncrementGiven</b></td><td>1</td></tr> <tr><td><b>earthIsOblate</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags3</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags4</b></td><td>0</td></tr> <tr><td><b>uvRelativeToGrid</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags6</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags7</b></td><td>0</td></tr> <tr><td><b>resolutionAndComponentFlags8</b></td><td>0</td></tr> <tr><td><b>latitudeOfLastGridPoint</b></td><td>-90000</td></tr> <tr><td><b>latitudeOfLastGridPointInDegrees</b></td><td>-90.0</td></tr> <tr><td><b>longitudeOfLastGridPoint</b></td><td>330000</td></tr> <tr><td><b>longitudeOfLastGridPointInDegrees</b></td><td>330.0</td></tr> <tr><td><b>iDirectionIncrement</b></td><td>30000</td></tr> <tr><td><b>jDirectionIncrement</b></td><td>30000</td></tr> <tr><td><b>scanningMode</b></td><td>0</td></tr> <tr><td><b>iScansNegatively</b></td><td>0</td></tr> <tr><td><b>jScansPositively</b></td><td>0</td></tr> <tr><td><b>jPointsAreConsecutive</b></td><td>0</td></tr> <tr><td><b>alternativeRowScanning</b></td><td>0</td></tr> <tr><td><b>iScansPositively</b></td><td>1</td></tr> <tr><td><b>jScansNegatively</b></td><td>1</td></tr> <tr><td><b>scanningMode4</b></td><td>0</td></tr> <tr><td><b>scanningMode5</b></td><td>0</td></tr> <tr><td><b>scanningMode6</b></td><td>0</td></tr> <tr><td><b>scanningMode7</b></td><td>0</td></tr> <tr><td><b>scanningMode8</b></td><td>0</td></tr> <tr><td><b>swapScanningAlternativeRows</b></td><td>0</td></tr> <tr><td><b>jDirectionIncrementInDegrees</b></td><td>30.0</td></tr> <tr><td><b>iDirectionIncrementInDegrees</b></td><td>30.0</td></tr> <tr><td><b>numberOfDataPoints</b></td><td>84</td></tr> <tr><td><b>numberOfValues</b></td><td>84</td></tr> <tr><td><b>zeros</b></td><td></td></tr> <tr><td><b>PVPresent</b></td><td>0</td></tr> <tr><td><b>padding_sec2_2</b></td><td>None</td></tr> <tr><td><b>PLPresent</b></td><td>0</td></tr> <tr><td><b>padding_sec2_1</b></td><td>None</td></tr> <tr><td><b>deletePV</b></td><td>1</td></tr> <tr><td><b>padding_sec2_3</b></td><td>None</td></tr> <tr><td><b>md5Section2</b></td><td>e09e4d6171c0ac85da1d256b2f8acf88</td></tr> <tr><td><b>lengthOfHeaders</b></td><td>85</td></tr> <tr><td><b>md5Headers</b></td><td>9160fb809a9d7b1efc95163bf36e6b51</td></tr> <tr><td><b>missingValue</b></td><td>9999</td></tr> <tr><td><b>tableReference</b></td><td>0</td></tr> <tr><td><b>section4Length</b></td><td>54</td></tr> <tr><td><b>halfByte</b></td><td>8</td></tr> <tr><td><b>dataFlag</b></td><td>8</td></tr> <tr><td><b>binaryScaleFactor</b></td><td>3</td></tr> <tr><td><b>referenceValue</b></td><td>240.56417846679688</td></tr> <tr><td><b>referenceValueError</b></td><td>1.52587890625e-05</td></tr> <tr><td><b>sphericalHarmonics</b></td><td>0</td></tr> <tr><td><b>complexPacking</b></td><td>0</td></tr> <tr><td><b>integerPointValues</b></td><td>0</td></tr> <tr><td><b>additionalFlagPresent</b></td><td>0</td></tr> <tr><td><b>orderOfSPD</b></td><td>2</td></tr> <tr><td><b>boustrophedonic</b></td><td>0</td></tr> <tr><td><b>hideThis</b></td><td>0</td></tr> <tr><td><b>packingType</b></td><td>grid_simple</td></tr> <tr><td><b>bitsPerValue</b></td><td>4</td></tr> <tr><td><b>constantFieldHalfByte</b></td><td>8</td></tr> <tr><td><b>bitMapIndicator</b></td><td>255</td></tr> <tr><td><b>numberOfCodedValues</b></td><td>84</td></tr> <tr><td><b>packingError</b></td><td>4.000007629394531</td></tr> <tr><td><b>unpackedError</b></td><td>1.52587890625e-05</td></tr> <tr><td><b>maximum</b></td><td>320.5641784667969</td></tr> <tr><td><b>minimum</b></td><td>240.56417846679688</td></tr> <tr><td><b>average</b></td><td>279.70703560965404</td></tr> <tr><td><b>standardDeviation</b></td><td>19.67421739058438</td></tr> <tr><td><b>skewness</b></td><td>-0.7312302105044429</td></tr> <tr><td><b>kurtosis</b></td><td>-0.16904561574741717</td></tr> <tr><td><b>isConstant</b></td><td>0.0</td></tr> <tr><td><b>numberOfMissing</b></td><td>0</td></tr> <tr><td><b>dataLength</b></td><td>5</td></tr> <tr><td><b>changeDecimalPrecision</b></td><td>0</td></tr> <tr><td><b>decimalPrecision</b></td><td>0</td></tr> <tr><td><b>bitsPerValueAndRepack</b></td><td>4</td></tr> <tr><td><b>scaleValuesBy</b></td><td>1.0</td></tr> <tr><td><b>offsetValuesBy</b></td><td>0.0</td></tr> <tr><td><b>gridType</b></td><td>regular_ll</td></tr> <tr><td><b>getNumberOfValues</b></td><td>84</td></tr> <tr><td><b>padding_sec4_1</b></td><td>None</td></tr> <tr><td><b>md5Section4</b></td><td>7ea3331d80a962b5dc99276b76451eac</td></tr> <tr><td><b>section5Length</b></td><td>4</td></tr> <tr><td><b>7777</b></td><td>7777</td></tr>\n",
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"5448f13a-677d-4bcb-822a-3a0717fae123\"  />\n",
-       "<label for=\"5448f13a-677d-4bcb-822a-3a0717fae123\" title=\"Keys in the ecCodes ls namespace\">ls</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"1f32e53f-cf32-467f-99a1-34f536fe3df2\"  />\n",
+       "<label for=\"1f32e53f-cf32-467f-99a1-34f536fe3df2\" title=\"Keys in the ecCodes ls namespace\">ls</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1772,8 +1894,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"c7b6e148-ca75-481c-bce7-b80186619cb3\"  />\n",
-       "<label for=\"c7b6e148-ca75-481c-bce7-b80186619cb3\" title=\"Keys in the ecCodes geography namespace\">geography</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"d41e79c9-324b-40e8-8afa-e91b3790f5e6\"  />\n",
+       "<label for=\"d41e79c9-324b-40e8-8afa-e91b3790f5e6\" title=\"Keys in the ecCodes geography namespace\">geography</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1785,8 +1907,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"39b1424d-18b4-4aa0-a469-8d2c66803d7b\"  />\n",
-       "<label for=\"39b1424d-18b4-4aa0-a469-8d2c66803d7b\" title=\"Keys in the ecCodes mars namespace\">mars</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"5a953ecd-f4b9-44ac-a7b2-c7cabd0aeb46\"  />\n",
+       "<label for=\"5a953ecd-f4b9-44ac-a7b2-c7cabd0aeb46\" title=\"Keys in the ecCodes mars namespace\">mars</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1798,8 +1920,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"963a2eab-99dd-4d50-949a-0bb9b90501ce\" checked />\n",
-       "<label for=\"963a2eab-99dd-4d50-949a-0bb9b90501ce\" title=\"Keys in the ecCodes parameter namespace\">parameter</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"db581bab-d814-40b0-ac67-d295c1615db9\" checked />\n",
+       "<label for=\"db581bab-d814-40b0-ac67-d295c1615db9\" title=\"Keys in the ecCodes parameter namespace\">parameter</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1811,8 +1933,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"dec462bb-4c39-4651-b6fe-716869f75c4e\"  />\n",
-       "<label for=\"dec462bb-4c39-4651-b6fe-716869f75c4e\" title=\"Keys in the ecCodes statistics namespace\">statistics</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"88d9241a-8e94-4df4-b0b6-955f6655e1cb\"  />\n",
+       "<label for=\"88d9241a-8e94-4df4-b0b6-955f6655e1cb\" title=\"Keys in the ecCodes statistics namespace\">statistics</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1824,8 +1946,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"5f0c466f-6e8e-4d95-bcab-392eaec32b2e\"  />\n",
-       "<label for=\"5f0c466f-6e8e-4d95-bcab-392eaec32b2e\" title=\"Keys in the ecCodes time namespace\">time</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"58056fef-26ca-44cf-a0d2-4a497af48c15\"  />\n",
+       "<label for=\"58056fef-26ca-44cf-a0d2-4a497af48c15\" title=\"Keys in the ecCodes time namespace\">time</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1837,8 +1959,8 @@
        "</table>\n",
        "</div>\n",
        "     \n",
-       "<input type=\"radio\" name=\"eh-tabs\" id=\"c5e93ddf-c2cd-4c3b-a192-c1dd233def31\"  />\n",
-       "<label for=\"c5e93ddf-c2cd-4c3b-a192-c1dd233def31\" title=\"Keys in the ecCodes vertical namespace\">vertical</label>\n",
+       "<input type=\"radio\" name=\"eh-tabs\" id=\"3da2eefa-f60c-4b5a-a82c-067e2e1b367e\"  />\n",
+       "<label for=\"3da2eefa-f60c-4b5a-a82c-067e2e1b367e\" title=\"Keys in the ecCodes vertical namespace\">vertical</label>\n",
        "<div class=\"tab\">\n",
        "<style type=\"text/css\">table.eh td {\n",
        "    vertical-align: top;\n",
@@ -1861,7 +1983,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1873,9 +1995,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mpy38",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "mpy38"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1887,7 +2009,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previous reference to ecCodes GRIB namespace

![Screenshot 2023-05-04 at 14 38 52](https://user-images.githubusercontent.com/16657983/236222765-b78a00be-d8da-41f4-8e0c-42e3bd20364c.png)

is now a link to [this file](https://user-images.githubusercontent.com/16657983/236216946-9fea8461-1d43-4986-a258-2c81faee482c.png) and there is a statistics namespace example too (as GRIB namespaces might not be super familiar to some users)

![Screenshot 2023-05-04 at 14 39 14](https://user-images.githubusercontent.com/16657983/236222840-94e31dcc-117a-448b-9ecd-78f013b870f2.png)

