### PR TITLE
Implement parts for url stream

### DIFF
--- a/earthkit/data/sources/multi_url.py
+++ b/earthkit/data/sources/multi_url.py
@@ -13,7 +13,9 @@ from .multi import MultiSource
 
 
 class MultiUrl(MultiSource):
-    def __init__(self, urls, *args, filter=None, merger=None, force=None, **kwargs):
+    def __init__(
+        self, urls, *args, filter=None, merger=None, force=None, lazily=True, **kwargs
+    ):
         if not isinstance(urls, (list, tuple)):
             urls = [urls]
 
@@ -21,6 +23,9 @@ class MultiUrl(MultiSource):
         #     urls = [url for url in urls if filter(url)]
 
         assert len(urls)
+
+        if len(urls) > 1 and isinstance(urls[0], str):
+            urls = sorted(urls)
 
         sources = [
             from_source(
@@ -30,9 +35,10 @@ class MultiUrl(MultiSource):
                 merger=merger,
                 force=force,
                 # Load lazily so we can do parallel downloads
-                lazily=True,
+                lazily=lazily,
+                **kwargs
             )
-            for url in sorted(urls)
+            for url in urls
         ]
 
         super().__init__(sources, filter=filter, merger=merger)

--- a/earthkit/data/sources/stream.py
+++ b/earthkit/data/sources/stream.py
@@ -221,22 +221,21 @@ class StreamSource(StreamSourceBase):
     def mutate(self):
         assert self._reader_ is None
 
-        return make_source(
+        return _from_stream(
             self._stream, batch_size=self.batch_size, group_by=self.group_by
         )
 
 
 class StreamSourceMaker:
-    def __init__(self, create, data, stream_kwargs):
-        self.create = create
-        self.data = data
+    def __init__(self, source, stream_kwargs):
+        self.in_source = source
         self.stream_kwargs = dict(stream_kwargs)
         self.source = None
 
     def __call__(self):
         if self.source is None:
-            stream = self.create(self.data)
-            self.source = make_source(stream, **self.stream_kwargs)
+            stream = self.in_source.to_stream()
+            self.source = _from_stream(stream, **self.stream_kwargs)
 
             prev = None
             src = self.source
@@ -248,7 +247,7 @@ class StreamSourceMaker:
         return self.source
 
 
-def make_source(stream, group_by, batch_size):
+def _from_stream(stream, group_by, batch_size):
     _kwargs = dict(batch_size=batch_size, group_by=group_by)
 
     if group_by:
@@ -263,17 +262,17 @@ def make_source(stream, group_by, batch_size):
     raise ValueError(f"Unsupported stream parameters {batch_size=} {group_by=}")
 
 
-def make_stream_from_method(owner, create, data, **kwargs):
+def _from_source(source, **kwargs):
     stream_kwargs, kwargs = parse_stream_kwargs(**kwargs)
 
     if kwargs:
         raise TypeError(f"got invalid keyword argument(s): {list(kwargs.keys())}")
 
-    if not isinstance(data, (list, tuple)):
-        maker = StreamSourceMaker(create, data, stream_kwargs)
+    if not isinstance(source, (list, tuple)):
+        maker = StreamSourceMaker(source, stream_kwargs)
         return maker()
     else:
-        sources = [StreamSourceMaker(create, d, stream_kwargs) for d in data]
+        sources = [StreamSourceMaker(s, stream_kwargs) for s in source]
         return MultiStreamSource(sources, **stream_kwargs)
 
 

--- a/earthkit/data/utils/url.py
+++ b/earthkit/data/utils/url.py
@@ -1,0 +1,22 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+from abc import ABCMeta, abstractmethod
+
+
+class HttpAuthenticator(metaclass=ABCMeta):
+    @abstractmethod
+    def auth_header(self, url):
+        pass
+
+
+class AnonymousHttpAuthenticator(metaclass=ABCMeta):
+    def auth_header(self, url):
+        return {}

--- a/tests/grib/test_grib_url.py
+++ b/tests/grib/test_grib_url.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import pytest
+
+from earthkit.data import from_source
+from earthkit.data.testing import earthkit_remote_test_data_file
+
+
+@pytest.mark.parametrize(
+    "parts,expected_meta",
+    [
+        ([(0, 150)], [("t", 1000)]),
+        ([(240, 150)], [("u", 1000)]),
+        ([(240, 480)], [("u", 1000), ("v", 1000)]),
+    ],
+)
+def test_grib_single_url_parts(parts, expected_meta):
+    ds = from_source(
+        "url", earthkit_remote_test_data_file("examples/test6.grib"), parts=parts
+    )
+
+    assert len(ds) == len(expected_meta)
+
+    cnt = 0
+    for i, f in enumerate(ds):
+        assert f.metadata(("param", "level")) == expected_meta[i], i
+        cnt += 1
+
+    assert cnt == len(expected_meta)
+
+
+@pytest.mark.parametrize(
+    "parts1,parts2,expected_meta",
+    [
+        (
+            [(240, 150)],
+            None,
+            [("u", 1000), ("2t", 0), ("msl", 0)],
+        ),
+        (
+            None,
+            [(0, 526)],
+            [
+                ("t", 1000),
+                ("u", 1000),
+                ("v", 1000),
+                ("t", 850),
+                ("u", 850),
+                ("v", 850),
+                ("2t", 0),
+            ],
+        ),
+        (
+            [(240, 150)],
+            [(0, 526)],
+            [("u", 1000), ("2t", 0)],
+        ),
+    ],
+)
+def test_grib_multi_url_parts(parts1, parts2, expected_meta):
+    ds = from_source(
+        "url",
+        [
+            [earthkit_remote_test_data_file("examples/test6.grib"), parts1],
+            [earthkit_remote_test_data_file("examples/test.grib"), parts2],
+        ],
+    )
+
+    assert len(ds) == len(expected_meta)
+
+    cnt = 0
+    for i, f in enumerate(ds):
+        assert f.metadata(("param", "level")) == expected_meta[i], i
+        cnt += 1
+
+    assert cnt == len(expected_meta)
+
+
+if __name__ == "__main__":
+    from earthkit.data.testing import main
+
+    main()

--- a/tests/sources/test_url.py
+++ b/tests/sources/test_url.py
@@ -145,6 +145,20 @@ def test_url_netcdf_source_save():
     assert os.path.exists(tmp.path)
 
 
+def test_multi_url_parts_invalid():
+    parts1 = [(240, 150)]
+    parts2 = [(0, 526)]
+    with pytest.raises(ValueError):
+        from_source(
+            "url",
+            [
+                [earthkit_remote_test_data_file("examples/test6.grib"), parts1],
+                [earthkit_remote_test_data_file("examples/test.grib"), parts2],
+            ],
+            parts=[(0, 240)],
+        )
+
+
 if __name__ == "__main__":
     test_part_url()
     # from earthkit.data.testing import main


### PR DESCRIPTION
This PR makes parts (only single parts) work for url streams:

```python
# the remote file contains 6 GRIB messages. 
# We only read the first 2 (between bytes offset=0 and lenght=480).
ds = from_source(
        "url",
       "https://get.ecmwf.int/repository/test-data/earthkit-data/examples/test6.grib",
        parts=[(0, 480)],
        stream=True,
    )

for f in ds:
    # f is a field
    print(f)
```

output:
```
GribField(t,1000,20180801,1200,0,0)
GribField(u,1000,20180801,1200,0,0)
```