### PR TITLE
Do not implicitly set generatingProcessIdentifier when writing GRIB data

### DIFF
--- a/earthkit/data/core/__init__.py
+++ b/earthkit/data/core/__init__.py
@@ -65,12 +65,12 @@ class Base(metaclass=MetaBase):
 
     # I/O
     @abstractmethod
-    def save(self, path):
+    def save(self, path, **kwargs):
         """Writes data into the specified ``path``."""
         self._not_implemented()
 
     @abstractmethod
-    def write(self, f):
+    def write(self, f, **kwargs):
         """Writes data to the ``f`` file object."""
         self._not_implemented()
 

--- a/earthkit/data/core/fieldlist.py
+++ b/earthkit/data/core/fieldlist.py
@@ -1164,7 +1164,7 @@ class FieldList(Index):
                 )
         return False
 
-    def save(self, filename, append=False):
+    def save(self, filename, append=False, **kwargs):
         r"""Write all the fields into a file.
 
         Parameters
@@ -1177,9 +1177,9 @@ class FieldList(Index):
         """
         flag = "wb" if not append else "ab"
         with open(filename, flag) as f:
-            self.write(f)
+            self.write(f, **kwargs)
 
-    def write(self, f):
+    def write(self, f, **kwargs):
         r"""Write all the fields to a file object.
 
         Parameters
@@ -1188,7 +1188,7 @@ class FieldList(Index):
             The target file object.
         """
         for s in self:
