### PR TITLE
Allow logging control for mars source

### DIFF
--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -670,7 +670,7 @@ mars
 
   To figure out which data you need, or discover relevant data available in MARS, see the publicly accessible `MARS catalog`_ (or this `access restricted catalog <https://apps.ecmwf.int/mars-catalogue/>`_).
 
-  The MARS access is direct when the MARS client is installed (as at ECMWF), otherwise it will use the `web API`_. In order to use the `web API`_ you will need to register and retrieve an access token. For a more extensive documentation about MARS, please refer to the `MARS user documentation`_.
+  The MARS access is direct when the MARS client is installed (as at ECMWF) and the ``use-standalone-mars-client-when-available`` :ref:`settings <settings>` is True (this is the default), otherwise it will use the `web API`_. In order to use the `web API`_ you will need to register and retrieve an access token. For a more extensive documentation about MARS, please refer to the `MARS user documentation`_.
 
   :param tuple *args: positional arguments specifying the request as a dict
   :param bool prompt: when True it can offer a prompt to specify the credentials for `web API`_ and write them into the default RC file ``~/.ecmwfapirc``. The prompt only appears when:
@@ -696,7 +696,6 @@ mars
 
 
           request = {...}
-
           ds = earthkit.data.from_source("mars", request, log=my_logging_function)
 
     - direct MARS access:

--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -661,7 +661,7 @@ fdb
 mars
 --------------
 
-.. py:function:: from_source("mars", *args, prompt=True, **kwargs)
+.. py:function:: from_source("mars", *args, prompt=True, log="default", **kwargs)
   :noindex:
 
   The ``mars`` source will retrieve data from the ECMWF MARS (Meteorological Archival and Retrieval System) archive. In addition
@@ -678,6 +678,34 @@ mars
     - no `web API`_ RC file exists at the default location ``~/.ecmwfapirc``
     - no `web API`_ RC file exists at the location specified via the ``ECMWF_API_RC_FILE`` environment variable
     - no credentials specified via the ``ECMWF_API_URL`` and ``ECMWF_API_KEY``  environment variables
+  :param log: control the logging of the retrieval. The behaviour depends on the underlying MARS client used:
+
+    - `web API`_ based access:
+
+      - "default": the built-in logging of `web API`_ is used
+      - None: turn off logging
+      - callable:  the log is written to the specified callable. The callable should accept a single argument, a string with the log message.
+
+      .. code-block:: python
+
+          import earthkit.data
+
+
+          def my_logging_function(msg):
+              print("message=", msg)
+
+
+          request = {...}
+
+          ds = earthkit.data.from_source("mars", request, log=my_logging_function)
+
+    - direct MARS access:
+
+      - "default": log is written to the standard output
+      - None: turn off logging for standard output. Standard error is still logged.
+      - dict specifying the "stdout" or/and the "stderr" kwargs for Pythons's ``subrocess.run()`` method
+
+  :type log: str, None, callable, dict
   :param dict **kwargs: other keyword arguments specifying the request
 
   The following example retrieves analysis GRIB data for a subarea for 2 surface parameters:

--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -682,9 +682,9 @@ mars
 
     - `web API`_ based access:
 
-      - "default": the built-in logging of `web API`_ is used
+      - "default": the built-in logging of `web API`_ is used (the log is written to stdout)
       - None: turn off logging
-      - callable:  the log is written to the specified callable. The callable should accept a single argument, a string with the log message.
+      - callable: the log is written to the specified callable. The callable should accept a single argument, a string with the log message.
 
       .. code-block:: python
 
@@ -700,8 +700,8 @@ mars
 
     - direct MARS access:
 
-      - "default": log is written to the standard output
-      - None: turn off logging for standard output. Standard error is still logged.
+      - "default": log is written to stdout
+      - None: turn off logging
       - dict specifying the "stdout" or/and the "stderr" kwargs for Pythons's ``subrocess.run()`` method
 
   :type log: str, None, callable, dict

--- a/src/earthkit/data/sources/ecmwf_api.py
+++ b/src/earthkit/data/sources/ecmwf_api.py
@@ -45,10 +45,11 @@ class MARSAPIKeyPrompt(APIKeyPrompt):
 
 
 class ECMWFApi(FileSource):
-    def __init__(self, *args, prompt=True, **kwargs):
+    def __init__(self, *args, prompt=True, log="default", **kwargs):
         super().__init__()
 
         self.prompt = prompt
+        self.log = log
 
         request = {}
         for a in args:

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -32,7 +32,10 @@ def _no_log(msg):
 class StandaloneMarsClient:
     EXE = "/usr/local/bin/mars"
 
