### PR TITLE
Bump Read the Docs OS to use urllib3 2.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,12 @@
 version: 2
 formats: []
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 python:
-  version: 3.8
   install:
-  - requirements: docs/requirements.txt
+    - requirements: docs/requirements.txt
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,5 +8,5 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+  - requirements: docs/requirements.txt
   system_packages: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,3 @@ Sphinx
 sphinx-rtd-theme
 nbsphinx
 setuptools
-urllib3<2.0.0


### PR DESCRIPTION
Hello, urllib3 maintainer here :wave:

You don't need to pin urllib3 just to get Read the Docs working.