### PR TITLE
Fix cube detailed error report

### DIFF
--- a/src/earthkit/data/indexing/cube.py
+++ b/src/earthkit/data/indexing/cube.py
@@ -87,7 +87,7 @@ class FieldCube:
         # print(self.source[3])
 
         # Get a mapping of user names to unique values
-        # With possible reduce dimentionality if the user use 'level+param'
+        # With possible reduce dimensionality if the user use 'level+param'
         self.user_coords = self.source.unique_values(*names, remapping=remapping, patches=patches)
 
         self.user_shape = tuple(len(v) for k, v in self.user_coords.items())
@@ -98,7 +98,7 @@ class FieldCube:
                 details.append(f"{key=} ({len(v)}) {v}")
             assert not isinstance(self.source, str), f"Not expecting a str here ({self.source})"
             for i, f in enumerate(self.source):
-                details.append(f"{i}={f} {f.metadata('number')}")
+                details.append(f"{i}={f} {f.metadata('number', default=None)}")
                 if i > 30:
                     details.append("...")
                     break

--- a/tests/grib/test_grib_cube.py
+++ b/tests/grib/test_grib_cube.py
@@ -10,9 +10,11 @@
 #
 
 import numpy as np
+import pytest
 
 from earthkit.data import from_source
 from earthkit.data.testing import earthkit_examples_file
+from earthkit.data.testing import earthkit_test_data_file
 
 
 def test_grib_cube():
@@ -122,6 +124,15 @@ def test_grib_cubelet():
     for i, cb in enumerate(c.iterate_cubelets(reading_chunks)):
         assert cb.to_numpy().shape == (7, 12)
         assert np.isclose(cb.to_numpy()[0, 0], ref[i])
+
+
+def test_grib_cube_non_hypercube():
+    ds = from_source("file", earthkit_examples_file("tuv_pl.grib"))
+    ds += from_source("file", earthkit_test_data_file("ml_data.grib"))[:2]
+    assert len(ds) == 18 + 2
+
+    with pytest.raises(ValueError):
+        ds.cube("param", "level")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the issue when the missing "number" metadata key caused a crash when generating a detailed report for a FieldCube.