### PR TITLE
Write missing values to grib output

### DIFF
--- a/earthkit/data/sources/numpy_list.py
+++ b/earthkit/data/sources/numpy_list.py
@@ -35,7 +35,7 @@ class NumpyField(Field):
     def write(self, f):
         from earthkit.data.writers import write
 
-        write(f, self.values, self._metadata, check_nans=False)
+        write(f, self.values, self._metadata, check_nans=True)
 
 
 class NumpyFieldList(FieldList):

--- a/earthkit/data/writers/grib.py
+++ b/earthkit/data/writers/grib.py
@@ -13,14 +13,13 @@ from . import Writer
 class GribWriter(Writer):
     METADATA_TYPE = "GribMetadata"
 
-    def write(self, f, values, metadata, check_nans=False):
+    def write(self, f, values, metadata, check_nans=True):
         handle = metadata._handle
         if check_nans:
             import numpy as np
 
             if np.isnan(values).any():
-                # missing_value = np.finfo(values.dtype).max
-                missing_value = 9999
+                missing_value = handle.MISSING_VALUE
                 values = np.nan_to_num(values, nan=missing_value)
                 handle.set_double("missingValue", missing_value)
                 handle.set_long("bitmapPresent", 1)

--- a/tests/sources/test_numpy_list.py
+++ b/tests/sources/test_numpy_list.py
@@ -85,6 +85,37 @@ def test_numpy_list_grib_multi_field():
         assert f.metadata("name") == "2 metre dewpoint temperature", f"name {i}"
 
 
+def test_numpy_list_grib_write_missing():
+    ds = from_source("file", earthkit_examples_file("test.grib"))
+
+    assert ds[0].metadata("shortName") == "2t"
+
+    v = ds[0].values
+    v1 = np.array(v)
+    assert not np.isnan(v1[0])
+    assert not np.isnan(v1[1])
+
+    v1[0] = np.nan
+    assert np.isnan(v1[0])
+    assert not np.isnan(v1[1])
+
+    md = ds[0].metadata()
+    md1 = md.override(shortName="msl")
+    r = FieldList.from_numpy(v1, md1)
+
+    assert np.isnan(r[0].values[0])
+    assert not np.isnan(r[0].values[1])
+
+    # save to disk
+    tmp = temp_file()
+    r.save(tmp.path)
+    assert os.path.exists(tmp.path)
+    r_tmp = from_source("file", tmp.path)
+
+    assert np.isnan(r_tmp[0].values[0])
+    assert not np.isnan(r_tmp[0].values[1])
+
+
 if __name__ == "__main__":
     from earthkit.data.testing import main
 


### PR DESCRIPTION
When we use `save` on a NumpyFieldLists it will write np.nan-s as missing values into the resulting grib data.