### PR TITLE
Use warnings.warn for kwargs check in to_xarray

### DIFF
--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -134,12 +134,13 @@ class XarrayMixIn:
         xarray_open_dataset_kwargs.update(
             Kwargs(
                 user=user_xarray_open_dataset_kwargs,
-                default={},
+                default=default,
                 forced={
                     "errors": "raise",
                     "engine": "cfgrib",
                 },
                 logging_owner="xarray_open_dataset_kwargs",
+                warn_non_default=False,
             )
         )
 

--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -70,12 +70,19 @@ class XarrayMixIn:
             xarray_open_dataset_kwargs: dict, optional
                 Keyword arguments passed to ``xarray.open_dataset()``. Default value is::
 
-                    {"backend_kwargs": {"errors": "raise"},
+                    {"backend_kwargs": {"errors": "raise", "ignore_keys": []},
                     "squeeze": False, "cache": True, "chunks": None,
                     "errors": "raise", "engine": "cfgrib"}
 
-                Please note that the settings ``errors="raise"`` and ``engine="cfgrib"`` are always
-                enforced and cannot be changed.
+                Please note that:
+
+                - ``backend_kwargs`` is passed to :xref:`cfgrib`, with the exception
+                  of ``ignore_keys``
+                - ``ignore_keys``  is not supported by :xref:`cfgrib`, but implemented in
+                  earthkit-data. It specifies the metadata keys that should be ignored when reading
+                  the GRIB messages in the backend.
+                - settings ``errors="raise"`` and ``engine="cfgrib"`` are always enforced and cannot
+                  be changed.
 
         Returns
         -------
@@ -121,17 +128,18 @@ class XarrayMixIn:
                 logging_main_key=key,
             )
 
-        default = dict(squeeze=False)  # TODO:Documenet me
+        default = dict(squeeze=False)  # TODO:Document me
         default.update(self.xarray_open_dataset_kwargs())
 
         xarray_open_dataset_kwargs.update(
             Kwargs(
                 user=user_xarray_open_dataset_kwargs,
-                default=default,
+                default={},
                 forced={
                     "errors": "raise",
                     "engine": "cfgrib",
                 },
+                logging_owner="xarray_open_dataset_kwargs",
             )
         )
 

--- a/src/earthkit/data/utils/kwargs.py
+++ b/src/earthkit/data/utils/kwargs.py
@@ -34,6 +34,7 @@ class Kwargs(dict):
         forced=None,
         logging_owner="",
         logging_main_key="",
+        warn_non_default=True,
     ):
         if default is None:
             default = {}
@@ -53,13 +54,14 @@ class Kwargs(dict):
                 )
                 continue
 
-            if k in default and v != default[k]:
-                warnings.warn(
-                    (
-                        f"In {logging_owner} {logging_main_key}, overriding the default value "
-                        f"({k}={default[k]}) with {k}={v} is not recommended."
+            if warn_non_default:
+                if k in default and v != default[k]:
+                    warnings.warn(
+                        (
+                            f"In {logging_owner} {logging_main_key}, overriding the default value "
+                            f"({k}={default[k]}) with {k}={v} is not recommended."
+                        )
                     )
-                )
 
             kwargs[k] = v
 

--- a/src/earthkit/data/utils/kwargs.py
+++ b/src/earthkit/data/utils/kwargs.py
@@ -9,6 +9,7 @@
 
 import copy
 import logging
+import warnings
 
 LOG = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class Kwargs(dict):
 
         for k, v in user.items():
             if k in forced and v != forced[k]:
-                LOG.warning(
+                warnings.warn(
                     (
                         f"In {logging_owner} {logging_main_key},"
                         f"ignoring attempt to override {k}={forced[k]} with {k}={v}."
@@ -53,7 +54,7 @@ class Kwargs(dict):
                 continue
 
             if k in default and v != default[k]:
-                LOG.warning(
+                warnings.warn(
                     (
                         f"In {logging_owner} {logging_main_key}, overriding the default value "
                         f"({k}={default[k]}) with {k}={v} is not recommended."


### PR DESCRIPTION
Fixes #379 

- removed warnings when non-default kwargs used
- use warnings.warn() when forced kwargs specified with non-default values