### PR TITLE
Fix for module imports

### DIFF
--- a/earthkit/data/utils/module_inputs_wrapper.py
+++ b/earthkit/data/utils/module_inputs_wrapper.py
@@ -14,7 +14,6 @@ common signitures or mapping defined at call time
 import inspect
 import types
 import typing as T
-from ast import Module
 from functools import wraps
 
 from earthkit.data import transform

--- a/earthkit/data/utils/module_inputs_wrapper.py
+++ b/earthkit/data/utils/module_inputs_wrapper.py
@@ -180,7 +180,7 @@ def transform_module_inputs(in_module, **kwargs):
         Version of in_module where all functions are wrapped with transform_modul_inputs
     """
     # wrapped_module must be different to original to prevent overriding cached module
-    wrapped_module = Module
+    wrapped_module = types.ModuleType(__name__)
     for name in dir(in_module):
         func = getattr(in_module, name)
         # Wrap any functions that are not hidden
@@ -193,5 +193,5 @@ def transform_module_inputs(in_module, **kwargs):
         else:
             # If not a func, we just copy
             setattr(wrapped_module, name, func)
-
+    
     return wrapped_module

--- a/earthkit/data/utils/module_inputs_wrapper.py
+++ b/earthkit/data/utils/module_inputs_wrapper.py
@@ -192,5 +192,5 @@ def transform_module_inputs(in_module, **kwargs):
         else:
             # If not a func, we just copy
             setattr(wrapped_module, name, func)
-    
+
     return wrapped_module


### PR DESCRIPTION
types is better choice than ast. ast does not create a clean Module and causes overwriting of methods.