### PR TITLE
Feature/write xarray remmapping to grib

### DIFF
--- a/docs/examples/xarray_engine_overview.ipynb
+++ b/docs/examples/xarray_engine_overview.ipynb
@@ -571,7 +571,7 @@
     "tags": []
    },
    "source": [
-    "### Writing back to a GRIB"
+    "### Writing back to GRIB"
    ]
   },
   {

--- a/docs/guide/xarray/overview.rst
+++ b/docs/guide/xarray/overview.rst
@@ -41,7 +41,7 @@ We can convert :ref:`grib` data into an Xarray dataset by using :py:meth:`~data.
 Using open_dataset()
 ++++++++++++++++++++
 
-We can also use the Xarray engine to read GRIB data directly with :py:func:`xarray.open_dataset` function. Naturally, this feature requires earthkit-data to be installed.
+We can also use the Xarray engine to read GRIB data directly with the :py:func:`xarray.open_dataset` function. Naturally, this feature requires earthkit-data to be installed.
 
 .. code-block:: python
 

--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -734,11 +734,11 @@ class Field(Base):
             self._metadata.get("number", None),
         )
 
-    def _attributes(self, names, remapping=None, default=None):
+    def _attributes(self, names, remapping=None, joiner=None, default=None):
         result = {}
         metadata = self._metadata.get
         if remapping is not None:
-            metadata = remapping(metadata)
+            metadata = remapping(metadata, joiner=joiner)
 
         for name in names:
             result[name] = metadata(name, default=default)

--- a/src/earthkit/data/utils/xarray/builder.py
+++ b/src/earthkit/data/utils/xarray/builder.py
@@ -20,18 +20,19 @@ LOG = logging.getLogger(__name__)
 
 
 class VariableBuilder:
-    def __init__(self, var_dims, data, local_attr_keys, tensor):
+    def __init__(self, var_dims, data, local_attr_keys, tensor, remapping):
         self.var_dims = var_dims
         self.data = data
         self._attrs = {}
         self.local_keys = ensure_iterable(local_attr_keys)
         self.tensor = tensor
+        self.remapping = remapping
 
     def build(self):
-        self._attrs["_earthkit"] = (
-            "message",
-            self.tensor.source[0].metadata().override()._handle.get_buffer(),
-        )
+        attrs = {
+            "message": self.tensor.source[0].metadata().override()._handle.get_buffer(),
+        }
+        self._attrs["_earthkit"] = attrs
         return xarray.Variable(self.var_dims, self.data, attrs=self._attrs)
 
     def load_attrs(self, keys, strict=True):
@@ -234,7 +235,9 @@ class TensorBackendBuilder:
     def make_variable(self, ds, dims, key, name):
         ds_var = ds.sel(**{key: name})
 
-        tensor_dims, tensor_coords, extra_tensor_attrs = self.prepare_tensor(ds_var, dims, name)
+        tensor_dims, tensor_coords, tensor_coords_component, extra_tensor_attrs = self.prepare_tensor(
+            ds_var, dims, name
+        )
         tensor_dim_keys = [d.key for d in tensor_dims]
 
         # print("tensor_dims", tensor_dims)
@@ -250,7 +253,15 @@ class TensorBackendBuilder:
 
         var_dims = []
         for d in tensor_dims:
-            k, c = d.as_coord(d.key, tensor.user_coords[d.key], tensor)
+            # Create coord for each dimension
+            # Dimensions like "level_per_type" are templates and will be
+            # added as multiple concrete dimensions to the dataset
+            k, c = d.as_coord(
+                d.key,
+                values=tensor.user_coords[d.key],
+                component=tensor_coords_component.get(d.key, None),
+                tensor=tensor,
+            )
             if k not in self.tensor_coords:
                 self.tensor_coords[k] = c
             var_dims.append(k)
@@ -289,13 +300,16 @@ class TensorBackendBuilder:
 
         # var_attrs = self.profile.remap(var_attrs)
 
-        var = VariableBuilder(var_dims, data, extra_tensor_attrs, tensor)
+        remapping = self.profile.remapping.build()
+
+        var = VariableBuilder(var_dims, data, extra_tensor_attrs, tensor, remapping)
         # var = xarray.Variable(var_dims, data, attrs=var_attrs)
         return var
 
     def prepare_tensor(self, ds, dims, name):
         tensor_dims = []
         tensor_coords = {}
+        tensor_coords_component = {}
         extra_tensor_attrs = []
 
         # print(f"prepare_tensor: {name=} {dims=}")
@@ -304,7 +318,7 @@ class TensorBackendBuilder:
         # from .fieldlist import unique_values
 
         # remapping = self.profile.remapping.build()
-        vals = ds.unique_values([d.key for d in dims])
+        vals, component_vals = ds.unique_values([d.key for d in dims], component=True)
 
         # print("unique_values", vals)
         # print("ensure_dims", self.profile.dims.ensure_dims)
@@ -323,16 +337,17 @@ class TensorBackendBuilder:
                         f"Dimension '{d.name}' of variable '{name}' has multiple values={vals[d.key]}"
                     )
                 elif num == 1 and d.name in self.profile.dims.dims_as_attrs:
-                    print("extra_tensor_attrs", d.key)
                     extra_tensor_attrs.append(d.key)
                 elif num > 1 or not self.profile.dims.squeeze or d.name in self.profile.dims.ensure_dims:
                     tensor_dims.append(d)
                     # tensor_coords[d.key] = ds.index(d.key)
                     tensor_coords[d.key] = vals[d.key]
+                    if d.key in component_vals:
+                        tensor_coords_component[d.key] = component_vals[d.key]
                     self.check_tensor_coords(name, d.key, tensor_coords)
 
         # TODO:  check if fieldlist forms a full hypercube with respect to the the dims/coordinate
-        return tensor_dims, tensor_coords, extra_tensor_attrs
+        return tensor_dims, tensor_coords, tensor_coords_component, extra_tensor_attrs
 
     def check_tensor_coords(self, var_name, coord_name, tensor_coords):
         if self.profile.strict:
@@ -384,6 +399,9 @@ class DatasetBuilder:
         ds = WrappedFieldList(self.ds, keys=self.profile.index_keys, remapping=remapping)
         # print(f"{remapping=}")
         # print(f"ds: {ds.indices()}")
+
+        # print(f"ds: {ds.index('level_and_type')}")
+        # print("components", ds.index("level_and_type", component=True))
 
         # global attributes are keys which are the same for all the fields
         # attributes = {k: v[0] for k, v in ds_ori.indices().items() if len(v) == 1}
@@ -481,26 +499,3 @@ class SplitDatasetBuilder(DatasetBuilder):
             s_ds._ek_builder = None
 
         return datasets[0] if len(datasets) == 1 else datasets
-
-    # def parse(self):
-    #     assert not hasattr(self.ds, "_ek_builder")
-    #     from .fieldlist import WrappedFieldList
-    #     from .profile import Profile
-
-    #     self.profile = Profile.make(self.profile, **self.kwargs)
-
-    #     remapping = profile.remapping.build()
-
-    #     # create a new fieldlist and ensure all the required metadata is kept in memory
-    #     ds = WrappedFieldList(self.ds, profile.index_keys, remapping=remapping)
-
-    #     # print("dims", profile.dim_keys)
-
-    #     profile.update(ds)
-
-    #     # print("dims", profile.dim_keys)
-
-    #     # the data is only sorted once
-    #     ds_sorted = ds.order_by(profile.sort_keys)
-
-    #     return ds, ds_sorted, profile

--- a/src/earthkit/data/utils/xarray/engine.py
+++ b/src/earthkit/data/utils/xarray/engine.py
@@ -311,15 +311,14 @@ class XarrayEarthkitDataArray(XarrayEarthkit):
 
     @property
     def metadata(self):
-        md = self._obj.attrs.get("_earthkit", tuple())
-        if len(md) == 2:
-            name, data = md
-            if name == "message":
-                from earthkit.data.readers.grib.memory import GribMessageMemoryReader
-                from earthkit.data.readers.grib.metadata import StandAloneGribMetadata
+        md = self._obj.attrs.get("_earthkit", dict())
+        if "message" in md:
+            data = md["message"]
+            from earthkit.data.readers.grib.memory import GribMessageMemoryReader
+            from earthkit.data.readers.grib.metadata import StandAloneGribMetadata
 
-                handle = next(GribMessageMemoryReader(data)).handle
-                return StandAloneGribMetadata(handle)
+            handle = next(GribMessageMemoryReader(data)).handle
+            return StandAloneGribMetadata(handle)
 
         raise ValueError(
             (
@@ -331,7 +330,7 @@ class XarrayEarthkitDataArray(XarrayEarthkit):
     def _to_fields(self):
         from .grib import data_array_to_fields
 
-        for f in data_array_to_fields(self._obj):
+        for f in data_array_to_fields(self._obj, metadata=self.metadata):
             yield f
 
 

--- a/src/earthkit/data/utils/xarray/fieldlist.py
+++ b/src/earthkit/data/utils/xarray/fieldlist.py
@@ -12,34 +12,132 @@ import logging
 from collections import defaultdict
 
 from earthkit.data.core.fieldlist import FieldList
+from earthkit.data.core.index import Selection
+from earthkit.data.core.index import normalize_selection
 from earthkit.data.core.order import build_remapping
 
 LOG = logging.getLogger(__name__)
 
 
+class CollectorJoiner:
+    def __init__(self, func):
+        self.func = func
+
+    def format_name(self, x, **kwargs):
+        return self.func(x, **kwargs)
+
+    def format_string(self, x):
+        return str(x)
+
+    def join(self, args):
+        remapped = "".join(str(x) for x in args)
+        components = tuple([str(x) for x in args[1::2]])
+        return (remapped, components)
+
+    @staticmethod
+    def patch(patch, value):
+        if isinstance(value, tuple) and len(value) == 2:
+            return patch(value[0]), value[1]
+        return patch(value)
+
+
+class IndexSelection(Selection):
+    def match_element(self, element):
+        return all(v(element) for k, v in self.actions.items())
+
+
+class IndexDB:
+    def __init__(self, index, component):
+        self._index = index if index is not None else dict()
+        self._component = component if component is not None else dict()
+
+    def index(self, key, maker=None):
+        # LOG.debug(f"index(): {key=} {self._index=}")
+        if key not in self._index:
+            # # LOG.debug(f"Key={key} not found in IndexDB")
+            if maker is not None:
+                self._index[key] = maker(key)[key]
+            else:
+                raise KeyError(f"Could not find index for {key=}")
+        return self._index[key]
+
+    def component(self, key):
+        if key not in self._component:
+            raise KeyError(f"Could not find component for {key=}")
+        return self._component[key]
+
+    def collect(self, keys, component=False):
+        remaining_keys = list(keys)
+        indices = dict()
+        components = dict()
+        for k in keys:
+            if k in self._index:
+                indices[k] = self._index[k]
+                remaining_keys.remove(k)
+                if component and k in self._component:
+                    components[k] = self._component[k]
+        return remaining_keys, indices, components
+
+    def filter(self, *args, **kwargs):
+        kwargs = normalize_selection(*args, **kwargs)
+
+        index = dict()
+        component = dict()
+
+        for k in self._index:
+            if k in kwargs:
+                selection = IndexSelection(dict(k=kwargs[k]))
+                idx = list(i for i, element in enumerate(self._index[k]) if selection.match_element(element))
+                index[k] = [self._index[k][i] for i in idx]
+                if k in self._component:
+                    component[k] = component[k][0], [self._component[k][1][i] for i in idx]
+            else:
+                index[k] = self._index[k]
+                if k in self._component:
+                    component[k] = self._component[k]
+        return IndexDB(index, component)
+
+    def __repr__(self) -> str:
+        return f"IndexDB(_index={self._index}, component={self._component})"
+
+    # def component_keys(self, key):
+    #     if key not in self._component:
+    #         raise KeyError(f"Could not find component for {key=}")
+    #     return self._component[key][0]
+
+
 class WrappedFieldList(FieldList):
     def __init__(self, fieldlist, keys=None, db=None, remapping=None):
         super().__init__()
-
         self.ds = fieldlist
 
         self.remapping = remapping
         if self.remapping is not None:
             self.remapping = build_remapping(remapping)
 
-        self.db = dict()
+        self.db = IndexDB(None, None)
         if db is not None:
             self.db = db
         elif keys:
-            self.db = self.unique_values(keys)
+            self.db = IndexDB(*self.unique_values(keys, component=True))
 
-    def index(self, key):
+        assert self.db
+
+        # self.db = dict()
+        # if db is not None:
+        #     self.db = db
+        # elif keys:
+        #     self.db = self.unique_values(keys)
+
+    def index(self, key, component=False):
         # print(f"called {key=}")
-        if key not in self.db:
-            # print(f"Key={key} not found in local metadata")
-            self.db[key] = self.unique_values(key)[key]
-            # return self.ds.index(key)
-        return self.db[key]
+        if component:
+            if self.remapping and key in self.remapping:
+                return self.db.component(key)
+            else:
+                return None
+
+        return self.db.index(key, self.unique_values)
 
     def __getitem__(self, n):
         return self.ds[n]
@@ -50,9 +148,11 @@ class WrappedFieldList(FieldList):
     def sel(self, *args, **kwargs):
         assert "remapping" not in kwargs
         assert "patches" not in kwargs
-        return WrappedFieldList(
-            self.ds.sel(*args, remapping=self.remapping, **kwargs), remapping=self.remapping
-        )
+        ds = self.ds.sel(*args, remapping=self.remapping, **kwargs)
+        db = None
+        # if not args and self.db and all(k in self.db for k in kwargs):
+        #     db = self.db.filter(**kwargs)
+        return WrappedFieldList(ds, db=db, remapping=self.remapping)
 
     def order_by(self, *args, **kwargs):
         assert "remapping" not in kwargs
@@ -61,23 +161,36 @@ class WrappedFieldList(FieldList):
             self.ds.order_by(*args, remapping=self.remapping, **kwargs), db=self.db, remapping=self.remapping
         )
 
-    def unique_values(self, names):
+    def unique_values(self, names, component=False):
         if isinstance(names, str):
             names = [names]
 
-        indices = dict()
-        keys = list(names)
-        for k in names:
-            if k in self.db:
-                indices[k] = self.db[k]
-                keys.remove(k)
+        # indices = dict()
+        # components = dict()
+        # keys = list(names)
+        keys, indices, components = self.db.collect(names, component=component)
+        # for k in names:
+        #     if k in self.db:
+        #         indices[k] = self.db.index[k]
+        #         keys.remove(k)
 
         if keys:
             vals = defaultdict(dict)
+            if component:
+                components = dict()
+                joiner = CollectorJoiner
+            else:
+                joiner = None
+
             for f in self.ds:
-                r = f._attributes(keys, remapping=self.remapping)
+                r = f._attributes(keys, remapping=self.remapping, joiner=joiner)
                 for k, v in r.items():
                     vals[k][v] = True
+                    # if k in self.remapping:
+                    #     vals[k][v[0]] = True
+                    #     vals[WrappedFieldList.components_key(k)][v[1]] = True
+                    # else:
+                    #     vals[k][v[0]] = True
 
             vals = {k: tuple(values.keys()) for k, values in vals.items()}
 
@@ -85,7 +198,23 @@ class WrappedFieldList(FieldList):
                 v = [x for x in v if x is not None]
                 vals[k] = sorted(v)
 
-            for k, v in vals.items():
-                indices[k] = v
+            if component and self.remapping:
+                for k, v in vals.items():
+                    if k in self.remapping:
+                        indices[k] = [x[0] for x in v]
+                        components[k] = self.remapping.components(k), [x[1] for x in v]
+                        assert len(indices[k]) == len(
+                            components[k][1]
+                        ), f"{len(indices[k])} != {len(components[k])} {indices[k]=} {components[k]=}"
+                    else:
+                        indices[k] = v
+            else:
+                for k, v in vals.items():
+                    indices[k] = v
 
-        return indices
+        if component:
+            # print(f"{indices=}")
+            # print(f"{components=}")
+            return indices, components
+        else:
+            return indices

--- a/tests/core/test_remapping.py
+++ b/tests/core/test_remapping.py
@@ -12,6 +12,7 @@
 import pytest
 
 from earthkit.data.core.order import build_remapping
+from earthkit.data.utils.xarray.fieldlist import CollectorJoiner
 
 data = {"type": "cf", "number": 0, "name": "t2m"}
 
@@ -82,3 +83,71 @@ def test_remapping_patch_repeated():
     _fn = r(fn)
 
     assert _fn("type") == "x"
+
+
+@pytest.mark.parametrize(
+    "remapping,patch,expected_values",
+    [
+        (
+            {"type": "{type}{number}"},
+            None,
+            {"type": ("cf0", ("cf", "0")), "number": 0, "name": "t2m"},
+        ),
+        (
+            {"my_type": "{type}{number}"},
+            None,
+            {"my_type": ("cf0", ("cf", "0")), "type": "cf", "number": 0, "name": "t2m"},
+        ),
+        (
+            {"type": "{type}{number}"},
+            {"type": {"cf0": "pf"}, "number": 12, "name": None},
+            {"type": ("pf", ("cf", "0")), "number": 12, "name": None},
+        ),
+        (
+            {"my_type": "{type}{number}"},
+            {"my_type": {"cf0": "pf"}, "number": 12, "name": None},
+            {"my_type": ("pf", ("cf", "0")), "type": "cf", "number": 12, "name": None},
+        ),
+        (
+            {"my_type": "{type}{number}"},
+            {"my_type": lambda x: x + "_", "number": 12, "name": None},
+            {"my_type": ("cf0_", ("cf", "0")), "type": "cf", "number": 12, "name": None},
+        ),
+    ],
+)
+def test_remapping_collector(remapping, patch, expected_values):
+    r = build_remapping(remapping, patch)
+    _fn = r(fn, joiner=CollectorJoiner)
+    for k, v in expected_values.items():
+        assert _fn(k) == v
+
+
+@pytest.mark.parametrize(
+    "remapping,patch,expected_values",
+    [
+        (
+            {"type": "{type}{number}"},
+            None,
+            {"type": ["type", "number"], "number": [], "name": []},
+        ),
+        (
+            {"my_type": "{type}{number}"},
+            None,
+            {"my_type": ["type", "number"], "type": [], "number": [], "name": []},
+        ),
+        (
+            {"type": "{type}{number}"},
+            {"type": {"cf0": "pf"}, "number": 12, "name": None},
+            {"type": ["type", "number"], "number": [], "name": []},
+        ),
+        (
+            {"my_type": "{type}{number}"},
+            {"my_type": {"cf0": "pf"}, "number": 12, "name": None},
+            {"my_type": ["type", "number"], "type": [], "number": [], "name": []},
+        ),
+    ],
+)
+def test_remapping_components(remapping, patch, expected_values):
+    r = build_remapping(remapping, patch)
+    for k, v in expected_values.items():
+        assert r.components(k) == v

--- a/tests/xr_engine/test_xr_engine.py
+++ b/tests/xr_engine/test_xr_engine.py
@@ -398,7 +398,6 @@ def test_xr_engine_detailed_flatten_check():
     assert np.allclose(r.values, vals_ref)
 
     r = da.loc[:, 0, :, 500, 9 * 36 + 0]
-    print(da.coords["levelist"])
     assert r.shape == (2, 2)
     vals_ref = np.array([[269.00918579, 268.78610229], [268.57771301, 268.08932495]])
     assert np.allclose(r.values, vals_ref)


### PR DESCRIPTION
This PR makes it possible to convert Xarrays created with remapping to GRIB. E.g. this works now:

```python
import earthkit.data as ekd

ds = ekd.from_source("sample", "pl.grib")
a = ds.to_xarray(level_dim_mode="level_and_type")
print(a)
fs = a.earthkit.to_fieldlist()
```
```
<xarray.Dataset>
Dimensions:                  (forecast_reference_time: 4, step: 2,
                              level_and_type: 2, latitude: 19, longitude: 36)
Coordinates:
  * forecast_reference_time  (forecast_reference_time) datetime64[ns] 2024-06...
  * step                     (step) timedelta64[ns] 00:00:00 06:00:00
  * level_and_type           (level_and_type) <U5 '500pl' '700pl'
  * latitude                 (latitude) float64 90.0 80.0 70.0 ... -80.0 -90.0
  * longitude                (longitude) float64 0.0 10.0 20.0 ... 340.0 350.0
Data variables:
    r                        (forecast_reference_time, step, level_and_type, latitude, longitude) float64 ...
    t                        (forecast_reference_time, step, level_and_type, latitude, longitude) float64 ...

...
```