### PR TITLE
Fix cds errors due to dict union operator

### DIFF
--- a/earthkit/data/sources/cds.py
+++ b/earthkit/data/sources/cds.py
@@ -170,7 +170,7 @@ class CdsRetriever(FileSource):
                 *[batched(ensure_iterable(request[k]), v) for k, v in split_on.items()]
             ):
                 subrequest = dict(zip(split_on, values))
-                requests.append(request | subrequest)
+                requests.append({**request, **subrequest})
         return requests
 
     def client(self):

--- a/tests/sources/test_cds.py
+++ b/tests/sources/test_cds.py
@@ -254,8 +254,8 @@ def test_cds_multiple_requests(
     s = from_source(
         "cds",
         "reanalysis-era5-single-levels",
-        base_request | {"variable": "2t", "split_on": split_on1},
-        base_request | {"variable": "msl", "split_on": split_on2},
+        {**base_request, **{"variable": "2t", "split_on": split_on1}},
+        {**base_request, **{"variable": "msl", "split_on": split_on2}},
     )
     assert len(s._indexes) == expected_file_num
     assert len(s) == 4


### PR DESCRIPTION
Some CDS retrievals fail with Python 3.8 due to the usage of the new dict union operator `|`, which is only available in 3.9.