### PR TITLE
Enable header only grib message cloning

### DIFF
--- a/earthkit/data/readers/grib/metadata.py
+++ b/earthkit/data/readers/grib/metadata.py
@@ -273,24 +273,20 @@ class GribMetadata(Metadata):
             )
             d.update(md)
 
-            # at the moment we cannot use headers_only clone when setting the
-            # geography
-            handle = self._handle.clone()
-        else:
-            handle = self._handle.clone(headers_only=True)
-            # whether headers_only=True works depends on the eccCodes version and the
-            # message properties. We check it by comparing the message lengths.
-            shrunk = handle.get_long("totalLength") < self._handle.get_long(
-                "totalLength"
-            )
+        handle = self._handle.clone(headers_only=True)
+        # whether headers_only=True works depends on the eccCodes version and the
+        # message properties. We check it by comparing the message lengths.
+        shrunk = handle.get_long("totalLength") < self._handle.get_long("totalLength")
 
-            # some keys, needed later, are not copied into the clone when
-            # headers_only=True. We store them as extra keys.
-            if shrunk:
-                extra = {"bitsPerValue": self._handle.get("bitsPerValue", default=0)}
+        # some keys, needed later, are not copied into the clone when
+        # headers_only=True. We store them as extra keys.
+        if shrunk:
+            extra = {"bitsPerValue": self._handle.get("bitsPerValue", default=0)}
 
         handle.set_multiple(d)
 
+        # we need to set the values to the new size otherwise the clone generated
+        # with headers_only=True will be inconsistent
         if new_value_size is not None and new_value_size > 0:
             import numpy as np
 

--- a/earthkit/data/utils/message.py
+++ b/earthkit/data/utils/message.py
@@ -50,7 +50,7 @@ class EccodesFeatures:
         LOG.debug(f"ecCodes versions: {self.versions}")
 
     def check_clone_kwargs(self, **kwargs):
-        if not (self._py_version >= (1, 7, 0) and self._version >= (2, 34, 0)):
+        if not (self._py_version >= (1, 7, 0) and self._version >= (2, 35, 0)):
             kwargs = dict(**kwargs)
             kwargs.pop("headers_only", None)
         return kwargs

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- eccodes=>2.34.1
+- eccodes=>2.35.0
 - python-eccodes>=1.7.0
 - pip
 - numpy

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- eccodes=>2.34.1
+- eccodes=>2.35.0
 - python-eccodes>=1.7.0
 - pip
 - numpy


### PR DESCRIPTION
Header only GRIB message cloning was fixed in ecCodes 2.35.0. This PR re-enables it for GRIB metadata().override(). At the same time the minimum ecCodes version was raised to 2.35.0.