### PR TITLE
bugfix netcdf.py

### DIFF
--- a/earthkit/data/readers/netcdf.py
+++ b/earthkit/data/readers/netcdf.py
@@ -297,9 +297,9 @@ class NetCDFReader(Reader):
 
                 # self.log.info("COORD %s %s %s %s", coord, type(coord), hasattr(c, 'calendar'), c)
 
-                standard_name = getattr(c, "standard_name", '')
-                axis = getattr(c, "axis", '')
-                long_name = getattr(c, "long_name", '')
+                standard_name = getattr(c, "standard_name", "")
+                axis = getattr(c, "axis", "")
+                long_name = getattr(c, "long_name", "")
 
                 use = False
 

--- a/earthkit/data/readers/netcdf.py
+++ b/earthkit/data/readers/netcdf.py
@@ -297,9 +297,9 @@ class NetCDFReader(Reader):
 
                 # self.log.info("COORD %s %s %s %s", coord, type(coord), hasattr(c, 'calendar'), c)
 
-                standard_name = getattr(c, "standard_name", None)
-                axis = getattr(c, "axis", None)
-                long_name = getattr(c, "long_name", None)
+                standard_name = getattr(c, "standard_name", '')
+                axis = getattr(c, "axis", '')
+                long_name = getattr(c, "long_name", '')
 
                 use = False
 

--- a/tests/readers/test_netcdf_reader.py
+++ b/tests/readers/test_netcdf_reader.py
@@ -220,7 +220,7 @@ def test_get_fields_missing_standard_name_attr_in_coord_array():
     """test _get_fields() can handle a missing 'standard_name' attr in coordinate data arrays"""
 
     # example dataset
-    fs = from_source("file", earthkit_file("docs/examples/test.nc"))
+    fs = from_source("file", earthkit_examples_file("test.nc"))
     ds = fs.to_xarray()
 
     # delete 'standard_name' attribute (if exists) in any coordinate data arrays


### PR DESCRIPTION
`standard_name` is expected to be of type string, e.g.

https://github.com/ecmwf/earthkit-data/blob/68d755906d8ce15c214345e07539b7a4e9af4b0f/earthkit/data/readers/netcdf.py#L307

this PR is related to https://github.com/ecmwf/earthkit-data/issues/62, which is for solving a bug with the `standard_name` attribute in a netcdf coordinates data array

note that (for consistency) the PR includes updating `axis` and `long_name` to be empty string also