### PR TITLE
Limit urllib3 version for read the docs builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ Sphinx
 sphinx-rtd-theme
 nbsphinx
 setuptools
+urllib3<=2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,4 @@ Sphinx
 sphinx-rtd-theme
 nbsphinx
 setuptools
-urllib3<=2.0.0
+urllib3<2.0.0


### PR DESCRIPTION
We need urllib3<2.0.0 on read the docs otherwise the builds fail due to the incompatibility between requests and urllib3 . See: https://github.com/psf/requests/issues/6432