### PR TITLE
Adds additional common netCDF coordinates

### DIFF
--- a/src/earthkit/data/readers/netcdf/dataset.py
+++ b/src/earthkit/data/readers/netcdf/dataset.py
@@ -15,8 +15,8 @@ LOG = logging.getLogger(__name__)
 
 
 GEOGRAPHIC_COORDS = {
-    "x": ["x", "projection_x_coordinate", "lon", "longitude"],
-    "y": ["y", "projection_y_coordinate", "lat", "latitude"],
+    "x": ["x", "X", "xc", "projection_x_coordinate", "lon", "longitude"],
+    "y": ["y", "Y", "yc", "projection_y_coordinate", "lat", "latitude"],
 }
 
 


### PR DESCRIPTION
Adds a few more common geographic coordinates found frequently in netCDF data - namely:
- `"X"` and `"Y"` (capital X and Y)
- `"xc"` and `"yc"`

These additional geographic coordinates make it easier to work with datasets which use these coordinate names. These additional coordinates have been selected based on their use within some CDS datasets.