### PR TITLE
Return list of BoundingBox objects on a FieldList

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,3 +15,9 @@ GRIB
 .. -----
 
 .. - :py:class:`BufrReader <data.readers.bufr.BUFRReader>`
+
+
+Other
+--------
+
+- :py:class:`BoundingBox <data.utils.bbox.BoundingBox>`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,8 @@ def _skip_for_api(app, what, name, obj, skip, options):
         "data.readers",
         "data.readers.grib.codes",
         "data.readers.grib.index",
+        "data.utils",
+        "data.utils.bbox",
     ]:
         skip = True
     elif what == "package" and name not in [
@@ -124,18 +126,24 @@ def _skip_for_api(app, what, name, obj, skip, options):
         "data.readers",
         "data.readers.grib",
         "data.readers.grib.index",
+        "data.utils",
+        "data.utils.bbox",
     ]:
         skip = True
     elif what == "class" and name not in [
         "data.readers.bufr.BUFRReader",
         "data.readers.grib.codes.GribField",
         "data.readers.grib.index.FieldList",
+        "data.utils.bbox.BoundingBox",
     ]:
         skip = True
     elif what == "method" and "abstractmethod" in getattr(obj, "properties", []):
         skip = True
     elif what in ("function", "attribute", "data"):
         skip = True
+
+    if not skip:
+        print(f"{what} {name}")
     return skip
 
 

--- a/earthkit/data/readers/grib/codes.py
+++ b/earthkit/data/readers/grib/codes.py
@@ -561,7 +561,7 @@ class GribField(Base):
 
         Returns
         -------
-        :class:`BoundingBox`
+        :obj:`BoundingBox <data.utils.bbox.BoundingBox>`
         """
         return BoundingBox(
             north=self.handle.get("latitudeOfFirstGridPointInDegrees", default=None),

--- a/earthkit/data/readers/grib/fieldlist.py
+++ b/earthkit/data/readers/grib/fieldlist.py
@@ -428,7 +428,7 @@ class FieldListMixin(PandasMixIn, XarrayMixIn):
         Returns
         -------
         list
-            List with one :obj:`BoundingBox` per
+            List with one :obj:`BoundingBox <data.utils.bbox.BoundingBox>` per
             :obj:`GribField <data.readers.grib.codes.GribField>`
         """
         return [s.bounding_box() for s in self]

--- a/earthkit/data/readers/grib/fieldlist.py
+++ b/earthkit/data/readers/grib/fieldlist.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 
 from earthkit.data.core.caching import auxiliary_cache_file
 from earthkit.data.core.index import ScaledIndex
-from earthkit.data.utils.bbox import BoundingBox
 
 from .pandas import PandasMixIn
 from .xarray import XarrayMixIn
