### PR TITLE
Improve in memory gribfield implementation

### DIFF
--- a/docs/examples/numpy_fieldlist.ipynb
+++ b/docs/examples/numpy_fieldlist.ipynb
@@ -57,7 +57,7 @@
    "id": "9e6a80f5-77fc-40f8-a0be-86b80275c390",
    "metadata": {},
    "source": [
-    "In the examples below we will compute the potential temperature using the following method:"
+    "We will use the following method to compute the potential temperature:"
    ]
   },
   {
@@ -98,7 +98,7 @@
     {
      "data": {
       "text/plain": [
-       "GribField(t,850,20180801,1200,0,0)"
+       "(GribField(t,850,20180801,1200,0,0), 'K')"
       ]
      },
      "execution_count": 3,
@@ -108,51 +108,7 @@
    ],
    "source": [
     "f = ds[3]\n",
-    "f"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "0025e432-afa1-40ce-8968-7543364ef5f8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'K'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f.metadata(\"units\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "a01201de-4aca-4ada-ab29-474d45d53e90",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([272.53916931, 272.53916931, 272.53916931, 272.53916931,\n",
-       "       272.53916931, 272.53916931, 272.53916931, 272.53916931,\n",
-       "       272.53916931, 272.53916931])"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f.values[:10]"
+    "f, f.metadata(\"units\")"
    ]
   },
   {
@@ -165,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "60db0219-044d-4977-abf5-e30065400a8f",
    "metadata": {},
    "outputs": [
@@ -184,7 +140,7 @@
        "       285.48786915, 285.48786915])"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -209,12 +165,12 @@
     "tags": []
    },
    "source": [
-    "We create a new :py:class:`~data.readers.grib.metadata.GribMetadata` object from the source field's :py:meth:`~data.readers.grib.codes.GribField.metadata` using :py:meth:`~data.readers.grib.metadata.GribMetadata.override`."
+    "We create a new :py:class:`~data.readers.grib.metadata.GribMetadata` object from the source field's :py:meth:`~data.readers.grib.codes.GribField.metadata` using :py:meth:`~data.readers.grib.metadata.GribMetadata.override`. The original metadata remains the same."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "f8dcc33c-6818-415d-8088-6a01666ca87f",
    "metadata": {
     "editable": true,
@@ -223,36 +179,6 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<earthkit.data.readers.grib.metadata.StandAloneGribMetadata at 0x1694997b0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "md_new = f.metadata().override(shortName=\"pt\")\n",
-    "md_new"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "34aec901-4f60-4154-99ac-890172b96efa",
-   "metadata": {},
-   "source": [
-    "The original metadata remains the same."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "67a58bb4-e435-4d01-9e97-5965e0ac49f9",
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -264,8 +190,9 @@
     }
    ],
    "source": [
+    "md_new = f.metadata().override(shortName=\"pt\")\n",
     "print(md_new[\"shortName\"])\n",
-    "print(f.metadata()[\"shortName\"])"
+    "print(f.metadata(\"shortName\"))"
    ]
   },
   {
@@ -285,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "5a2557a6-091c-4345-a792-d3bfa7876c77",
    "metadata": {
     "editable": true,
@@ -354,7 +281,7 @@
        "0       an       0  regular_ll  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "2ccde1fc-f8c4-4d4d-abda-3ca3feebd02e",
    "metadata": {},
    "outputs": [
@@ -376,63 +303,13 @@
        "ArrayField(pt,850,20180801,1200,0,0)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ds_new[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "4113f204-dd96-422d-acb5-e2e0901cfb7a",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ds_new[0].values[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "cee91d37-2444-477d-b43f-fbd2b58c4519",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Potential temperature'"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ds_new[0].metadata(\"name\")"
    ]
   },
   {
@@ -447,12 +324,12 @@
     "tags": []
    },
    "source": [
-    "We can save our new fieldlist into a GRIB file:"
+    "The new fieldlist can be saved into a GRIB file:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "c22a23fc-fccd-45ef-887e-95ab61b0dee1",
    "metadata": {
     "editable": true,
@@ -521,7 +398,7 @@
        "0       an       0  regular_ll  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,6 +406,8 @@
    "source": [
     "path = \"_pt_single.grib\"\n",
     "ds_new.save(path)\n",
+    "\n",
+    "# read file back and check content\n",
     "ds1 = earthkit.data.from_source(\"file\",path)\n",
     "ds1.ls()"
    ]
@@ -551,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "bedb28e0-dc98-4145-8559-da96cadca828",
    "metadata": {},
    "outputs": [
@@ -648,7 +527,7 @@
        "2       an       0  regular_ll     K  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -660,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "id": "74881517-ce58-4692-b1f1-cf281c5c1df2",
    "metadata": {},
    "outputs": [
@@ -670,7 +549,7 @@
        "(3, 84)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -679,29 +558,6 @@
     "p = np.asarray(fs.metadata(\"level\")).reshape(-1, 1)*100. # hPa -> Pa\n",
     "t_new = potential_temperature(fs.values, p)\n",
     "t_new.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "bedf4a1f-1696-4da9-ae6b-575cd42d692c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915])"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "t_new[0,:10]"
    ]
   },
   {
@@ -721,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "ab0c805e-9e33-40f1-a816-501c2cff64a1",
    "metadata": {
     "editable": true,
@@ -820,7 +676,7 @@
        "2       an       0  regular_ll  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -829,50 +685,6 @@
     "md_new = [f.metadata().override(shortName=\"pt\") for f in fs]\n",
     "ds_new = FieldList.from_array(t_new, md_new)\n",
     "ds_new.ls()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "b0298472-345e-41f4-836e-a05b45509b2b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915, 285.48786915, 285.48786915,\n",
-       "       285.48786915, 285.48786915])"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ds_new[0].values[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "835412a7-85a2-4b07-ae40-e7e816e1a0bf",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Potential temperature', 'Potential temperature', 'Potential temperature']"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ds_new.metadata(\"name\")"
    ]
   },
   {
@@ -887,12 +699,12 @@
     "tags": []
    },
    "source": [
-    "We can save the fieldlist into a GRIB file:"
+    "The new fieldlist can be saved into a GRIB file:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "id": "e8e1c8a2-87aa-4ec2-895e-8ea7bd83e101",
    "metadata": {
     "editable": true,
@@ -991,7 +803,7 @@
        "2       an       0  regular_ll  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -999,6 +811,8 @@
    "source": [
     "path = \"_pt_multi.grib\"\n",
     "ds_new.save(path)\n",
+    "\n",
+    "# read file back and check content\n",
     "ds1 = earthkit.data.from_source(\"file\", path)\n",
     "ds1.ls()"
    ]
@@ -1028,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "id": "6c6e8651-f5a3-4534-9227-812e8e69407d",
    "metadata": {
     "editable": true,
@@ -1058,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "id": "32c53494-e8f4-4a22-aa93-e16b5188483a",
    "metadata": {},
    "outputs": [
@@ -1151,7 +965,7 @@
        "2       an       0  regular_ll  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1175,12 +989,12 @@
     }
    },
    "source": [
-    "We can save the results into a GRIB file:"
+    "The new fieldlist can be saved into a GRIB file:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "id": "a149caa0-b1ba-4b8e-b2d0-6aad7ee224a6",
    "metadata": {},
    "outputs": [
@@ -1273,7 +1087,7 @@
        "2       an       0  regular_ll  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1281,6 +1095,8 @@
    "source": [
     "path = \"_pt_from_loop.grib\"\n",
     "ds_r.save(path)\n",
+    "\n",
+    "# read file back and check content\n",
     "ds1 = earthkit.data.from_source(\"file\", path)\n",
     "ds1.ls()"
    ]

--- a/docs/guide/misc/grib_memory.rst
+++ b/docs/guide/misc/grib_memory.rst
@@ -45,7 +45,6 @@ When reading :ref:`grib` data from disk as a :ref:`file source <data-sources-fil
 - :ref:`grib-field-policy <grib-field-policy>`
 - :ref:`grib-handle-policy <grib-handle-policy>`
 - :ref:`grib-handle-cache-size <grib-handle-cache-size>`
-- :ref:`use-grib-metadata-cache <use-grib-metadata-cache>`
 
 .. _grib-field-policy:
 
@@ -79,18 +78,10 @@ grib-handle-cache-size
 
 When :ref:`grib-handle-policy <grib-handle-policy>` is ``"cache"``, the setting ``grib-handle-cache-size`` (default is ``1``) specifies the maximum number of GRIB handles kept in an in-memory cache per fieldlist. This is an LRU cache, so when it is full, the least recently used GRIB handle is removed and a new GRIB message is loaded from disk and added to the cache.
 
-.. _use-grib-metadata-cache:
-
-use-grib-metadata-cache
-+++++++++++++++++++++++++++++++++++
-
-When ``use-grib-metadata-cache`` is ``True`` (this is the default) all the fields will cache their metadata access. This is an in-memory cache attached to the field and implemented for the low-level metadata accessor for individual keys. This cache can be useful when the same metadata keys are accessed multiple times for the same field.
-
-
 Overriding the settings
 ++++++++++++++++++++++++++++
 
-In addition to changing the :ref:`settings` themselves, it is possible to override the 4 parameters above when loading a given fieldlist by passing them as keyword arguments to :func:`from_source`. The parameter names are the same but the dashes are replaced by underscores. When a parameter is not specified in :func:`from_source` or is set to None, its value is taken from the actual :ref:`settings`. E.g.:
+In addition to changing the :ref:`settings` themselves, it is possible to override the parameters above when loading a given fieldlist by passing them as keyword arguments to :func:`from_source`. The parameter names are the same but the dashes are replaced by underscores. When a parameter is not specified in :func:`from_source` or is set to None, its value is taken from the actual :ref:`settings`. E.g.:
 
 .. code-block:: python
 
@@ -102,7 +93,6 @@ In addition to changing the :ref:`settings` themselves, it is possible to overri
         grib_field_policy="persistent",
         grib_handle_policy="temporary",
         grib_handle_cache_size=0,
-        use_grib_metadata_cache=True,
     )
 
 

--- a/docs/guide/misc/grib_metadata.rst
+++ b/docs/guide/misc/grib_metadata.rst
@@ -1,0 +1,27 @@
+.. _grib-metadata-cache
+
+GRIB field metadata caching
+//////////////////////////////
+
+The ``use-grib-metadata-cache`` :ref:`setting <settings>` controls whether :ref:`grib` fields will cache their metadata access. The default value is ``True``.
+
+This is an in-memory cache attached to the field and implemented for the low-level metadata accessor for individual keys. Getting the values from the cache can be significantly faster than reading them from the GRIB handle, even when the handle is kept in memory.
+
+This setting is applied to all the different GRIB field types, even for fields stored entirely in memory (see :ref:`grib-memory`).
+
+
+Overriding the settings
+++++++++++++++++++++++++++++
+
+In addition to changing the :ref:`settings`, it is possible to override ``use-grib-metadata-cache`` when loading a given fieldlist by passing the ``use_grib_metadata_cache`` keyword argument (note the underscores) to :func:`from_source`. When this kwarg is not specified in :func:`from_source` or is set to None, its value is taken from the actual :ref:`settings`. E.g.:
+
+.. code-block:: python
+
+    import earthkit.data
+
+    # will override the settings
+    ds = earthkit.data.from_source(
+        "file",
+        "test6.grib",
+        use_grib_metadata_cache=False,
+    )

--- a/src/earthkit/data/indexing/fieldlist.py
+++ b/src/earthkit/data/indexing/fieldlist.py
@@ -7,6 +7,8 @@
 # nor does it submit to any jurisdiction.
 #
 
+from collections import defaultdict
+
 from earthkit.data.core.fieldlist import FieldList
 
 
@@ -82,6 +84,17 @@ class SimpleFieldList(FieldList):
         from itertools import chain
 
         return cls.from_fields(list(chain(*[f for f in sources])))
+
+    def _diag(self):
+        r = defaultdict(int)
+        for f in self:
+            try:
+                md_cache = f._diag()
+                for k in ["metadata_cache_hits", "metadata_cache_misses", "metadata_cache_size"]:
+                    r[k] += md_cache[k]
+            except Exception:
+                pass
+        return r
 
 
 # For backwards compatibility

--- a/src/earthkit/data/indexing/fieldlist.py
+++ b/src/earthkit/data/indexing/fieldlist.py
@@ -7,7 +7,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-from collections import defaultdict
 
 from earthkit.data.core.fieldlist import FieldList
 
@@ -84,17 +83,6 @@ class SimpleFieldList(FieldList):
         from itertools import chain
 
         return cls.from_fields(list(chain(*[f for f in sources])))
-
-    def _diag(self):
-        r = defaultdict(int)
-        for f in self:
-            try:
-                md_cache = f._diag()
-                for k in ["metadata_cache_hits", "metadata_cache_misses", "metadata_cache_size"]:
-                    r[k] += md_cache[k]
-            except Exception:
-                pass
-        return r
 
 
 # For backwards compatibility

--- a/src/earthkit/data/readers/grib/codes.py
+++ b/src/earthkit/data/readers/grib/codes.py
@@ -9,7 +9,6 @@
 
 import logging
 import os
-from collections import defaultdict
 from functools import cached_property
 
 import eccodes
@@ -329,14 +328,3 @@ class GribField(Field):
         bytes
         """
         return self.handle.get_buffer()
-
-    def _diag(self):
-        r = r = defaultdict(int)
-        try:
-            md_cache = self._metadata._cache
-            r["metadata_cache_size"] += len(md_cache)
-            r["metadata_cache_hits"] += md_cache.hits
-            r["metadata_cache_misses"] += md_cache.misses
-        except Exception:
-            pass
-        return r

--- a/src/earthkit/data/readers/grib/index/__init__.py
+++ b/src/earthkit/data/readers/grib/index/__init__.py
@@ -394,23 +394,21 @@ class GribFieldListInFiles(GribFieldList):
     def __len__(self):
         return self.number_of_parts()
 
-    def _diag(self):
+    def _cache_diag(self):
+        """For testing only"""
         r = defaultdict(int)
         r.update(self._field_manager.diag())
         r.update(self._handle_manager.diag())
 
         if self._field_manager.cache is not None:
+            from earthkit.data.utils.diag import collect_field_metadata_cache_diag
+
             for f in self._field_manager.cache.values():
                 if f._handle is not None:
                     r["current_handle_count"] += 1
 
                 if self._use_metadata_cache:
-                    try:
-                        md_cache = f._diag()
-                        for k in ["metadata_cache_hits", "metadata_cache_misses", "metadata_cache_size"]:
-                            r[k] += md_cache[k]
-                    except Exception:
-                        pass
+                    collect_field_metadata_cache_diag(f, r)
         return r
 
     @abstractmethod

--- a/src/earthkit/data/sources/array_list.py
+++ b/src/earthkit/data/sources/array_list.py
@@ -27,7 +27,7 @@ class ArrayField(Field):
         Metadata object describing the field metadata.
     """
 
-    def __init__(self, array, metadata, use_metadata_cache=False):
+    def __init__(self, array, metadata):
         if isinstance(array, list):
             import numpy as np
 

--- a/src/earthkit/data/sources/array_list.py
+++ b/src/earthkit/data/sources/array_list.py
@@ -27,7 +27,7 @@ class ArrayField(Field):
         Metadata object describing the field metadata.
     """
 
-    def __init__(self, array, metadata):
+    def __init__(self, array, metadata, use_metadata_cache=False):
         if isinstance(array, list):
             import numpy as np
 
@@ -38,6 +38,7 @@ class ArrayField(Field):
 
             metadata = UserMetadata(metadata, values=array)
 
+        # TODO: this solution is questionable due to performance reasons
         metadata = metadata._hide_internal_keys()
 
         super().__init__(metadata=metadata)

--- a/src/earthkit/data/utils/diag.py
+++ b/src/earthkit/data/utils/diag.py
@@ -8,6 +8,7 @@
 #
 
 import time
+from collections import defaultdict
 
 
 class TimeDiag:
@@ -120,3 +121,37 @@ class Diag:
 
     def peak(self):
         return self.memory.peak()
+
+
+def metadata_cache_diag(fieldlist):
+    r = defaultdict(int)
+    for f in fieldlist:
+        collect_field_metadata_cache_diag(f, r)
+        # try:
+        #     md_cache = f._diag()
+        #     for k in ["metadata_cache_hits", "metadata_cache_misses", "metadata_cache_size"]:
+        #         r[k] += md_cache[k]
+        # except Exception:
+        #     pass
+    return r
+
+
+def collect_field_metadata_cache_diag(field, r):
+    try:
+        md_cache = field_cache_diag(field)
+        for k in ["metadata_cache_hits", "metadata_cache_misses", "metadata_cache_size"]:
+            r[k] += md_cache[k]
+    except Exception:
+        pass
+
+
+def field_cache_diag(field):
+    r = defaultdict(int)
+    try:
+        md_cache = field.metadata()._cache
+        r["metadata_cache_size"] += len(md_cache)
+        r["metadata_cache_hits"] += md_cache.hits
+        r["metadata_cache_misses"] += md_cache.misses
+    except Exception:
+        pass
+    return r

--- a/tests/grib/grib_fixtures.py
+++ b/tests/grib/grib_fixtures.py
@@ -9,7 +9,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-
 from earthkit.data import from_source
 from earthkit.data.testing import ARRAY_BACKENDS
 from earthkit.data.testing import earthkit_examples_file
@@ -17,15 +16,15 @@ from earthkit.data.testing import earthkit_test_data_file
 from earthkit.data.utils.array import get_backend
 
 
-def load_array_fieldlist(path, array_backend):
-    ds = from_source("file", path)
+def load_array_fieldlist(path, array_backend, **kwargs):
+    ds = from_source("file", path, **kwargs)
     return ds.to_fieldlist(array_backend=array_backend)
     # return FieldList.from_array(
     #     ds.values, [m.override(generatingProcessIdentifier=120) for m in ds.metadata()]
     # )
 
 
-def load_grib_data(filename, fl_type, folder="example"):
+def load_grib_data(filename, fl_type, folder="example", **kwargs):
     if isinstance(filename, str):
         filename = [filename]
 
@@ -37,10 +36,19 @@ def load_grib_data(filename, fl_type, folder="example"):
         raise ValueError(f"Invalid folder={folder}")
 
     if fl_type == "file":
-        return from_source("file", path), get_backend("numpy")
+        return from_source("file", path, **kwargs), get_backend("numpy")
     elif fl_type in ARRAY_BACKENDS:
         array_backend = fl_type
-        return load_array_fieldlist(path, array_backend), get_backend(array_backend)
+        return load_array_fieldlist(path, array_backend, **kwargs), get_backend(array_backend)
+    elif fl_type == "array":
+        return load_array_fieldlist(path, "numpy", **kwargs), get_backend("numpy")
+    elif fl_type == "memory":
+        assert len(path) == 1
+        with open(path[0], "rb") as f:
+            ds = from_source("stream", f, read_all=True, **kwargs)
+            len(ds)  # force reading
+            return ds, get_backend("numpy")
+
     else:
         raise ValueError(f"Invalid fl_type={fl_type}")
 


### PR DESCRIPTION
This PR:

- reduces the memory usage when a new array fieldlist is created with `FieldList.to_fieldlist()` 
- reduces the memory usage when `to_numpy()`, `to_array()` or `values` called on a fieldlist
- applies the `use-grib-metadata-cache` setting to all types of GRIB fields, even for fields entirely in memory


