### PR TITLE
cfgrib does not need to be specified. 

### DIFF
--- a/earthkit/data/readers/grib/xarray.py
+++ b/earthkit/data/readers/grib/xarray.py
@@ -131,7 +131,6 @@ class XarrayMixIn:
                 default=default,
                 forced={
                     "errors": "raise",
-                    "engine": "cfgrib",
                 },
             )
         )


### PR DESCRIPTION
cfgrib engine automatically detects when it is needed, hene it is not neccesary to include in open_dataset kwargs.
Additionally current implementation prevents using different engine (which we are working on)