### PR TITLE
support lambert_azimuthal_equal_area metadata

### DIFF
--- a/src/earthkit/data/readers/grib/metadata.py
+++ b/src/earthkit/data/readers/grib/metadata.py
@@ -156,7 +156,7 @@ class GribFieldGeography(Geography):
             assert x == y, (x, y)
             return x
 
-        if grid_type == "lambert":
+        if grid_type in ["lambert", "lambert_azimuthal_equal_area"]:
             x = self.metadata.get("DxInMetres")
             y = self.metadata.get("DyInMetres")
             assert x == y, (x, y)


### PR DESCRIPTION
This allows getting the "resolution" metadata for grib with "lambert_azimuthal_equal_area" encoding.