-    def execute(self, request, target):
+    def __init__(self, log="default"):
+        self.log = log
+
+    def execute(self, request, target, log=None):
         req = ["retrieve,"]
 
         for k, v in request.items():
@@ -48,7 +51,7 @@ class StandaloneMarsClient:
             LOG.debug(f"Sending Mars request: '{req_str}'")
 
             log = {}
-            if log is None:
+            if self.log is None:
                 log = {"stdout": subprocess.DEVNULL}
             elif self.log and isinstance(self.log, dict):
                 log = self.log
@@ -68,7 +71,7 @@ class MarsRetriever(ECMWFApi):
     def service(self):
         if SETTINGS.get("use-standalone-mars-client-when-available"):
             if os.path.exists(StandaloneMarsClient.EXE):
-                return StandaloneMarsClient()
+                return StandaloneMarsClient(self.log)
 
         if self.prompt:
             prompt = MARSAPIKeyPrompt()

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -28,6 +28,7 @@ LOG = logging.getLogger(__name__)
 def _no_log(msg):
     pass
 
+
 class StandaloneMarsClient:
     EXE = "/usr/local/bin/mars"
 
@@ -98,7 +99,7 @@ class MarsRetriever(ECMWFApi):
             kwargs = {"log": self.log}
         elif self.log != "default":
             raise ValueError(f"Unsupported log type={type(self.log)}")
-        
+
         return ecmwfapi.ECMWFService("mars", **kwargs)
 
 

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -28,7 +28,6 @@ LOG = logging.getLogger(__name__)
 def _no_log(msg):
     pass
 
-
 class StandaloneMarsClient:
     EXE = "/usr/local/bin/mars"
 
@@ -52,9 +51,11 @@ class StandaloneMarsClient:
 
             log = {}
             if self.log is None:
-                log = {"stdout": subprocess.DEVNULL}
+                log = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
             elif self.log and isinstance(self.log, dict):
                 log = self.log
+            elif self.log != "default":
+                raise ValueError(f"Unsupported log type={type(self.log)}")
 
             subprocess.run(
                 [self.EXE, filename], env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"), check=True, **log
@@ -93,8 +94,11 @@ class MarsRetriever(ECMWFApi):
         kwargs = {}
         if self.log is None:
             kwargs = {"log": _no_log}
-        elif self.log != "default":
+        elif callable(self.log):
             kwargs = {"log": self.log}
+        elif self.log != "default":
+            raise ValueError(f"Unsupported log type={type(self.log)}")
+        
         return ecmwfapi.ECMWFService("mars", **kwargs)
 
 

--- a/src/earthkit/data/testing.py
+++ b/src/earthkit/data/testing.py
@@ -95,6 +95,10 @@ NO_MARS_DIRECT = not StandaloneMarsClient.enabled()
 NO_MARS_API = not (NO_MARS_DIRECT and os.path.exists(os.path.expanduser("~/.ecmwfapirc")))
 NO_MARS = NO_MARS_API and NO_MARS_DIRECT
 
+HAS_MARS = not NO_MARS
+HAS_MARS_API = not NO_MARS_API
+HAS_MARS_DIRECT = not NO_MARS_DIRECT
+
 NO_CDS = not os.path.exists(os.path.expanduser("~/.cdsapirc"))
 NO_HDA = not os.path.exists(os.path.expanduser("~/.hdarc"))
 IN_GITHUB = os.environ.get("GITHUB_WORKFLOW") is not None

--- a/src/earthkit/data/testing.py
+++ b/src/earthkit/data/testing.py
@@ -18,6 +18,7 @@ from earthkit.data import from_object
 from earthkit.data import from_source
 from earthkit.data.readers.text import TextReader
 from earthkit.data.sources.empty import EmptySource
+from earthkit.data.sources.mars import StandaloneMarsClient
 
 LOG = logging.getLogger(__name__)
 
@@ -90,7 +91,10 @@ def modules_installed(*modules):
     return True
 
 
-NO_MARS = not os.path.exists(os.path.expanduser("~/.ecmwfapirc"))
+NO_MARS_DIRECT = not StandaloneMarsClient.enabled()
+NO_MARS_API = not (NO_MARS_DIRECT and os.path.exists(os.path.expanduser("~/.ecmwfapirc")))
+NO_MARS = NO_MARS_API and NO_MARS_DIRECT
+
 NO_CDS = not os.path.exists(os.path.expanduser("~/.cdsapirc"))
 NO_HDA = not os.path.exists(os.path.expanduser("~/.hdarc"))
 IN_GITHUB = os.environ.get("GITHUB_WORKFLOW") is not None

--- a/src/earthkit/data/testing.py
+++ b/src/earthkit/data/testing.py
@@ -95,10 +95,6 @@ NO_MARS_DIRECT = not StandaloneMarsClient.enabled()
 NO_MARS_API = not (NO_MARS_DIRECT and os.path.exists(os.path.expanduser("~/.ecmwfapirc")))
 NO_MARS = NO_MARS_API and NO_MARS_DIRECT
 
-HAS_MARS = not NO_MARS
-HAS_MARS_API = not NO_MARS_API
-HAS_MARS_DIRECT = not NO_MARS_DIRECT
-
 NO_CDS = not os.path.exists(os.path.expanduser("~/.cdsapirc"))
 NO_HDA = not os.path.exists(os.path.expanduser("~/.hdarc"))
 IN_GITHUB = os.environ.get("GITHUB_WORKFLOW") is not None

--- a/tests/sources/test_mars.py
+++ b/tests/sources/test_mars.py
@@ -13,6 +13,7 @@ import pytest
 
 from earthkit.data import from_source
 from earthkit.data.testing import NO_MARS
+from earthkit.data.testing import NO_MARS_API
 
 
 @pytest.mark.long_test
@@ -78,6 +79,63 @@ def test_mars_grib_expect_any_2():
             grid=[2, 2],
             date="1054-05-10",
         )
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
+def test_mars_grib_log_1():
+    s = from_source(
+        "mars",
+        prompt=False,
+        log="default",
+        param=["2t", "msl"],
+        levtype="sfc",
+        area=[50, -50, 20, 50],
+        grid=[2, 2],
+        date="2023-05-10",
+    )
+    assert len(s) == 2
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
+def test_mars_grib_log_2():
+    s = from_source(
+        "mars",
+        prompt=False,
+        log=None,
+        param=["2t", "msl"],
+        levtype="sfc",
+        area=[50, -50, 20, 50],
+        grid=[2, 2],
+        date="2023-05-10",
+    )
+    assert len(s) == 2
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS_API, reason="No access to MARS")
+def test_mars_grib_log_3():
+    res = 0
+
+    def _my_log(msg):
+        nonlocal res
+        res = 1
+
+    s = from_source(
+        "mars",
+        prompt=False,
+        log=_my_log,
+        param=["2t", "msl"],
+        levtype="sfc",
+        area=[50, -50, 20, 50],
+        grid=[2, 2],
+        date="2023-05-10",
+    )
+    assert len(s) == 2
 
 
 if __name__ == "__main__":

