### PR TITLE
Fix: Use `FileNotFoundError` when no file found rather than FileExistsError

### DIFF
--- a/src/earthkit/data/readers/__init__.py
+++ b/src/earthkit/data/readers/__init__.py
@@ -182,7 +182,7 @@ def reader(source, path, **kwargs):
         r = _non_existing(source, path, **kwargs)
         if r is not None:
             return r
-        raise FileExistsError(f"No such file exists: '{path}'")
+        raise FileNotFoundError(f"No such file exists: '{path}'")
 
     if os.path.getsize(path) == 0:
         r = _empty(source, path, **kwargs)

--- a/tests/readers/test_empty_file.py
+++ b/tests/readers/test_empty_file.py
@@ -21,7 +21,7 @@ def test_empty_file_reader():
 
 
 def test_nonexisting_file_reader():
-    with pytest.raises(FileExistsError):
+    with pytest.raises(FileNotFoundError):
         earthkit.data.from_source("file", "__nonexistingfile__")
 
 


### PR DESCRIPTION
When no file found to read from, a `FileExistsError` was being thrown,
Would `FileNotFoundError` be more apt?