### PR TITLE
Add to_latlon to grib field

### DIFF
--- a/earthkit/data/readers/grib/codes.py
+++ b/earthkit/data/readers/grib/codes.py
@@ -456,6 +456,35 @@ class GribField(Base):
         return values
 
     def to_points(self, flatten=False):
+        r"""Returns the geographical coordinates in the data's original
+        Coordinate Reference System (CRS).
+
+        Parameters
+        ----------
+        flatten: bool
+            When it is True 1D ndarrays are returned. Otherwise ndarrays with the field's
+            :obj:`shape` are returned.
+
+        Returns
+        -------
+        dict
+            Dictionary with items "x" and "y", containing the ndarrays of the x and
+            y coordinates, respectively.
+
+        Raises
+        ------
+        ValueError
+            When the coordinates in the data's original CRS are not available.
+
+        """
+        grid_type = self.metadata("gridType", default=None)
+        if grid_type in ["regular_ll", "reduced_gg", "regular_gg"]:
+            lon, lat = self.data(("lon", "lat"), flatten=flatten)
+            return dict(x=lon, y=lat)
+        else:
+            raise ValueError("grid_type={grid_type} is not supported in to_points()")
+
+    def to_latlon(self, flatten=False):
         r"""Returns the latitudes/longitudes of all the gridpoints in the field.
 
         Parameters
@@ -472,7 +501,7 @@ class GribField(Base):
 
         """
         lon, lat = self.data(("lon", "lat"), flatten=flatten)
-        return dict(lon=lon, lat=lat)
+        return dict(lat=lat, lon=lon)
 
     def __repr__(self):
         return "GribField(%s,%s,%s,%s,%s,%s)" % (

--- a/tests/grib/test_grib_contents.py
+++ b/tests/grib/test_grib_contents.py
@@ -602,11 +602,11 @@ def test_grib_values_with_missing():
     assert np.count_nonzero(np.isnan(m)) == 38
 
 
-def test_grib_to_points_1():
+def test_grib_to_latlon_single():
     f = from_source("file", earthkit_test_data_file("test_single.grib"))
 
     eps = 1e-5
-    v = f[0].to_points(flatten=True)
+    v = f[0].to_latlon(flatten=True)
     assert isinstance(v, dict)
     assert isinstance(v["lon"], np.ndarray)
     assert isinstance(v["lat"], np.ndarray)
@@ -628,10 +628,10 @@ def test_grib_to_points_1():
     )
 
 
-def test_grib_to_points_1_shape():
+def test_grib_to_latlon_single_shape():
     f = from_source("file", earthkit_test_data_file("test_single.grib"))
 
-    v = f[0].to_points()
+    v = f[0].to_latlon()
     assert isinstance(v, dict)
     assert isinstance(v["lon"], np.ndarray)
     assert isinstance(v["lat"], np.ndarray)
@@ -645,6 +645,38 @@ def test_grib_to_points_1_shape():
     assert v["lat"].shape == (7, 12)
     for i, y in enumerate(v["lat"]):
         assert np.allclose(y, np.ones(12) * (90 - i * 30))
+
+
+def test_grib_to_points_single():
+    f = from_source("file", earthkit_test_data_file("test_single.grib"))
+
+    eps = 1e-5
+    v = f[0].to_points(flatten=True)
+    assert isinstance(v, dict)
+    assert isinstance(v["x"], np.ndarray)
+    assert isinstance(v["y"], np.ndarray)
+    check_array(
+        v["x"],
+        (84,),
+        first=0.0,
+        last=330.0,
+        meanv=165.0,
+        eps=eps,
+    )
+    check_array(
+        v["y"],
+        (84,),
+        first=90,
+        last=-90,
+        meanv=0,
+        eps=eps,
+    )
+
+
+def test_grib_to_points_unsupported_grid():
+    f = from_source("file", earthkit_test_data_file("mercator.grib"))
+    with pytest.raises(ValueError):
+        f[0].to_points()
 
 
 def test_grib_datetime():


### PR DESCRIPTION
1. `to_latlon()` returns a dict as:

   `{"lat": array, "lon": array}`

2. `to_points()` for these grid types `["regular_ll", "reduced_gg", "regular_gg"]` simply returns:

   `{"x": lon-array, "y": lat-array}`

    For other grid types it throws a ValueError. Not sure if it is the right implementation.