### PR TITLE
Add serialisation to grib fieldlists

### DIFF
--- a/src/earthkit/data/readers/grib/index/__init__.py
+++ b/src/earthkit/data/readers/grib/index/__init__.py
@@ -210,11 +210,34 @@ class GribMaskFieldList(GribFieldList, MaskIndex):
         MaskIndex.__init__(self, *args, **kwargs)
         FieldList._init_from_mask(self, self)
 
+    def __getstate__(self):
+        r = {}
+        r["mask_index"] = self._index
+        r["mask_indices"] = self._indices
+        return r
+
+    def __setstate__(self, state):
+        _index = state["mask_index"]
+        _indices = state["mask_indices"]
+        self.__init__(_index, _indices)
+
 
 class GribMultiFieldList(GribFieldList, MultiIndex):
     def __init__(self, *args, **kwargs):
         MultiIndex.__init__(self, *args, **kwargs)
         FieldList._init_from_multi(self, self)
+
+    def __getstate__(self):
+        r = {}
+        r["multi_indexes"] = self._indexes
+        r["kwargs"] = self._kwargs
+        return r
+
+    def __setstate__(self, state):
+        self.__init__(
+            state["multi_indexes"],
+            **state["kwargs"],
+        )
 
 
 class GribFieldManager:

--- a/src/earthkit/data/sources/stream.py
+++ b/src/earthkit/data/sources/stream.py
@@ -205,6 +205,9 @@ class StreamFieldList(FieldList, Source):
     def group_by(self, *keys, **kwargs):
         return self._source.group_by(*keys)
 
+    def __getstate__(self):
+        raise NotImplementedError("StreamFieldList cannot be pickled")
+
 
 class Stream:
     def __init__(self, stream=None, maker=None, **kwargs):

--- a/tests/grib/test_grib_cache.py
+++ b/tests/grib/test_grib_cache.py
@@ -9,6 +9,8 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pickle
+
 import pytest
 
 from earthkit.data import from_source
@@ -53,7 +55,8 @@ def _check_diag(diag, ref):
 
 
 @pytest.mark.parametrize("handle_cache_size", [1, 5])
-def test_grib_cache_basic_patched(handle_cache_size, patch_metadata_cache):
+@pytest.mark.parametrize("serialise", [True, False])
+def test_grib_cache_basic_patched(handle_cache_size, serialise, patch_metadata_cache):
 
     with settings.temporary(
         {
@@ -64,6 +67,10 @@ def test_grib_cache_basic_patched(handle_cache_size, patch_metadata_cache):
         }
     ):
         ds = from_source("file", earthkit_examples_file("tuv_pl.grib"))
+        if serialise:
+            pickled_f = pickle.dumps(ds)
+            ds = pickle.loads(pickled_f)
+
         assert len(ds) == 18
 
         # unique values

--- a/tests/grib/test_grib_serialise.py
+++ b/tests/grib/test_grib_serialise.py
@@ -18,6 +18,7 @@ import pytest
 
 from earthkit.data import from_source
 from earthkit.data.core.temporary import temp_file
+from earthkit.data.testing import earthkit_examples_file
 
 here = os.path.dirname(__file__)
 sys.path.insert(0, here)
@@ -70,7 +71,7 @@ def test_grib_serialise_array_fieldlist(fl_type, array_backend):
 
     keys = ["param", "date", "time", "step", "level", "gridType", "type"]
     for k in keys:
-        ds.metadata(k) == ds.metadata(k)
+        ds2.metadata(k) == ds.metadata(k)
 
     r = ds2.sel(param="2t")
     assert len(r) == 1
@@ -85,3 +86,81 @@ def test_grib_serialise_array_fieldlist(fl_type, array_backend):
         assert len(ds2) == len(r_tmp)
         v_tmp = r_tmp[0].to_numpy()
         assert np.allclose(v1 + 1, v_tmp)
