### PR TITLE
from_source should fail when try to load empty file

### DIFF
--- a/earthkit/data/readers/__init__.py
+++ b/earthkit/data/readers/__init__.py
@@ -169,6 +169,12 @@ def reader(source, path, **kwargs):
         return DirectoryReader(source, path).mutate()
     LOG.debug("Reader for %s", path)
 
+    if not os.path.exists(path):
+        raise FileExistsError(f"No such file exists: '{path}'")
+
+    if os.path.getsize(path) == 0:
+        raise Exception(f"File is empty: '{path}'")
+
     n_bytes = SETTINGS.get("reader-type-check-bytes")
     with open(path, "rb") as f:
         magic = f.read(n_bytes)

--- a/tests/readers/test_empty_file.py
+++ b/tests/readers/test_empty_file.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import pytest
+
+import earthkit.data
+from earthkit.data.testing import earthkit_test_data_file
+
+
+def test_empty_file_reader():
+    with pytest.raises(Exception):
+        earthkit.data.from_source("file", earthkit_test_data_file("empty_file.grib"))
+
+
+def test_nonexisting_file_reader():
+    with pytest.raises(FileExistsError):
+        earthkit.data.from_source("file", "__nonexistingfile__")
+
+
+if __name__ == "__main__":
+    from earthkit.data.testing import main
+
+    main(__file__)


### PR DESCRIPTION
With this PR `from_source` throws an exception when the input is an empty file. Previously, the result was a `TextReader`.

The consequence of this change is that when reading/downloading multiple files now it is enough to have an empty file out of many valid ones and the program fail if the exception is uncaught. 