### PR TITLE
Add python eccodes as a direct dependency with a minimum version

### DIFF
--- a/=
+++ b/=
@@ -1,0 +1,2 @@
+Collecting xarray
+  Using cached xarray-2023.5.0-py3-none-any.whl (994 kB)

--- a/=
+++ b/=
@@ -1,2 +1,0 @@
-Collecting xarray
-  Using cached xarray-2023.5.0-py3-none-any.whl (994 kB)

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - eccodes=>2.19.0
-- python-eccodes
+- python-eccodes>=1.5.0
 - pip
 - numpy
 - pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ test_suite = tests
 packages = find_namespace:
 install_requires =
     cfgrib>=0.9.10.1
+    eccodes>=1.5.0
     dask
     entrypoints
     filelock


### PR DESCRIPTION
* add python-eccodes as a direct dependency in setup.cfg (previously it was installed indirectly by cfgrib)
* set a  minimum version for it (it is required because earthkit-data uses the high level python interface, which is a newer development)