--- a/tests/sources/test_mars.py
+++ b/tests/sources/test_mars.py
@@ -12,8 +12,10 @@
 import pytest
 
 from earthkit.data import from_source
+from earthkit.data.core.temporary import temp_file
 from earthkit.data.testing import NO_MARS
 from earthkit.data.testing import NO_MARS_API
+from earthkit.data.testing import NO_MARS_DIRECT
 
 
 @pytest.mark.long_test
@@ -136,6 +138,31 @@ def test_mars_grib_log_3():
         date="2023-05-10",
     )
     assert len(s) == 2
+
+
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_MARS or (NO_MARS_DIRECT and not NO_MARS_API), reason="No access to MARS")
+def test_mars_grib_log_4():
+    with temp_file as tmp:
+        with open(tmp, "w") as f:
+            s = from_source(
+                "mars",
+                prompt=False,
+                log={"stdout": f},
+                param=["2t", "msl"],
+                levtype="sfc",
+                area=[50, -50, 20, 50],
+                grid=[2, 2],
+                date="2023-05-10",
+            )
+            assert len(s) == 2
+
+        t = ""
+        with open(tmp) as f:
+            t = f.read()
+
+        assert t
 
 
 if __name__ == "__main__":

--- a/tests/sources/test_mars.py
+++ b/tests/sources/test_mars.py
@@ -144,7 +144,7 @@ def test_mars_grib_log_3():
 @pytest.mark.download
 @pytest.mark.skipif(NO_MARS or (NO_MARS_DIRECT and not NO_MARS_API), reason="No access to MARS")
 def test_mars_grib_log_4():
-    with temp_file as tmp:
+    with temp_file() as tmp:
         with open(tmp, "w") as f:
             s = from_source(
                 "mars",


### PR DESCRIPTION
Fixes #454 

This PR adds the `log` option to `from_source("mars",...)` to enable logging control of the retrievals. Because the retrieval is based on either the command line (direct) MARS client or the Python `ecmwf_api` client, `log` offers different options for these different clients.

![image](https://github.com/user-attachments/assets/ff8db425-8314-447a-942c-ba012cf3ab48)

<img width="584" alt="image" src="https://github.com/user-attachments/assets/793feb0d-da37-48c2-ae57-405153324d5a">