@@ -432,7 +431,7 @@ class FieldListMixin(PandasMixIn, XarrayMixIn):
             List with one :obj:`BoundingBox` per
             :obj:`GribField <data.readers.grib.codes.GribField>`
         """
-        return BoundingBox.multi_merge([s.bounding_box() for s in self])
+        return [s.bounding_box() for s in self]
 
     def statistics(self):
         import numpy as np

--- a/earthkit/data/readers/netcdf.py
+++ b/earthkit/data/readers/netcdf.py
@@ -397,7 +397,7 @@ class NetCDFReader(Reader):
         return {"base_time": r, "valid_time": r}
 
     def bounding_box(self):
-        return BoundingBox.multi_merge([s.bounding_box() for s in self.get_fields()])
+        return [s.bounding_box() for s in self.get_fields()]
 
 
 def reader(source, path, magic=None, deeper_check=False):

--- a/earthkit/data/sources/multi.py
+++ b/earthkit/data/sources/multi.py
@@ -138,7 +138,7 @@ class MultiSource(Source):
         return {k: sorted(v) for k, v in result.items()}
 
     def bounding_box(self):
-        return BoundingBox.multi_merge([s.bounding_box() for s in self.sources])
+        return BoundingBox.union([s.bounding_box() for s in self.sources])
 
 
 source = MultiSource

--- a/earthkit/data/utils/bbox.py
+++ b/earthkit/data/utils/bbox.py
@@ -21,6 +21,20 @@ def _normalize(lon, minimum):
 
 
 class BoundingBox:
+    r"""Represents a geographic bounding box.
+
+    Parameters
+    ----------
+    north: number
+        Northern latitude (degrees)
+    west: number
+        Western longitude (degrees)
+    south: number
+        Southern latitude (degrees)
+    east: number
+        Eastern longitude (degrees)
+    """
+
     def __init__(self, *, north, west, south, east):
         # Convert to float as these values may come from Numpy
         self.north = min(float(north), 90.0)
@@ -65,19 +79,33 @@ class BoundingBox:
 
     @property
     def width(self):
+        """number: Returns the East-West size (degrees)"""
         return self.east - self.west
 
     @property
     def height(self):
+        """number: Returns the North-South size (degrees)"""
         return self.north - self.south
 
     @classmethod
-    def union(cls, *args):
-        if len(args) == 1 and isinstance(args[0], list):
-            bboxes = args[0]
-        else:
-            bboxes = list(args)
+    def union(cls, bboxes):
+        """Generates the union of a list of :obj:`BoundingBox` objects.
 
