### PR TITLE
Fix unknown param in grib namespaces

### DIFF
--- a/docs/release_notes/version_0.10_updates.rst
+++ b/docs/release_notes/version_0.10_updates.rst
@@ -1,6 +1,16 @@
 Version 0.10 Updates
 /////////////////////////
 
+Version 0.10.7
+===============
+
+Fixes
+++++++
+
+- When "param" or "shortName" in a namespace is "~" in the GRIB header :func:`metadata` now returns the value of "paramId" as a str for both these keys in the relevant namespaces. Previously "~" was returned.
+
+
+Version 0.9.0
 
 Version 0.10.4
 ===============

--- a/src/earthkit/data/readers/grib/metadata.py
+++ b/src/earthkit/data/readers/grib/metadata.py
@@ -415,7 +415,14 @@ class GribMetadata(Metadata):
 
         if namespace == "default" or namespace == "":
             namespace = None
-        return self._handle.as_namespace(namespace)
+        r = self._handle.as_namespace(namespace)
+
+        # special case when  "param" is "~".
+        if r is not None:
+            for k in ("shortName", "param"):
+                if k in r and r[k] == "~":
+                    r[k] = self.get(k)
+        return r
 
     @property
     def geography(self):

--- a/tests/grib/test_grib_metadata.py
+++ b/tests/grib/test_grib_metadata.py
@@ -558,6 +558,9 @@ def test_grib_tilde_shortname(fl_type, array_backend):
     assert f[0].metadata("paramId", astype=int) == 106
     assert f[0].metadata("param") == "106"
 
+    assert f[0].metadata(namespace="mars")["param"] == "106"
+    assert f[0].metadata(namespace="parameter")["shortName"] == "106"
+
 
 if __name__ == "__main__":
     from earthkit.data.testing import main


### PR DESCRIPTION
With this PR when "param" or "shortName" in a namespace is "\~" in the GRIB header, `metadata()` returns the value of "paramId" as a str for both these keys in the relevant namespaces. Previously "~" was returned.