-            s.write(f)
+            s.write(f, **kwargs)
 
     def to_fieldlist(self, backend, **kwargs):
         r"""Convert to a new :class:`FieldList` based on the ``backend``.

--- a/earthkit/data/readers/__init__.py
+++ b/earthkit/data/readers/__init__.py
@@ -60,12 +60,12 @@ class Reader(Base, os.PathLike, metaclass=ReaderMeta):
     def cache_file(self, *args, **kwargs):
         return self.source.cache_file(*args, **kwargs)
 
-    def save(self, path):
+    def save(self, path, **kwargs):
         mode = "wb" if self.binary else "w"
         with open(path, mode) as f:
-            self.write(f)
+            self.write(f, **kwargs)
 
-    def write(self, f):
+    def write(self, f, **kwargs):
         if not self.appendable:
             assert f.tell() == 0
         mode = "rb" if self.binary else "r"

--- a/earthkit/data/readers/directory.py
+++ b/earthkit/data/readers/directory.py
@@ -83,10 +83,10 @@ class DirectoryReader(Reader):
             merger=self.merger,
         )
 
-    def save(self, path):
+    def save(self, path, **kwargs):
         shutil.copytree(self.path, path)
 
-    def write(self, f):
+    def write(self, f, **kwargs):
         raise NotImplementedError()
 
 

--- a/earthkit/data/readers/grib/codes.py
+++ b/earthkit/data/readers/grib/codes.py
@@ -219,12 +219,15 @@ class GribCodesHandle(CodesHandle):
     def get_data_points(self):
         return eccodes.codes_grib_get_data(self._handle)
 
-    def set_values(self, values):
+    def set_values(self, values, generating_proc_id=None):
         try:
             assert self.path is None, "Only cloned handles can have values changed"
             eccodes.codes_set_values(self._handle, values.flatten())
-            # This is writing on the GRIB that something has been modified (255=unknown)
-            eccodes.codes_set_long(self._handle, "generatingProcessIdentifier", 255)
+            # For ECMWF gribs: indicates that something has been modified (255=unknown)
+            if generating_proc_id is not None:
+                eccodes.codes_set_long(
+                    self._handle, "generatingProcessIdentifier", generating_proc_id
+                )
         except Exception as e:
             LOG.error("Error setting values")
             LOG.exception(e)

--- a/earthkit/data/readers/grib/codes.py
+++ b/earthkit/data/readers/grib/codes.py
@@ -219,15 +219,10 @@ class GribCodesHandle(CodesHandle):
     def get_data_points(self):
         return eccodes.codes_grib_get_data(self._handle)
 
-    def set_values(self, values, generating_proc_id=None):
+    def set_values(self, values):
         try:
             assert self.path is None, "Only cloned handles can have values changed"
             eccodes.codes_set_values(self._handle, values.flatten())
-            # For ECMWF gribs: indicates that something has been modified (255=unknown)
-            if generating_proc_id is not None:
-                eccodes.codes_set_long(
-                    self._handle, "generatingProcessIdentifier", generating_proc_id
-                )
         except Exception as e:
             LOG.error("Error setting values")
             LOG.exception(e)

--- a/earthkit/data/readers/grib/output.py
+++ b/earthkit/data/readers/grib/output.py
@@ -123,12 +123,15 @@ class GribOutput:
             k: v for k, v in sorted(metadata.items(), key=lambda x: order(x[0]))
         }
 
+        if "generatingProcessIdentifier" not in metadata:
+            metadata["generatingProcessIdentifier"] = 255
+
         LOG.debug("GribOutput.metadata %s", metadata)
 
         for k, v in metadata.items():
             handle.set(k, v)
 
-        handle.set_values(values, generating_proc_id=255)
+        handle.set_values(values)
 
         file, path = self.f(handle)
         handle.write(file)

--- a/earthkit/data/readers/grib/output.py
+++ b/earthkit/data/readers/grib/output.py
@@ -128,7 +128,7 @@ class GribOutput:
         for k, v in metadata.items():
             handle.set(k, v)
 
-        handle.set_values(values)
+        handle.set_values(values, generating_proc_id=255)
 
         file, path = self.f(handle)
         handle.write(file)

--- a/earthkit/data/sources/file.py
+++ b/earthkit/data/sources/file.py
@@ -114,11 +114,11 @@ class FileSource(Source, os.PathLike, metaclass=FileSourceMeta):
     def values(self):
         return self._reader.values
 
-    def save(self, path):
-        return self._reader.save(path)
+    def save(self, path, **kwargs):
+        return self._reader.save(path, **kwargs)
 
-    def write(self, f):
-        return self._reader.write(f)
+    def write(self, f, **kwargs):
+        return self._reader.write(f, **kwargs)
 
     def scaled(self, *args, **kwargs):
         return self._reader.scaled(*args, **kwargs)

--- a/earthkit/data/sources/memory.py
+++ b/earthkit/data/sources/memory.py
@@ -51,11 +51,11 @@ class MemoryBaseSource(Source):
     def to_fieldlist(self, *args, **kwargs):
         return self._reader.to_fieldlist(*args, **kwargs)
 
-    def save(self, path):
-        return self._reader.save(path)
+    def save(self, path, **kwargs):
+        return self._reader.save(path, **kwargs)
 
-    def write(self, f):
-        return self._reader.write(f)
+    def write(self, f, **kwargs):
+        return self._reader.write(f, **kwargs)
 
     def scaled(self, *args, **kwargs):
         return self._reader.scaled(*args, **kwargs)

--- a/earthkit/data/sources/multi.py
+++ b/earthkit/data/sources/multi.py
@@ -84,10 +84,10 @@ class MultiSource(Source):
         string = ",".join(repr(s) for s in self.sources)
         return f"{self.__class__.__name__}({string})"
 
-    def save(self, path):
+    def save(self, path, **kwargs):
         with open(path, "wb") as f:
             for s in self.sources:
-                s.write(f)
+                s.write(f, **kwargs)
 
     def graph(self, depth=0):
         print(" " * depth, self.__class__.__name__, self.merger)

--- a/earthkit/data/sources/numpy_list.py
+++ b/earthkit/data/sources/numpy_list.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 
 
 class NumpyField(Field):
-    r"""Represents a field consisting of an ndarray and metadata object.
+    r"""Represent a field consisting of an ndarray and metadata object.
 
     Parameters
     ----------
@@ -46,10 +46,19 @@ class NumpyField(Field):
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
-    def write(self, f):
+    def write(self, f, **kwargs):
+        r"""Write the field to a file object.
+
+        Parameters
+        ----------
+        f: file object
+            The target file object.
+        **kwargs: dict, optional
+            Other keyword arguments passed to :meth:`data.writers.grib.GribWriter.write`.
+        """
         from earthkit.data.writers import write
 
-        write(f, self.values, self._metadata, check_nans=True)
+        write(f, self.values, self._metadata, **kwargs)
 
 
 class NumpyFieldListCore(PandasMixIn, XarrayMixIn, FieldList):
@@ -158,7 +167,7 @@ class ListMerger:
 
 
 class NumpyFieldList(NumpyFieldListCore):
-    r"""Represents a list of :obj:`NumpyField <data.sources.numpy_list.NumpyField>`\ s.
+    r"""Represent a list of :obj:`NumpyField <data.sources.numpy_list.NumpyField>`\ s.
 
     The preferred way to create a NumpyFieldList is to use either the
     static :obj:`from_numpy` method or the :obj:`to_fieldlist` method.

--- a/earthkit/data/writers/grib.py
+++ b/earthkit/data/writers/grib.py
@@ -13,7 +13,7 @@ from . import Writer
 class GribWriter(Writer):
     DATA_FORMAT = "grib"
 
-    def write(self, f, values, metadata, check_nans=True, generating_proc_id=None):
+    def write(self, f, values, metadata, check_nans=True):
         r"""Write a GRIB field to a file object.
 
         Parameters
