### PR TITLE
Implement a generic to_fieldlist method instead of to_decoded

### DIFF
--- a/earthkit/data/sources/memory.py
+++ b/earthkit/data/sources/memory.py
@@ -48,6 +48,9 @@ class MemoryBaseSource(Source):
     def values(self):
         return self._reader.values
 
+    def to_fieldlist(self, *args, **kwargs):
+        return self._reader.to_fieldlist(*args, **kwargs)
+
     def save(self, path):
         return self._reader.save(path)
 

--- a/earthkit/data/sources/numpy_list.py
+++ b/earthkit/data/sources/numpy_list.py
@@ -43,12 +43,6 @@ class NumpyField(Field):
         else:
             return self._array.astype(dtype, copy=False)
 
-    def to_decoded(self, **kwargs):
-        if self._array_matches(self._array, **kwargs):
-            return self
-        else:
-            return NumpyField(self.to_numpy(**kwargs), self.metadata())
-
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
@@ -124,7 +118,7 @@ class NumpyFieldListCore(PandasMixIn, XarrayMixIn, FieldList):
     def __repr__(self):
         return f"{self.__class__.__name__}(fields={len(self)})"
 
-    def to_decoded(self, **kwargs):
+    def _to_numpy_fieldlist(self, **kwargs):
         if self[0]._array_matches(self._array[0], **kwargs):
             return self
         else:
@@ -167,12 +161,12 @@ class NumpyFieldList(NumpyFieldListCore):
     r"""Represents a list of :obj:`NumpyField <data.sources.numpy_list.NumpyField>`\ s.
 
     The preferred way to create a NumpyFieldList is to use either the
-    static :obj:`from_numpy` method or the :obj:`to_decoded` method.
+    static :obj:`from_numpy` method or the :obj:`to_fieldlist` method.
 
     See Also
     --------
     from_numpy
-    to_decoded
+    to_fieldlist
 
     """
 

--- a/earthkit/data/sources/stream.py
+++ b/earthkit/data/sources/stream.py
@@ -25,9 +25,6 @@ class StreamMemorySource(MemoryBaseSource):
     def __iter__(self):
         return iter(self._reader)
 
-    def to_decoded(self, **kwargs):
-        return self._reader.to_decoded(**kwargs)
-
 
 class StreamSource(Source):
     def __init__(self, stream, group_by=None, **kwargs):

--- a/tests/numpy_fs/numpy_fs_fixtures.py
+++ b/tests/numpy_fs/numpy_fs_fixtures.py
@@ -93,7 +93,7 @@ def check_numpy_fs(ds, ds_input, md_full):
         assert r[2].metadata("param") == "u"
 
 
-def check_numpy_fs_decoded(ds, ds_input, md_full, flatten=False, dtype=None):
+def check_numpy_fs_from_to_fieldlist(ds, ds_input, md_full, flatten=False, dtype=None):
     assert len(ds_input) in [1, 2, 3]
     assert len(ds) == len(md_full)
     assert ds.metadata("param") == md_full

--- a/tests/numpy_fs/test_numpy_fs.py
+++ b/tests/numpy_fs/test_numpy_fs.py
@@ -22,7 +22,10 @@ from earthkit.data.testing import earthkit_examples_file
 
 here = os.path.dirname(__file__)
 sys.path.insert(0, here)
-from numpy_fs_fixtures import check_numpy_fs, check_numpy_fs_decoded  # noqa: E402
+from numpy_fs_fixtures import (  # noqa: E402
+    check_numpy_fs,
+    check_numpy_fs_from_to_fieldlist,
+)
 
 
 def test_numpy_fs_grib_single_field():
@@ -123,28 +126,28 @@ def test_numpy_fs_grib_from_list_of_arrays_bad():
         {"flatten": True, "dtype": np.float32},
     ],
 )
-def test_numpy_fs_grib_from_to_decoded(kwargs):
+def test_numpy_fs_grib_from_to_fieldlist(kwargs):
     ds = from_source("file", earthkit_examples_file("test.grib"))
     md_full = ds.metadata("param")
     assert len(ds) == 2
 
-    r = ds.to_decoded(**kwargs)
-    check_numpy_fs_decoded(r, [ds], md_full, **kwargs)
+    r = ds.to_fieldlist("numpy", **kwargs)
+    check_numpy_fs_from_to_fieldlist(r, [ds], md_full, **kwargs)
 
 
-def test_numpy_fs_grib_from_to_decoded_repeat():
+def test_numpy_fs_grib_from_to_fieldlist_repeat():
     ds = from_source("file", earthkit_examples_file("test.grib"))
     md_full = ds.metadata("param")
     assert len(ds) == 2
 
     kwargs = {}
-    r = ds.to_decoded(**kwargs)
-    check_numpy_fs_decoded(r, [ds], md_full, **kwargs)
+    r = ds.to_fieldlist("numpy", **kwargs)
+    check_numpy_fs_from_to_fieldlist(r, [ds], md_full, **kwargs)
 
     kwargs = {"flatten": True, "dtype": np.float32}
-    r1 = r.to_decoded(**kwargs)
+    r1 = r.to_fieldlist("numpy", **kwargs)
     assert r1 is not r
-    check_numpy_fs_decoded(r1, [ds], md_full, **kwargs)
+    check_numpy_fs_from_to_fieldlist(r1, [ds], md_full, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR replaces the recently added `to_decoded()` method on a `FieldList` with the more generic `to_fieldlist()`. The new method provides a means to convert one `FieldList` into another one using a different `backend`.

<img src="https://github.com/ecmwf/earthkit-data/assets/9033020/f6f71d5c-a121-4e87-9c7c-9496f03cf708"   width="550">
