### PR TITLE
Feature/source ads

### DIFF
--- a/earthkit/data/sources/ads.py
+++ b/earthkit/data/sources/ads.py
@@ -1,0 +1,67 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import cdsapi
+import yaml
+
+from .cds import CdsRetriever
+from .prompt import APIKeyPrompt
+
+
+class ADSAPIKeyPrompt(APIKeyPrompt):
+    register_or_sign_in_url = "https://ads.atmosphere.copernicus.eu/"
+    retrieve_api_key_url = "https://ads.atmosphere.copernicus.eu/api-how-to"
+
+    prompts = [
+        dict(
+            name="url",
+            default="https://ads.atmosphere.copernicus.eu/api/v2",
+            title="API url",
+            validate=r"http.?://.*",
+        ),
+        dict(
+            name="key",
+            example="123:abcdef01-0000-1111-2222-0123456789ab",
+            title="API key",
+            hidden=True,
+            validate=r"\d+:[\-0-9a-f]+",
+        ),
+    ]
+
+    rcfile = "~/.adsapirc"
+
+    def load(self, file):
+        return yaml.safe_load(file)
+
+    def save(self, input, file):
+        yaml.dump(input, file, default_flow_style=False)
+
+
+def client():
+    prompt = ADSAPIKeyPrompt()
+    credentials = prompt.check(load=True)
+    return cdsapi.Client(**credentials)
+
+
+EXTENSIONS = {
+    "grib": ".grib",
+    "netcdf": ".nc",
+}
+
+
+class AdsRetriever(CdsRetriever):
+    sphinxdoc = """
+    AdsRetriever
+    """
+
+    def client(self):
+        return client()
+
+
+source = AdsRetriever

--- a/earthkit/data/sources/ads.py
+++ b/earthkit/data/sources/ads.py
@@ -8,6 +8,7 @@
 #
 
 import os
+
 import cdsapi
 import yaml
 

--- a/earthkit/data/sources/ads.py
+++ b/earthkit/data/sources/ads.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import os
 import cdsapi
 import yaml
 
@@ -36,17 +37,23 @@ class ADSAPIKeyPrompt(APIKeyPrompt):
 
     rcfile = "~/.adsapirc"
 
-    def load(self, file):
-        return yaml.safe_load(file)
-
     def save(self, input, file):
         yaml.dump(input, file, default_flow_style=False)
 
 
 def client():
     prompt = ADSAPIKeyPrompt()
