### PR TITLE
Do not normalise metadata key names for sel, isel and order_by calls

### DIFF
--- a/src/earthkit/data/core/index.py
+++ b/src/earthkit/data/core/index.py
@@ -192,9 +192,6 @@ class Index(Source):
     def __len__(self):
         self._not_implemented()
 
-    def _normalize_kwargs_names(self, **kwargs):
-        return kwargs
-
     def sel(self, *args, remapping=None, **kwargs):
         """Uses metadata values to select a subset of the elements from a fieldlist-like object.
 
@@ -287,7 +284,6 @@ class Index(Source):
         GribField(t,850,20180801,1200,0,0)
         """
         kwargs = normalize_selection(*args, **kwargs)
-        kwargs = self._normalize_kwargs_names(**kwargs)
         if not kwargs:
             return self
 
@@ -382,7 +378,6 @@ class Index(Source):
 
         """
         kwargs = normalize_selection(*args, **kwargs)
-        kwargs = self._normalize_kwargs_names(**kwargs)
         if not kwargs:
             return self
 
@@ -487,7 +482,6 @@ class Index(Source):
         GribField(u,850,20180801,1200,0,0)
         """
         kwargs = normalize_order_by(*args, **kwargs)
-        kwargs = self._normalize_kwargs_names(**kwargs)
 
         remapping = build_remapping(remapping, patches)
 

--- a/src/earthkit/data/readers/grib/index/sql.py
+++ b/src/earthkit/data/readers/grib/index/sql.py
@@ -68,7 +68,6 @@ class FieldListInFilesWithSqlIndex(FieldListInFilesWithDBIndex):
         # print("Not using remapping here")
 
         coords = {k: None for k in coords}
-        coords = self._normalize_kwargs_names(**coords)
         coords = list(coords.keys())
         # print("coords:", coords)
         values = self.db.unique_values(*coords, remapping=remapping).values()
@@ -84,7 +83,6 @@ class FieldListInFilesWithSqlIndex(FieldListInFilesWithDBIndex):
 
     def sel(self, *args, remapping=None, **kwargs):
         kwargs = normalize_selection(*args, **kwargs)
-        kwargs = self._normalize_kwargs_names(**kwargs)
         if DATETIME in kwargs and kwargs[DATETIME] is not None:
             kwargs = _normalize_grib_kwargs_values(**kwargs)
 
@@ -94,7 +92,6 @@ class FieldListInFilesWithSqlIndex(FieldListInFilesWithDBIndex):
 
     def order_by(self, *args, remapping=None, **kwargs):
         kwargs = normalize_order_by(*args, **kwargs)
-        kwargs = self._normalize_kwargs_names(**kwargs)
 
         out = self
 


### PR DESCRIPTION
This PR removes the normalisation of metadata key names passed to:

- sel()
- isel()
- order_by()
- unique_values()

Previously the following normalisation was applied for GRIB metadata keys:

```python
@alias_argument("levelist", ["level", "levellist"])
@alias_argument("levtype", ["leveltype"])
@alias_argument("param", ["variable", "parameter"])
@alias_argument("number", ["realization", "realisation"])
@alias_argument("class", "klass")
def _normalize_kwargs_names(self, **kwargs):
    return kwargs
```