### PR TITLE
Add model option to ecmwf-open-data source

### DIFF
--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -520,12 +520,14 @@ cds
 ecmwf-open-data
 -------------------
 
-.. py:function:: from_source("ecmwf-open-data", *args, **kwargs)
+.. py:function:: from_source("ecmwf-open-data", *args, source="ecmwf", model="ifs", **kwargs)
   :noindex:
 
   The ``ecmwf-open-data`` source provides access to the `ECMWF open data`_, which is a subset of ECMWF real-time forecast data made available to the public free of charge.  It uses the `ecmwf-opendata <https://github.com/ecmwf/ecmwf-opendata>`_ package.
 
   :param tuple *args: specify the request as a dict
+  :param str source: either the name of the server to contact or a fully qualified URL. Possible values are "ecmwf" to access ECMWF's servers, or "azure" to access data hosted on Microsoft's Azure. Default is "ecmwf".
+  :param str model: name of the model that produced the data. Use "ifs" for the physics-driven model and "aifs" for the data-driven model. Please note that "aifs" is currently experimental and only produces a small subset of fields. Default is "ifs".
   :param dict **kwargs: other keyword arguments specifying the request
 
   Details about the request format can be found `here <https://github.com/ecmwf/ecmwf-opendata>`__.

--- a/earthkit/data/sources/ecmwf_open_data.py
+++ b/earthkit/data/sources/ecmwf_open_data.py
@@ -17,7 +17,7 @@ class EODRetriever(FileSource):
     EODRetriever
     """
 
-    def __init__(self, source="ecmwf", *args, **kwargs):
+    def __init__(self, *args, source="ecmwf", model="ifs", **kwargs):
         super().__init__()
         if len(args):
             assert len(args) == 1
@@ -27,7 +27,9 @@ class EODRetriever(FileSource):
 
         self.source_kwargs = self.request(**kwargs)
 
-        self.client = ecmwf.opendata.Client(source=source, preserve_request_order=True)
+        self.client = ecmwf.opendata.Client(
+            source=source, model=model, preserve_request_order=True
+        )
 
         self.path = self._retrieve(self.source_kwargs)
 

--- a/tests/sources/test_ecmwf_open_data.py
+++ b/tests/sources/test_ecmwf_open_data.py
@@ -25,7 +25,22 @@ def test_eod():
         levtype="sfc",
     )
     assert len(ds) == 2
-    assert ds.path
+    assert ds.metadata("param") == ["2t", "msl"]
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_EOD, reason="No access to EOD")
+@pytest.mark.parametrize("model", ["ifs", "aifs"])
+def test_eod_model(model):
+    ds = from_source(
+        "ecmwf-open-data",
+        model=model,
+        param="t",
+        levelist=500,
+    )
+    assert len(ds) == 1
+    assert ds[0].metadata(["param", "level"]) == ["t", 500]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the `model` option to the `ecmwf-open-data` source and updates the documentation:

![image](https://github.com/ecmwf/earthkit-data/assets/9033020/eb1ee86a-620b-4330-82dc-2326f131e5b4)