-    credentials = prompt.check(load=True)
-    return cdsapi.Client(**credentials)
+    prompt.check()
+
+    path = os.path.expanduser(prompt.rcfile)
+
+    if not os.path.exists(path):
+        prompt.ask_user_and_save()
+
+    with open(path) as f:
+        rc = yaml.safe_load(f.read())
+
+    return cdsapi.Client(**rc)
 
 
 EXTENSIONS = {

--- a/earthkit/data/sources/cds.py
+++ b/earthkit/data/sources/cds.py
@@ -68,6 +68,7 @@ class CdsRetriever(FileSource):
     sphinxdoc = """
     CdsRetriever
     """
+
     def client(self):
         return client()
 

--- a/earthkit/data/sources/cds.py
+++ b/earthkit/data/sources/cds.py
@@ -68,6 +68,8 @@ class CdsRetriever(FileSource):
     sphinxdoc = """
     CdsRetriever
     """
+    def client(self):
+        return client()
 
     def __init__(self, dataset, *args, **kwargs):
         super().__init__()
@@ -81,7 +83,7 @@ class CdsRetriever(FileSource):
 
         requests = self.requests(**kwargs)
 
-        client()  # Trigger password prompt before thraeding
+        self.client()  # Trigger password prompt before thraeding
 
         nthreads = min(self.settings("number-of-download-threads"), len(requests))
 
@@ -96,7 +98,7 @@ class CdsRetriever(FileSource):
 
     def _retrieve(self, dataset, request):
         def retrieve(target, args):
-            client().retrieve(args[0], args[1], target)
+            self.client().retrieve(args[0], args[1], target)
 
         return self.cache_file(
             retrieve,

--- a/tests/sources/test_ads.py
+++ b/tests/sources/test_ads.py
@@ -10,14 +10,15 @@
 #
 
 import pytest
+import os
 
 from earthkit.data import from_source
-from earthkit.data.testing import NO_CDS
 
+NO_ADS = not os.path.exists(os.path.expanduser("~/.adsapirc"))
 
 @pytest.mark.long_test
 @pytest.mark.download
-@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+@pytest.mark.skipif(NO_ADS, reason="No access to ADS")
 def test_ads_grib_1():
     s = from_source(
         "ads",
@@ -32,7 +33,7 @@ def test_ads_grib_1():
 
 @pytest.mark.long_test
 @pytest.mark.download
-@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+@pytest.mark.skipif(NO_ADS, reason="No access to ADS")
 def test_ads_grib_2():
     s = from_source(
         "ads",
@@ -48,7 +49,7 @@ def test_ads_grib_2():
 
 @pytest.mark.long_test
 @pytest.mark.download
-@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+@pytest.mark.skipif(NO_ADS, reason="No access to ADS")
 def test_ads_grib_3():
     s = from_source(
         "ads",
@@ -63,7 +64,7 @@ def test_ads_grib_3():
 
 @pytest.mark.long_test
 @pytest.mark.download
-@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+@pytest.mark.skipif(NO_ADS, reason="No access to ADS")
 def test_ads_netcdf():
     s = from_source(
         "ads",

--- a/tests/sources/test_ads.py
+++ b/tests/sources/test_ads.py
@@ -21,8 +21,8 @@ from earthkit.data.testing import NO_CDS
 def test_ads_grib_1():
     s = from_source(
         "ads",
-        'cams-global-reanalysis-eac4',
-        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        "cams-global-reanalysis-eac4",
+        variable=["particulate_matter_10um", "particulate_matter_1um"],
         area=[50, -50, 20, 50],
         date="2012-12-12",
         time="12:00",
@@ -36,8 +36,8 @@ def test_ads_grib_1():
 def test_ads_grib_2():
     s = from_source(
         "ads",
-        'cams-global-reanalysis-eac4',
-        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        "cams-global-reanalysis-eac4",
+        variable=["particulate_matter_10um", "particulate_matter_1um"],
         area=[50, -50, 20, 50],
         date="2012-12-12",
         time="12:00",
@@ -52,8 +52,8 @@ def test_ads_grib_2():
 def test_ads_grib_3():
     s = from_source(
         "ads",
-        'cams-global-reanalysis-eac4',
-        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        "cams-global-reanalysis-eac4",
+        variable=["particulate_matter_10um", "particulate_matter_1um"],
         area=[50, -50, 20, 50],
         date="2012-12-12/to/2012-12-15",
         time="12:00",
@@ -67,8 +67,8 @@ def test_ads_grib_3():
 def test_ads_netcdf():
     s = from_source(
         "ads",
-        'cams-global-reanalysis-eac4',
-        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        "cams-global-reanalysis-eac4",
+        variable=["particulate_matter_10um", "particulate_matter_1um"],
         area=[50, -50, 20, 50],
         date="2012-12-12",
         time="12:00",

--- a/tests/sources/test_ads.py
+++ b/tests/sources/test_ads.py
@@ -9,12 +9,14 @@
 # nor does it submit to any jurisdiction.
 #
 
-import pytest
 import os
+
+import pytest
 
 from earthkit.data import from_source
 
 NO_ADS = not os.path.exists(os.path.expanduser("~/.adsapirc"))
+
 
 @pytest.mark.long_test
 @pytest.mark.download

--- a/tests/sources/test_ads.py
+++ b/tests/sources/test_ads.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import pytest
+
+from earthkit.data import from_source
+from earthkit.data.testing import NO_CDS
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+def test_ads_grib_1():
+    s = from_source(
+        "ads",
+        'cams-global-reanalysis-eac4',
+        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        area=[50, -50, 20, 50],
+        date="2012-12-12",
+        time="12:00",
+    )
+    assert len(s) == 2
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+def test_ads_grib_2():
+    s = from_source(
+        "ads",
+        'cams-global-reanalysis-eac4',
+        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        area=[50, -50, 20, 50],
+        date="2012-12-12",
+        time="12:00",
+        split_on="variable",
+    )
+    assert len(s) == 2
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+def test_ads_grib_3():
+    s = from_source(
+        "ads",
+        'cams-global-reanalysis-eac4',
+        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        area=[50, -50, 20, 50],
+        date="2012-12-12/to/2012-12-15",
+        time="12:00",
+    )
+    assert len(s) == 8
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+def test_ads_netcdf():
+    s = from_source(
+        "ads",
+        'cams-global-reanalysis-eac4',
+        variable = ['particulate_matter_10um', 'particulate_matter_1um'],
+        area=[50, -50, 20, 50],
+        date="2012-12-12",
+        time="12:00",
+        format="netcdf",
+    )
+    assert len(s) == 2
+
+
+if __name__ == "__main__":
+    from earthkit.data.testing import main
+
+    main(__file__)


### PR DESCRIPTION
Add the ability to use Atmosphere data store in addition to the climate data store. (https://github.com/ecmwf/earthkit-data/issues/141)

Mostly copied from [climetlab](https://github.com/ecmwf/climetlab/blob/develop/climetlab/sources/ads.py). The two APIs are almost identical save for having different endpoints and needing different authentication tokens.

The only change I made is a slight refactor to cds.py::CdsRetriever that allows us to subclass it for the AdsRetrriever rather than copying all that identical code. I also added some tests that I copied and adapted from tests/sources/test_cds.py

Let me know if there are any additional changes you'd like to see before merging this into earthkit. For instance CDSAPIKeyPrompt and ADSAPIKeyPrompt are also basically identical so could be merged if it seems worth it.