### PR TITLE
Implement repr to ArrayField

### DIFF
--- a/src/earthkit/data/sources/array_list.py
+++ b/src/earthkit/data/sources/array_list.py
@@ -46,7 +46,14 @@ class ArrayField(Field):
             return self.array_backend.array_ns.astype(self._array, dtype, copy=False)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}()"
+        return self.__class__.__name__ + "(%s,%s,%s,%s,%s,%s)" % (
+            self._metadata.get("shortName", None),
+            self._metadata.get("levelist", None),
+            self._metadata.get("date", None),
+            self._metadata.get("time", None),
+            self._metadata.get("step", None),
+            self._metadata.get("number", None),
+        )
 
     def write(self, f, **kwargs):
         r"""Write the field to a file object.

--- a/tests/array_fieldlist/test_numpy_fs_metadata.py
+++ b/tests/array_fieldlist/test_numpy_fs_metadata.py
@@ -23,6 +23,13 @@ from array_fl_fixtures import load_array_fl_file  # noqa: E402
 # See grib/test_grib_metadata.py
 
 
+def test_array_fl_field_repr():
+    ds, _ = load_array_fl(1)
+
+    t = repr(ds[0])
+    assert t == "ArrayField(2t,None,20200513,1200,0,0)"
+
+
 def test_array_fl_values_metadata_basic():
     ds, _ = load_array_fl(1)
 


### PR DESCRIPTION
This PR implements the repr for an ArrayField.  E.g. if `f` contains surface data:

```python
print(f)
>>> ArrayField(2t,None,20200513,1200,0,0)
```

Note: this repr is GRIB specific.