### PR TITLE
Pass polytope from_source kwargs to polytope client

### DIFF
--- a/docs/release_notes/version_0.7_updates.rst
+++ b/docs/release_notes/version_0.7_updates.rst
@@ -21,7 +21,7 @@ New features
 - added support for Lambert Conformal projection when using :meth:`Field.projection() <data.core.fieldlist.Field.projection>`
 - changed the default of the ``bits_per_value`` option to None in :meth:`NumpyFieldList.save() <data.sources.numpy_list.NumpyFieldList.save>`. None means the original ``bits_per_value`` in the GRIB header is kept when the data is written to disk.
 - added the ``model`` option to the :ref:`data-sources-eod` source
-- added the ``prompt`` optional argument to certain retrievals to control whether the prompt is to use. When enabled (default), the prompt asks the user to provide credentials when none seems to be specified. See the :ref:`data-sources-cds`, :ref:`data-sources-mars`, :ref:`data-sources-wekeo`, :ref:`data-sources-wekeocds` sources for more information on how the prompt works.
+- added the ``prompt`` optional argument to certain retrievals to control whether the prompt is to be used. When enabled (default), the prompt asks the user to provide credentials when none seems to be specified. See the :ref:`data-sources-cds`, :ref:`data-sources-mars`, :ref:`data-sources-wekeo`, :ref:`data-sources-wekeocds` sources for more information on how the prompt works.
 - added the ``user_email`` and ``user_key`` options to the :ref:`data-sources-polytope` source. This source does not use the prompt any longer.
 - allowed using :func:`save` without specifying a file name. In this case an attempt is made to generate the filename automatically, when it fails an exception is thrown.
 - :func:`from_source` now fails when trying to load an empty file

--- a/earthkit/data/sources/polytope.py
+++ b/earthkit/data/sources/polytope.py
@@ -76,30 +76,10 @@ class Polytope(Source):
 
         self.stream = stream
 
-        # Polytope client configuration options
-        client_kwargs = {}
-        for k in [
-            "config_path",
-            "address",
-            "port",
-            "username",
-            "key_path",
-            "quiet",
-            "verbose",
-            "log_file",
-            "log_level",
-            "user_key",
-            "user_email",
-            "password",
-            "insecure",
-            "skip_tls",
-            "cli",
-        ]:
-            if k in kwargs:
-                client_kwargs[k] = kwargs.pop(k, None)
-
         self.request = dict(dataset=dataset, request=request)
-        self.client = polytope.api.Client(**client_kwargs)
+
+        # all the kwargs are passed to the client!
+        self.client = polytope.api.Client(**kwargs)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.request['dataset']}, {self.request['request']})"


### PR DESCRIPTION
With this PR all the `**kwargs` in `from_source("polytope", ...., **kwargs)` are passed to the polytope client.