### PR TITLE
Return empty fieldlist when expect=any used in mars and no data is available

### DIFF
--- a/src/earthkit/data/readers/__init__.py
+++ b/src/earthkit/data/readers/__init__.py
@@ -148,6 +148,16 @@ def _unknown(method_name, source, path_or_data, **kwargs):
     return unknowns[method_name](source, path_or_data, **kwargs)
 
 
+def _non_existing(source, path, **kwargs):
+    if hasattr(source, "empty_reader"):
+        return source.empty_reader(path, **kwargs)
+
+
+def _empty(source, path, **kwargs):
+    if hasattr(source, "empty_reader"):
+        return source.empty_reader(path, **kwargs)
+
+
 def reader(source, path, **kwargs):
     """Create the reader for a file/directory specified by path"""
     assert isinstance(path, str), source
@@ -169,9 +179,15 @@ def reader(source, path, **kwargs):
     LOG.debug("Reader for %s", path)
 
     if not os.path.exists(path):
+        r = _non_existing(source, path, **kwargs)
+        if r is not None:
+            return r
         raise FileExistsError(f"No such file exists: '{path}'")
 
     if os.path.getsize(path) == 0:
+        r = _empty(source, path, **kwargs)
+        if r is not None:
+            return r
         raise Exception(f"File is empty: '{path}'")
 
     n_bytes = SETTINGS.get("reader-type-check-bytes")

--- a/src/earthkit/data/sources/ecmwf_api.py
+++ b/src/earthkit/data/sources/ecmwf_api.py
@@ -57,6 +57,12 @@ class ECMWFApi(FileSource):
 
         requests = self.requests(**request)
 
+        self.expect_any = False
+        for k, v in requests[0].items():
+            if k.lower() == "expect" and isinstance(v, str) and v.lower() == "any":
+                self.expect_any = True
+                break
+
         self.service()  # Trigger password prompt before threading
 
         nthreads = min(self.settings("number-of-download-threads"), len(requests))
@@ -117,3 +123,9 @@ class ECMWFApi(FileSource):
             # odc_read_odb_kwargs=odc_read_odb_kwargs,
             **kwargs,
         )
+
+    def empty_reader(self, *args, **kwargs):
+        if self.expect_any:
+            from .empty import EmptySource
+
+            return EmptySource()

--- a/src/earthkit/data/sources/empty.py
+++ b/src/earthkit/data/sources/empty.py
@@ -19,5 +19,8 @@ class EmptySource(FieldList):
     def __len__(self):
         return 0
 
+    def mutate_source(self):
+        return self
+
 
 source = EmptySource

--- a/tests/sources/test_empty.py
+++ b/tests/sources/test_empty.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+from earthkit.data import from_source
+from earthkit.data.testing import earthkit_examples_file
+
+
+def test_empty_source():
+    ds = from_source("empty")
+    assert len(ds) == 0
+
+
+def test_empty_source_concat1():
+    ds = from_source("empty")
+    assert len(ds) == 0
+
+    ds1 = from_source("file", earthkit_examples_file("test.grib"))
+
+    ds2 = ds + ds1
+    assert len(ds2) == 2
+    meta = ds2.metadata("shortName")
+    assert meta == ["2t", "msl"]
+
+
+def test_empty_source_concat2():
+    ds = from_source("empty")
+    assert len(ds) == 0
+
+    ds1 = from_source("file", earthkit_examples_file("test.grib"))
+
+    ds = ds + ds1
+    assert len(ds) == 2
+    meta = ds.metadata("shortName")
+    assert meta == ["2t", "msl"]
+
+
+def test_empty_source_concat3():
+    ds = from_source("empty")
+    assert len(ds) == 0
+
+    ds1 = from_source("file", earthkit_examples_file("test.grib"))
+
+    ds += ds1
+    assert len(ds) == 2
+    meta = ds.metadata("shortName")
+    assert meta == ["2t", "msl"]

--- a/tests/sources/test_mars.py
+++ b/tests/sources/test_mars.py
@@ -48,6 +48,38 @@ def test_mars_grib_2():
     assert len(s) == 2
 
 
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
+def test_mars_grib_expect_any_1():
+    ds = from_source(
+        "mars",
+        expect="any",
+        param=["2t", "msl"],
+        levtype="sfc",
+        area=[50, -50, 20, 50],
+        grid=[2, 2],
+        date="1054-05-10",
+    )
+
+    assert len(ds) == 0
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
+def test_mars_grib_expect_any_2():
+    with pytest.raises(Exception):
+        from_source(
+            "mars",
+            param=["2t", "msl"],
+            levtype="sfc",
+            area=[50, -50, 20, 50],
+            grid=[2, 2],
+            date="1054-05-10",
+        )
+
+
 if __name__ == "__main__":
     from earthkit.data.testing import main
 


### PR DESCRIPTION
This PR fixes the issue when a MARS retrieval specified `expect=any` but an exception was raised when no data was available/retrieved. With this PR now an empty fieldlist (an EmptySource object) is returned in this case.  E.g.:

```python
# date is out of range
ds = from_source(
        "mars",
        expect="any",
        param=["2t", "msl"],
        levtype="sfc",
        area=[50, -50, 20, 50],
        grid=[2, 2],
        date="1054-05-10",
    )

assert len(ds) == 0
```