### PR TITLE
Upgrade minimum version of cdsapi

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,8 +19,7 @@ dependencies:
 - entrypoints
 - jupyterlab
 - ecmwf-api-client>=1.6.1
-- cdsapi>=0.7.0
-- cads-api-client>=1.2.0
+- cdsapi>=0.7.1
 - hda
 - pip:
   - multiurl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,8 @@ dependencies = [
   "xarray>=0.19",
 ]
 optional-dependencies.all = [
-  "cads-api-client>=1.2",
   "cartopy",
-  "cdsapi>=0.7",
+  "cdsapi>=0.7.1",
   "eccovjson>=0.0.5",
   "ecmwf-api-client>=1.6.1",
   "ecmwf-opendata>=0.3.3",
@@ -63,17 +62,15 @@ optional-dependencies.all = [
   "pyodc",
 ]
 optional-dependencies.cds = [
-  "cads-api-client>=1.2",
-  "cdsapi>=0.7",
+  "cdsapi>=0.7.1",
 ]
 optional-dependencies.ci = [
   "array-api-compat",
   "torch",
 ]
 optional-dependencies.dev = [
-  "cads-api-client>=1.2",
   "cartopy",
-  "cdsapi>=0.7",
+  "cdsapi>=0.7.1",
   "earthkit-data-demo-source",
   "eccovjson>=0.0.5",
   "ecmwf-api-client>=1.6.1",

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -20,8 +20,7 @@ dependencies:
 - entrypoints
 - jupyterlab
 - ecmwf-api-client>=1.6.1
-- cdsapi>=0.7.0
-- cads-api-client>=1.2.0
+- cdsapi>=0.7.1
 - hda
 - jsonschema
 - pip:


### PR DESCRIPTION
The minimum version of CDSAPI has been upgraded to 0.7.1, which includes a bugfix to ensure compatibility between the new CDS beta and earthkit-data. The optional cads-api-client dependencies have also been removed, as the minimum version of cads-api-client has been upgraded within cdsapi.