@@ -26,10 +26,6 @@ class GribWriter(Writer):
             Metadata of the GRIB field/message.
         check_nans: bool
             Replace nans in ``values`` with GRIB missing values when writing to``f``.
-        generating_proc_id: int
-            Set the ``generatingProcessIdentifier`` ecCodes GRIB key
-            to the specified value when writing to ``f``. When
-            ``None`` no changes are made.
         """
         handle = metadata._handle
         if check_nans:
@@ -41,7 +37,7 @@ class GribWriter(Writer):
                 handle.set_double("missingValue", missing_value)
                 handle.set_long("bitmapPresent", 1)
 
-        handle.set_values(values, generating_proc_id=generating_proc_id)
+        handle.set_values(values)
         handle.write(f)
 
 

--- a/earthkit/data/writers/grib.py
+++ b/earthkit/data/writers/grib.py
@@ -13,7 +13,24 @@ from . import Writer
 class GribWriter(Writer):
     DATA_FORMAT = "grib"
 
-    def write(self, f, values, metadata, check_nans=True):
+    def write(self, f, values, metadata, check_nans=True, generating_proc_id=None):
+        r"""Write a GRIB field to a file object.
+
+        Parameters
+        ----------
+        f: file object
+            The target file object.
+        values: ndarray
+            Values of the GRIB field/message.
+        values: :class:`GribMetadata`
+            Metadata of the GRIB field/message.
+        check_nans: bool
+            Replace nans in ``values`` with GRIB missing values when writing to``f``.
+        generating_proc_id: int
+            Set the ``generatingProcessIdentifier`` ecCodes GRIB key
+            to the specified value when writing to ``f``. When
+            ``None`` no changes are made.
+        """
         handle = metadata._handle
         if check_nans:
             import numpy as np
@@ -24,7 +41,7 @@ class GribWriter(Writer):
                 handle.set_double("missingValue", missing_value)
                 handle.set_long("bitmapPresent", 1)
 
-        handle.set_values(values)
+        handle.set_values(values, generating_proc_id=generating_proc_id)
         handle.write(f)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     tqdm
     xarray>=0.19.0
     earthkit-meteo>=0.0.1
+    aws-requests-auth
 include_package_data = True
 
 [options.packages.find]

--- a/tests/grib/test_grib_output.py
+++ b/tests/grib/test_grib_output.py
@@ -55,6 +55,7 @@ def test_grib_output_latlon():
         assert ds[0].metadata("param") == "2t"
         assert ds[0].metadata("levtype") == "sfc"
         assert ds[0].metadata("edition") == 2
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 
@@ -79,6 +80,7 @@ def test_grib_output_o96():
         assert ds[0].metadata("param") == "2t"
         assert ds[0].metadata("levtype") == "sfc"
         assert ds[0].metadata("edition") == 2
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 
@@ -103,6 +105,7 @@ def test_grib_output_o160():
         assert ds[0].metadata("edition") == 2
         assert ds[0].metadata("levtype") == "sfc"
         assert ds[0].metadata("param") == "2t"
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 
@@ -130,6 +133,7 @@ def test_grib_output_mars_labeling():
         assert ds[0].metadata("levtype") == "sfc"
         assert ds[0].metadata("param") == "msl"
         assert ds[0].metadata("type") == "fc"
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 
@@ -158,6 +162,7 @@ def test_grib_output_pl(levtype):
         assert ds[0].metadata("level") == 850
         assert ds[0].metadata("levtype") == "pl"
         assert ds[0].metadata("param") == "t"
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 
@@ -185,6 +190,7 @@ def test_grib_output_tp():
         assert ds[0].metadata("levtype") == "sfc"
         assert ds[0].metadata("edition") == 1
         assert ds[0].metadata("step") == 48
+        assert ds[0].metadata("generatingProcessIdentifier") == 255
 
         assert np.allclose(ds[0].to_numpy(), data, rtol=EPSILON, atol=EPSILON)
 

--- a/tests/numpy_fs/test_numpy_fs_write.py
+++ b/tests/numpy_fs/test_numpy_fs_write.py
@@ -113,16 +113,7 @@ def test_numpy_fs_grib_write_append():
     assert r_tmp.metadata("shortName") == ["msl", "2d"]
 
 
-@pytest.mark.parametrize(
-    "_kwargs,expected_value",
-    [
-        ({}, 150),
-        ({"generating_proc_id": None}, 150),
-        ({"generating_proc_id": 255}, 255),
-        ({"generating_proc_id": 144}, 144),
-    ],
-)
-def test_numpy_fs_grib_write_generating_proc_id(_kwargs, expected_value):
+def test_numpy_fs_grib_write_generating_proc_id():
     ds = from_source("file", earthkit_examples_file("test.grib"))
 
     assert ds[0].metadata("shortName") == "2t"
@@ -132,21 +123,21 @@ def test_numpy_fs_grib_write_generating_proc_id(_kwargs, expected_value):
     v2 = v + 2
 
     md = ds[0].metadata()
-    md1 = md.override(shortName="msl")
+    md1 = md.override(shortName="msl", generatingProcessIdentifier=255)
     md2 = md.override(shortName="2d")
 
     r1 = FieldList.from_numpy([v1, v2], [md1, md2])
 
     # save to disk: using generatingProcessIdentifier=255 (default)
     with temp_file() as tmp:
-        r1.save(tmp, **_kwargs)
+        r1.save(tmp)
         assert os.path.exists(tmp)
         r_tmp = from_source("file", tmp)
         assert len(r_tmp) == 2
         assert r_tmp.metadata("shortName") == ["msl", "2d"]
         assert r_tmp.metadata("generatingProcessIdentifier") == [
-            expected_value,
-            expected_value,
+            255,
+            150,
         ]
 
 


### PR DESCRIPTION
Fixes #274 

Previously, when writing a `NumpyFieldList` the `generatingProcessIdentifier` ecCodes GRIB key was always set to 255 (internally) in the output.

With this PR this key is not set implicitly but must be set explicitly in `Metadata.override()`. E.g.:

```python
# ds is a fieldlist
md = ds[0].metadata().override(shortName="msl", generatingProcessIdentifier=255)
r = FieldList.from_numpy(ds[0].values, md)
r.save("my_data.grib")
```
