### PR TITLE
Improve source lookup

### DIFF
--- a/earthkit/data/sources/__init__.py
+++ b/earthkit/data/sources/__init__.py
@@ -119,15 +119,16 @@ class SourceLoader:
 
 
 class SourceMaker:
+    SOURCES = {}
+
     def __call__(self, name, *args, **kwargs):
         loader = SourceLoader()
 
-        klass = find_plugin(os.path.dirname(__file__), name, loader)
-
-        # if os.environ.get("FIEDLIST_TESTING_ENABLE_MOCKUP_SOURCE", False):
-        #     from earthkit.data.mockup import SourceMockup
-
-        #     klass = SourceMockup
+        if name in self.SOURCES:
+            klass = self.SOURCES[name]
+        else:
+            klass = find_plugin(os.path.dirname(__file__), name, loader)
+            self.SOURCES[name] = klass
 
         source = klass(*args, **kwargs)
 


### PR DESCRIPTION
With this PR finding the right class for the source when using `from_source()` is a little bit faster. It avoids running `os.walk()` to check the .py files in earthkit/data/sources whenever `from_source()`  is called.

The speedup is as follows:
- 10% on MacBook (ssd)
- 15% on ECMWF HPC (lustre) 

Please note that `from_source()` was already very fast, so the overall speedup for eathkit-data scripts is negligible.