### PR TITLE
Return index distance tuple in nearest_point_haversine

### DIFF
--- a/earthkit/data/geo/distance.py
+++ b/earthkit/data/geo/distance.py
@@ -103,7 +103,9 @@ def nearest_point_haversine(ref_point, points):
     Returns
     -------
     number
-        Index of the nearest point from ``points`` to ``ref_point``
+        Index of the nearest point to ``ref_point` in ``points``.
+    number
+        Distance (m) between ``ref_point`` and the nearest point in ``points``.
 
     Examples
     --------
@@ -112,7 +114,7 @@ def nearest_point_haversine(ref_point, points):
     >>> p_lat = [44.49, 50.73, 50.1]
     >>> p_lon = [11.34, 7.90, -8.1]
     >>> nearest_point_haversine(p_ref, (p_lat, p_lon))
-    2
+    (2, 523115.8314777661)
 
     """
     if np.asarray(ref_point[0]).size != 1 or np.asarray(ref_point[1]).size != 1:
@@ -122,4 +124,4 @@ def nearest_point_haversine(ref_point, points):
     index = np.nanargmin(distance)
     if isinstance(index, np.ndarray):
         return index[0]
-    return index
+    return (index, distance[index])

--- a/tests/geo/test_geo.py
+++ b/tests/geo/test_geo.py
@@ -100,27 +100,28 @@ def test_haversine_distance_invalid(p_ref):
 
 
 @pytest.mark.parametrize(
-    "p_ref,index_ref",
+    "p_ref,index_ref,dist_ref",
     [
-        ((0, 0), 0),
-        ((15, 22), 0),
-        ((44, 10), 6),
-        ((44, -10), 7),
-        ((89, -120), 4),
-        ((-50, -18), 8),
-        ((-50, 18), 9),
+        ((0, 0), 0, 0),
+        ((15, 22), 0, 2937383.915942687),
+        ((44, 10), 6, 890348.1323086087),
+        ((44, -10), 7, 890348.1323086087),
+        ((89, -120), 4, 111198.92344854656),
+        ((-50, -18), 8, 265965.0757389435),
+        ((-50, 18), 9, 265965.0757389435),
     ],
 )
-def test_haversine_nearest(p_ref, index_ref):
+def test_haversine_nearest(p_ref, index_ref, dist_ref):
     lats = np.array([0.0, 0, 0, 0, 90, -90, 48, 48, -48, -48, np.nan])
     lons = np.array([0, 90, -90, 180, 0, 0, 20, -20, -20, 20, 1.0])
 
-    index = nearest_point_haversine(p_ref, (lats, lons))
+    index, distance = nearest_point_haversine(p_ref, (lats, lons))
     assert index == index_ref, p_ref
+    assert np.isclose(distance, dist_ref)
 
 
 def test_haversine_nearest_invalid():
-    # p_ref must be a single point
+    # checks: p_ref must be a single point
     p_ref = ([15, 21], [22, 7])
     p = ([0.0, 0], [0, 90])
 


### PR DESCRIPTION
 `geo.nearest_point_haversine()` now returns a tuple of `(index, distance)`.

```python
>>> from earthkit.data.geo import nearest_point_haversine
>>> p_ref = (51.45, -0.97)
>>> p_lat = [44.49, 50.73, 50.1]
>>> p_lon = [11.34, 7.90, -8.1]
>>> nearest_point_haversine(p_ref, (p_lat, p_lon))
    (2, 523115.8314777661)
```