### PR TITLE
handle bad installations of PROJ

### DIFF
--- a/earthkit/data/wrappers/pandas.py
+++ b/earthkit/data/wrappers/pandas.py
@@ -8,6 +8,8 @@
 
 import logging
 
+import numpy as np
+
 from earthkit.data.utils.bbox import BoundingBox
 from earthkit.data.wrappers import Wrapper
 
@@ -137,6 +139,12 @@ class GeoPandasDataFrameWrapper(PandasDataFrameWrapper):
             ) = self.data.crs.area_of_use.bounds
         except AttributeError:
             logger.warn("Bounding box not found in geopandas object")
+            (
+                self.east,
+                self.south,
+                self.west,
+                self.north,
+            ) = (np.nan, np.nan, np.nan, np.nan)
         self.fields = None
 
     def __iter__(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ markers =
     notebook: testing notebooks can be slow. But needs to be performed to ensure that the documention is tested.
     no_cache_init: a test where the cache is not initialised. Must be run with --forked.
     no_eccodes: a test which should pass when ecCodes is not installed
+    with_proj: a test which should only pass if PROJ is installed and compatible with your system
 testpaths = tests

--- a/tests/readers/test_geojson_reader.py
+++ b/tests/readers/test_geojson_reader.py
@@ -8,6 +8,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 #
+import pytest
 
 from earthkit.data import from_source
 from earthkit.data.testing import earthkit_file
@@ -21,6 +22,7 @@ def test_geojson():
         assert _s.geometry
 
 
+@pytest.mark.with_proj
 def test_geojson_bounding_box():
     s = from_source("file", earthkit_file("tests/data/NUTS_RG_20M_2021_3035.geojson"))
     bb = s.bounding_box()


### PR DESCRIPTION
Current implementation results in failed tests if the underlying installation of PROJ is not compatible.
This change attaches a marker to the test such that it can be omitted by the user.
The environments used by the CI tests do not have this issue, so it is not necessary to omit the test for the GH actions.

Also included is the assignment of NaN values to the boundingbox such that the attributes exist, they are just unknown, this would allow users to set by hand if desired.