+        Parameters
+        ----------
+        bboxes: list
+            Input  :obj:`BoundingBox` objects.
+
+        Returns
+        -------
+        :obj:`BoundingBox`
+            Union of input objects.
+
+        See Also
+        --------
+        :obj:`union_with`
+
+        """
         north = max(z.north for z in bboxes)
         south = min(z.south for z in bboxes)
 
@@ -146,10 +174,40 @@ class BoundingBox:
             east=origin + east,
         )
 
-    # def union(self, other):
-    #     return self.union([self, other])
+    def union_with(self, other):
+        """Generates the union of the current object and ``other``.
+
+        Parameters
+        ----------
+        other: :obj:`BoundingBox`
+            The object to make the union with.
+
+        Returns
+        -------
+        :obj:`BoundingBox`
+            New object containing the union.
+
+        See Also
+        --------
+        :obj:`union`
+
+        """
+        return self.union([self, other])
 
     def add_margins(self, margins):
+        """Generates a new :obj:`BoundingBox` object with adjusted ``margins``.
+
+        Parameters
+        ----------
+        margins: str or number
+            The margin to be added to each side. When it is a ``str`` must specify a percentage
+            in terms of the current size like "50%", while a ``number`` must specify degrees.
+
+        Returns
+        -------
+        :obj:`BoundingBox`
+            New object with adjusted ``margins``.
+        """
         if isinstance(margins, str) and margins[-1] == "%":
             margins = int(margins[:-1]) / 100.0
             margins = max(

--- a/earthkit/data/utils/bbox.py
+++ b/earthkit/data/utils/bbox.py
@@ -72,7 +72,12 @@ class BoundingBox:
         return self.north - self.south
 
     @classmethod
-    def multi_merge(cls, bboxes):
+    def union(cls, *args):
+        if len(args) == 1 and isinstance(args[0], list):
+            bboxes = args[0]
+        else:
+            bboxes = list(args)
+
         north = max(z.north for z in bboxes)
         south = min(z.south for z in bboxes)
 
@@ -141,8 +146,8 @@ class BoundingBox:
             east=origin + east,
         )
 
-    def merge(self, other):
-        return self.multi_merge([self, other])
+    # def union(self, other):
+    #     return self.union([self, other])
 
     def add_margins(self, margins):
         if isinstance(margins, str) and margins[-1] == "%":

--- a/tests/grib/test_grib_contents.py
+++ b/tests/grib/test_grib_contents.py
@@ -710,8 +710,11 @@ def test_grib_datetime():
 
 
 def test_bbox():
-    s = from_source("file", earthkit_examples_file("test.grib"))
-    assert s.bounding_box().as_tuple() == (73, -27, 33, 45), s.bounding_box()
+    ds = from_source("file", earthkit_examples_file("test.grib"))
+    bb = ds.bounding_box()
+    assert len(bb) == 2
+    for b in bb:
+        assert b.as_tuple() == (73, -27, 33, 45)
 
 
 def test_grib_projection_ll():

--- a/tests/readers/test_grib_reader.py
+++ b/tests/readers/test_grib_reader.py
@@ -10,7 +10,6 @@
 #
 
 from earthkit.data import from_source
-from earthkit.data.testing import earthkit_file
 
 
 def test_grib_len():
@@ -39,11 +38,6 @@ def test_dummy_grib():
         level=[1000, 500],
     )
     assert len(s) == 8
-
-
-def test_bbox():
-    s = from_source("file", earthkit_file("docs/examples/test.grib"))
-    assert s.bounding_box().as_tuple() == (73, -27, 33, 45), s.bounding_box()
 
 
 if __name__ == "__main__":

--- a/tests/readers/test_netcdf_reader.py
+++ b/tests/readers/test_netcdf_reader.py
@@ -196,8 +196,11 @@ def test_netcdf_to_points_1():
 
 
 def test_bbox():
-    s = from_source("file", earthkit_file("docs/examples/test.nc"))
-    assert s.bounding_box().as_tuple() == (73, -27, 33, 45), s.bounding_box()
+    ds = from_source("file", earthkit_file("docs/examples/test.nc"))
+    bb = ds.bounding_box()
+    assert len(bb) == 2
+    for b in bb:
+        assert b.as_tuple() == (73, -27, 33, 45)
 
 
 def test_netcdf_proj_string_non_cf():

--- a/tests/utils/test_bbox.py
+++ b/tests/utils/test_bbox.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+import pytest
+
+from earthkit.data.utils.bbox import BoundingBox
+
+
+def test_globe():
+    globe1 = BoundingBox(north=90, west=0, east=360, south=-90)
+    assert globe1.width == 360
+    assert globe1.west == 0
+
+    globe2 = BoundingBox(north=90, west=-180, east=180, south=-90)
+    assert globe2.width == 360
+    assert globe2.west == -180
+
+    assert BoundingBox.union(globe1, globe2).width == 360, BoundingBox.union(
+        globe1, globe2
+    ).width
+    assert BoundingBox.union(globe2, globe1).width == 360, BoundingBox.union(
+        globe2, globe1
+    ).width
+
+    b1 = BoundingBox(north=90, west=-180, east=0, south=-90)
+    b2 = BoundingBox(north=90, west=0, east=180, south=-90)
+    b0 = BoundingBox.union(b1, b2)
+    assert b0.width == 360
+
+
+def test_almost_globe():
+    globe1 = BoundingBox(north=90, west=1, east=360, south=-90)
+    globe2 = BoundingBox(north=90, west=-180, east=179, south=-90)
+
+    assert BoundingBox.union(globe1, globe2).width == 360, BoundingBox.union(
+        globe1, globe2
+    ).width
+    assert BoundingBox.union(globe2, globe1).width == 360, BoundingBox.union(
+        globe2, globe1
+    ).width
+
+
+def test_bbox():
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i, south=30, east=10 + i)
+        assert bbox.width == 10, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i, south=30, east=350 + i)
+        assert bbox.width == 350, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i, south=30, east=(10 + i) % 360)
+        assert bbox.width == 10, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i, south=30, east=(350 + i) % 360)
+        assert bbox.width == 350, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i % 360, south=30, east=10 + i)
+        assert bbox.width == 10, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i % 360, south=30, east=350 + i)
+        assert bbox.width == 350, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i % 360, south=30, east=(10 + i) % 360)
+        assert bbox.width == 10, bbox
+
+    for i in range(-365, 365):
+        bbox = BoundingBox(north=90, west=i % 360, south=30, east=(350 + i) % 360)
+        assert bbox.width == 350, bbox
+
+    for i in range(-365, 365):
+        bbox1 = BoundingBox(north=90, west=150 + i, south=30, east=170 + i)
+        bbox2 = BoundingBox(north=90, west=-170 + i, south=30, east=-150 + i)
+
+        bbox = BoundingBox.union(bbox1, bbox2)
+        assert bbox.width == 60, (bbox1, bbox2, bbox, bbox.width)
+
+        bbox = BoundingBox.union(bbox2, bbox1)
+        assert bbox.width == 60, (bbox1, bbox2, bbox, bbox.width)
+
+        merge1 = BoundingBox.union(bbox1, bbox2)
+        merge2 = BoundingBox.union(bbox2, bbox1)
+        assert merge1 == merge2, (bbox1, bbox2, merge1, merge2)
+
+    with pytest.raises(ValueError):
+        BoundingBox(north=-10, west=0, south=30, east=1)
+
+    b0 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
+    b1 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
+    b2 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
+    b3 = BoundingBox.union(b1, b2)
+
+    assert b0 == b3
+
+
+def test_overlapping_bbox_1():
+    for offset in range(-500, 500, 10):
+        one = BoundingBox(north=90, west=offset + 10, east=offset + 20, south=-90)
+        two = BoundingBox(north=90, west=offset + 40, east=offset + 60, south=-90)
+        three = BoundingBox(north=90, west=offset + 15, east=offset + 35, south=-90)
+
+        sets = []
+        sets.append([one, two, three])
+        sets.append([two, one, three])
+        sets.append([one, three, two])
+        sets.append([one, three, two, one, three])
+        sets.append([one, one, one, two, one, two, one, three])
+        for i, s in enumerate(sets):
+            merged = BoundingBox.union(s)
+            expected = BoundingBox(
+                east=offset + 60, west=offset + 10, north=90, south=-90
+            )
+            assert merged.east == expected.east, (
+                i,
+                merged.east,
+                expected.east,
+                merged,
+                s,
+            )
+            assert merged.west == expected.west, (
+                i,
+                merged.west,
+                expected.west,
+                merged,
+                s,
+            )
+
+        four = BoundingBox(north=90, west=offset - 200, east=offset + 10, south=-90)
+        sets = []
+        sets.append([one, two, three, four])
+        sets.append([two, one, four, three])
+        sets.append([one, three, four, two])
+        sets.append([one, three, two, four, one, three])
+        sets.append([one, one, one, two, four, one, two, one, three])
+        for i, s in enumerate(sets):
+            merged = BoundingBox.union(s)
+            expected = BoundingBox(
+                east=offset + 60, west=offset - 200, north=90, south=-90
+            )
+            assert merged.east % 360 == expected.east % 360, (
+                i,
+                offset,
+                merged.east,
+                expected.east,
+                merged,
+                s,
+            )
+            assert merged.west % 360 == expected.west % 360, (
+                i,
+                merged.west,
+                expected.west,
+                merged,
+                s,
+            )
+            assert merged.west < merged.east
+
+
+def xxxtest_overlaps():
+    b1 = BoundingBox(north=90, west=-200, south=-90, east=-130)
+    b2 = BoundingBox(north=90, west=-180, south=-90, east=-90)
+    b0 = b1.overlaps(b2)
+    assert b0
+
+
+def test_overlapping_bbox_2():
+    b1 = BoundingBox(north=90, west=-200, south=-90, east=-130)
+    b2 = BoundingBox(north=90, west=-180, south=-90, east=-90)
+    b0 = BoundingBox.union(b1, b2)
+
+    assert b0.width == 110, b0.width
+
+    b3 = BoundingBox(north=90, west=-210, south=-90, east=-160)
+    b0 = BoundingBox.union(b0, b3)
+    assert b0.width == 120, b0.width
+
+    #      ----------------------
+    #           ---------------------
+    # ---------------------
+
+    for i in range(-365, 365):
+        b1 = BoundingBox(north=90, west=10 + i, south=-90, east=80 + i)
+        b2 = BoundingBox(north=90, west=30 + i, south=-90, east=120 + i)
+        b3 = BoundingBox(north=90, west=0 + i, south=-90, east=50 + i)
+        b0 = BoundingBox.union([b1, b2, b3])
+        assert b0.width == 120, (b0.width, b0)
+
+    # --------------------------------
+    #           ---------------------
+    #     ---------------------
+
+    for i in range(-365, 365):
+        b1 = BoundingBox(north=90, west=-10 + i, south=-90, east=200 + i)
+        b2 = BoundingBox(north=90, west=30 + i, south=-90, east=120 + i)
+        b3 = BoundingBox(north=90, west=0 + i, south=-90, east=50 + i)
+
+        b0 = BoundingBox.union([b1, b2, b3])
+        assert b0.width == 210, (b0.width, b0)
+
+    # --------------------------------
+    #           --------------------------
+    #     ---------------------
+
+    for i in range(-365, 365):
+        b1 = BoundingBox(north=90, west=-10 + i, south=-90, east=200 + i)
+        b2 = BoundingBox(north=90, west=30 + i, south=-90, east=300 + i)
+        b3 = BoundingBox(north=90, west=0 + i, south=-90, east=50 + i)
+
+        b0 = BoundingBox.union([b1, b2, b3])
+
+        assert b0.width == 310, (b0.width, b0)
+
+
+def test_overlapping_bbox_3():
+    for i in range(361):
+        b1 = BoundingBox(north=90, west=-45 - i, south=-90, east=45 - i)
+        b2 = BoundingBox(north=90, west=-45 + i, south=-90, east=45 + i)
+        b0 = BoundingBox.union(b1, b2)
+
+        if i <= 90:
+            assert b0.width == 90 + 2 * i, (i, b0.width, b0)
+
+        if i > 90 and i <= 180:
+            assert b0.width == 3 * 90 - 2 * (i - 90), (i, b0.width, b0)
+
+        if i > 180 and i <= 270:
+            assert b0.width == 90 + 2 * (i - 180), (i, b0.width, b0)
+
+        if i > 270:
+            assert b0.width == 3 * 90 - 2 * (i - 270), (i, b0.width, b0)
+
+
+if __name__ == "__main__":
+    from earthkit.data.testing import main
+
+    main(__file__)

--- a/tests/utils/test_bbox.py
+++ b/tests/utils/test_bbox.py
@@ -24,16 +24,16 @@ def test_globe():
     assert globe2.width == 360
     assert globe2.west == -180
 
-    assert BoundingBox.union(globe1, globe2).width == 360, BoundingBox.union(
-        globe1, globe2
+    assert BoundingBox.union([globe1, globe2]).width == 360, BoundingBox.union(
+        [globe1, globe2]
     ).width
-    assert BoundingBox.union(globe2, globe1).width == 360, BoundingBox.union(
-        globe2, globe1
+    assert BoundingBox.union([globe2, globe1]).width == 360, BoundingBox.union(
+        [globe2, globe1]
     ).width
 
     b1 = BoundingBox(north=90, west=-180, east=0, south=-90)
     b2 = BoundingBox(north=90, west=0, east=180, south=-90)
-    b0 = BoundingBox.union(b1, b2)
+    b0 = BoundingBox.union([b1, b2])
     assert b0.width == 360
 
 
@@ -41,11 +41,11 @@ def test_almost_globe():
     globe1 = BoundingBox(north=90, west=1, east=360, south=-90)
     globe2 = BoundingBox(north=90, west=-180, east=179, south=-90)
 
-    assert BoundingBox.union(globe1, globe2).width == 360, BoundingBox.union(
-        globe1, globe2
+    assert BoundingBox.union([globe1, globe2]).width == 360, BoundingBox.union(
+        [globe1, globe2]
     ).width
-    assert BoundingBox.union(globe2, globe1).width == 360, BoundingBox.union(
-        globe2, globe1
+    assert BoundingBox.union([globe2, globe1]).width == 360, BoundingBox.union(
+        [globe2, globe1]
     ).width
 
 
@@ -86,14 +86,14 @@ def test_bbox():
         bbox1 = BoundingBox(north=90, west=150 + i, south=30, east=170 + i)
         bbox2 = BoundingBox(north=90, west=-170 + i, south=30, east=-150 + i)
 
-        bbox = BoundingBox.union(bbox1, bbox2)
+        bbox = BoundingBox.union([bbox1, bbox2])
         assert bbox.width == 60, (bbox1, bbox2, bbox, bbox.width)
 
-        bbox = BoundingBox.union(bbox2, bbox1)
+        bbox = BoundingBox.union([bbox2, bbox1])
         assert bbox.width == 60, (bbox1, bbox2, bbox, bbox.width)
 
-        merge1 = BoundingBox.union(bbox1, bbox2)
-        merge2 = BoundingBox.union(bbox2, bbox1)
+        merge1 = BoundingBox.union([bbox1, bbox2])
+        merge2 = BoundingBox.union([bbox2, bbox1])
         assert merge1 == merge2, (bbox1, bbox2, merge1, merge2)
 
     with pytest.raises(ValueError):
@@ -102,7 +102,7 @@ def test_bbox():
     b0 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
     b1 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
     b2 = BoundingBox(north=89.9746, west=-179.975, south=-89.9746, east=179.975)
-    b3 = BoundingBox.union(b1, b2)
+    b3 = BoundingBox.union([b1, b2])
 
     assert b0 == b3
 
@@ -179,12 +179,12 @@ def xxxtest_overlaps():
 def test_overlapping_bbox_2():
     b1 = BoundingBox(north=90, west=-200, south=-90, east=-130)
     b2 = BoundingBox(north=90, west=-180, south=-90, east=-90)
-    b0 = BoundingBox.union(b1, b2)
+    b0 = BoundingBox.union([b1, b2])
 
     assert b0.width == 110, b0.width
 
     b3 = BoundingBox(north=90, west=-210, south=-90, east=-160)
-    b0 = BoundingBox.union(b0, b3)
+    b0 = BoundingBox.union([b0, b3])
     assert b0.width == 120, b0.width
 
     #      ----------------------
@@ -228,7 +228,7 @@ def test_overlapping_bbox_3():
     for i in range(361):
         b1 = BoundingBox(north=90, west=-45 - i, south=-90, east=45 - i)
         b2 = BoundingBox(north=90, west=-45 + i, south=-90, east=45 + i)
-        b0 = BoundingBox.union(b1, b2)
+        b0 = BoundingBox.union([b1, b2])
 
         if i <= 90:
             assert b0.width == 90 + 2 * i, (i, b0.width, b0)
@@ -241,6 +241,13 @@ def test_overlapping_bbox_3():
 
         if i > 270:
             assert b0.width == 3 * 90 - 2 * (i - 270), (i, b0.width, b0)
+
+
+def test_bbox_union_with():
+    b1 = BoundingBox(north=50, west=-20, south=-30, east=40)
+    b2 = BoundingBox(north=60, west=-10, south=-40, east=55)
+    b = b1.union_with(b2)
+    assert b == BoundingBox(north=60, west=-20, south=-40, east=55)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR alters the way the `bounding_box` method used on a `FieldList` in line with the internal discussions regarding the FieldList API.  It also changes some of the method names of `BoundingBox`. The outcome is summarised below:

- the `bounding_box` method on a FieldList returns a list of `BoundingBox` objects (one per field, both for GRIB and NetCDF)
- `BoundingBox`  has a classmethod `union` generating the union of the input list of `BoundingBox` objects
- `BoundingBox`  has an instance method `union_with` generating the union with another object

```python
# getting bounding boxes on a FieldList
bb_list = ds.bounding_box()

# forming union
bb = BoundingBox.union(bb_list)

# forming union with the instance method
bb1 = BoundinBox(...)
bb2 = BoundingBox(...)
bb = bb1.union_with(bb2)
```