+
+
+@pytest.mark.parametrize("fl_type", ["file"])
+@pytest.mark.parametrize("array_backend", ["numpy"])
+def test_grib_serialise_file_fieldlist_core(fl_type, array_backend):
+    ds = load_grib_data("test.grib", fl_type, array_backend)
+
+    pickled_f = pickle.dumps(ds)
+    ds2 = pickle.loads(pickled_f)
+
+    assert len(ds) == len(ds2)
+    assert np.allclose(ds.values, ds2.values)
+
+    keys = ["param", "date", "time", "step", "level", "gridType", "type"]
+    for k in keys:
+        ds2.metadata(k) == ds.metadata(k)
+
+    r = ds2.sel(param="2t")
+    assert len(r) == 1
+
+
+@pytest.mark.parametrize("fl_type", ["file"])
+@pytest.mark.parametrize("array_backend", ["numpy"])
+def test_grib_serialise_file_fieldlist_sel(fl_type, array_backend):
+    ds0 = load_grib_data("test6.grib", fl_type, array_backend)
+    ds = ds0.sel(param="t")
+    assert len(ds) == 2
+
+    pickled_f = pickle.dumps(ds)
+    ds2 = pickle.loads(pickled_f)
+
+    assert len(ds2) == 2
+    assert np.allclose(ds.values, ds2.values)
+
+    keys = ["param", "date", "time", "step", "level", "gridType", "type"]
+    for k in keys:
+        ds2.metadata(k) == ds.metadata(k)
+
+    r = ds2.sel(level=850)
+    assert len(r) == 1
+
+
+@pytest.mark.parametrize("fl_type", ["file"])
+@pytest.mark.parametrize("array_backend", ["numpy"])
+def test_grib_serialise_file_fieldlist_concat(fl_type, array_backend):
+    ds = load_grib_data("test.grib", fl_type, array_backend) + load_grib_data(
+        "test6.grib", fl_type, array_backend
+    )
+    assert len(ds) == 8
+
+    pickled_f = pickle.dumps(ds)
+    ds2 = pickle.loads(pickled_f)
+
+    assert len(ds2) == 8
+    assert np.allclose(ds[:2].values, ds2[:2].values)
+    assert np.allclose(ds[2:].values, ds2[2:].values)
+
+    keys = ["param", "date", "time", "step", "level", "gridType", "type"]
+    for k in keys:
+        ds2.metadata(k) == ds.metadata(k)
+
+
+def test_grib_serialise_stream_1():
+    with open(earthkit_examples_file("test.grib"), "rb") as f:
+        ds = from_source("stream", f)
+        with pytest.raises(NotImplementedError):
+            pickle.dumps(ds)
+
+
+def test_grib_serialise_stream_2():
+    with open(earthkit_examples_file("test.grib"), "rb") as f:
+        ds = from_source("stream", f, read_all=True)
+        pickled_f = pickle.dumps(ds)
+
+    ds2 = pickle.loads(pickled_f)
+
+    assert len(ds2) == 2
+    assert ds.metadata("shortName") == ["2t", "msl"]

--- a/tests/grib/test_grib_serialise.py
+++ b/tests/grib/test_grib_serialise.py
@@ -164,3 +164,16 @@ def test_grib_serialise_stream_2():
 
     assert len(ds2) == 2
     assert ds.metadata("shortName") == ["2t", "msl"]
+
+
+def test_grib_serialise_file_parts():
+    parts = (240, 150)
+
+    ds = from_source("file", earthkit_examples_file("test6.grib"), parts=parts)
+    assert len(ds) == 1
+
+    pickled_f = pickle.dumps(ds)
+    ds2 = pickle.loads(pickled_f)
+
+    assert len(ds2) == 1
+    assert ds2[0].metadata(["param", "level"]) == ["u", 1000]


### PR DESCRIPTION
Relates to #453
This PR adds serialisation to the following objects:

    GRIBReader
    GribMaskFieldList
    GribMultiFieldList
    GribFieldListInMemory
  