### PR TITLE
type specification for float in key type

### DIFF
--- a/earthkit/data/readers/grib/codes.py
+++ b/earthkit/data/readers/grib/codes.py
@@ -104,7 +104,7 @@ except Exception:
 
 class CodesHandle(eccodes.Message):
     MISSING_VALUE = np.finfo(np.float32).max
-    KEY_TYPES = {"s": str, "l": int, "d": float}
+    KEY_TYPES = {"s": str, "l": int, "d": float, "float": float}
 
     def __init__(self, handle, path, offset):
         super().__init__(handle)


### PR DESCRIPTION
This PR tries to fix a bug we encountered while decoding some records with typeOfLevel 'depthBelowLand' and calling `to_xarray`.
The level should be decoded as a float. Otherwise multiple records are decoded into level 0 (as integer). In order to do that cfgrib, specifies the key as `"level:float"`
https://github.com/ecmwf/cfgrib/blob/master/cfgrib/dataset.py#L154
However earthkit seems to encode the float type differently as `"d:"`. 
I do not know here if there is supposed to be a standard way of encode this in eccodes, so it is not clear to me who does it right/wrong here, if earthkit or cfgrib.
I am opening this PR to show the issue and hopefully get some guidance on how to proceed. 
