### PR TITLE
Alter field metadata

### DIFF
--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -79,12 +79,6 @@ class FieldListIndices:
 class Field(Base):
     r"""Represent a Field."""
 
-    def __init__(
-        self,
-        metadata=None,
-    ):
-        self.__metadata = metadata
-
     @abstractmethod
     def _values(self, dtype=None):
         r"""Return the raw values extracted from the underlying storage format
@@ -113,12 +107,10 @@ class Field(Base):
         return self._flatten(self._values())
 
     @property
+    @abstractmethod
     def _metadata(self):
         r"""Metadata: Get the object representing the field's metadata."""
-        if self.__metadata is None:
-            # TODO: remove this legacy method
-            self.__metadata = self._make_metadata()
-        return self.__metadata
+        self._not_implemented()
 
     def to_numpy(self, flatten=False, dtype=None, index=None):
         r"""Return the values stored in the field as an ndarray.
@@ -637,6 +629,16 @@ class Field(Base):
         else:
             return self._metadata.as_namespace(None)
 
+    @abstractmethod
+    def copy(self, **kwargs):
+        r"""Return a copy of the field.
+
+        Returns
+        -------
+        :obj:`Field`
+        """
+        self._not_implemented()
+
     def dump(self, namespace=all, **kwargs):
         r"""Generate dump with all the metadata keys belonging to ``namespace``.
 
@@ -667,6 +669,28 @@ class Field(Base):
 
         """
         return self._metadata.dump(namespace=namespace, **kwargs)
+
+    def save(self, filename, append=False, **kwargs):
+        r"""Write the field into a file.
+
+        Parameters
+        ----------
+        filename: str, optional
+            The target file path, if not defined attempts will be made to detect the filename
+        append: bool, optional
+            When it is true append data to the target file. Otherwise
+            the target file be overwritten if already exists. Default is False
+        **kwargs: dict, optional
+            Other keyword arguments passed to :obj:`write`.
+
+        See Also
+        --------
+        :obj:`write`
+
+        """
+        flag = "wb" if not append else "ab"
+        with open(filename, flag) as f:
+            self.write(f, **kwargs)
 
     def __getitem__(self, key):
         """Return the value of the metadata ``key``."""

--- a/src/earthkit/data/indexing/fieldlist.py
+++ b/src/earthkit/data/indexing/fieldlist.py
@@ -85,5 +85,44 @@ class SimpleFieldList(FieldList):
         return cls.from_fields(list(chain(*[f for f in sources])))
 
 
+class WrappedField:
+    def __init__(self, field):
+        self._field = field
+
+    def __getattr__(self, name):
+        return getattr(self._field, name)
+
+    def __repr__(self) -> str:
+        return repr(self._field)
+
+
+# class NewDataField(WrappedField):
+#     def __init__(self, field, data):
+#         super().__init__(field)
+#         self._data = data
+#         self.shape = data.shape
+
+#     def to_numpy(self, flatten=False, dtype=None, index=None):
+#         data = self._data
+#         if dtype is not None:
+#             data = data.astype(dtype)
+#         if flatten:
+#             data = data.flatten()
+#         if index is not None:
+#             data = data[index]
+#         return data
+
+
+class NewFieldMetadataWrapper:
+    def __init__(self, field, **kwargs):
+        from earthkit.data.core.metadata import WrappedMetadata
+
+        self.__metadata = WrappedMetadata(field._metadata, extra=kwargs, owner=field)
+
+    @property
+    def _metadata(self):
+        return self.__metadata
+
+
 # For backwards compatibility
 FieldArray = SimpleFieldList

--- a/src/earthkit/data/readers/grib/memory.py
+++ b/src/earthkit/data/readers/grib/memory.py
@@ -11,6 +11,7 @@ import logging
 
 import eccodes
 
+from earthkit.data.indexing.fieldlist import NewFieldMetadataWrapper
 from earthkit.data.indexing.fieldlist import SimpleFieldList
 from earthkit.data.readers import Reader
 from earthkit.data.readers.grib.codes import GribCodesHandle
@@ -152,6 +153,20 @@ class GribFieldInMemory(GribField):
         handle = eccodes.codes_new_from_message(buf)
         return GribFieldInMemory(
             GribCodesHandle(handle, None, None), use_metadata_cache=get_use_grib_metadata_cache()
+        )
+
+    def copy(self, **kwargs):
+        return NewMetadataGribFieldInMemory(self, **kwargs)
+
+
+class NewMetadataGribFieldInMemory(NewFieldMetadataWrapper, GribFieldInMemory):
+    def __init__(self, field, **kwargs):
+        NewFieldMetadataWrapper.__init__(self, field, **kwargs)
+        self._handle = field._handle
+        GribFieldInMemory.__init__(
+            self,
+            field._handle,
+            use_metadata_cache=field._use_metadata_cache,
         )
 
 

--- a/src/earthkit/data/readers/grib/output.py
+++ b/src/earthkit/data/readers/grib/output.py
@@ -77,6 +77,7 @@ class GribCoder:
         metadata={},
         template=None,
         return_bytes=False,
+        missing_value=9999,
         **kwargs,
     ):
         # Make a copy as we may modify it
@@ -105,7 +106,7 @@ class GribCoder:
 
             if np.isnan(values).any():
                 # missing_value = np.finfo(values.dtype).max
-                missing_value = 9999
+                missing_value = missing_value
                 values = np.nan_to_num(values, nan=missing_value)
                 metadata["missingValue"] = missing_value
                 metadata["bitmapPresent"] = 1
@@ -120,8 +121,13 @@ class GribCoder:
             for k in ("class", "type", "stream", "expver", "setLocalDefinition"):
                 metadata.pop(k, None)
 
+        # TODO: revisit that logic
         if "generatingProcessIdentifier" not in metadata:
             metadata["generatingProcessIdentifier"] = 255
+        else:
+            # kee
+            if metadata["generatingProcessIdentifier"] is None:
+                metadata.pop("generatingProcessIdentifier")
 
         LOG.debug("GribOutput.metadata %s", metadata)
 

--- a/src/earthkit/data/writers/__init__.py
+++ b/src/earthkit/data/writers/__init__.py
@@ -27,10 +27,10 @@ class Writer(metaclass=ABCMeta):
         pass
 
 
-def write(f, values, metadata, **kwargs):
-    x = _writers(metadata.data_format())
+def write(f, field, **kwargs):
+    x = _writers(field._metadata.data_format())
     c = x()
-    c.write(f, values, metadata, **kwargs)
+    c.write(f, field, **kwargs)
 
 
 @locked

--- a/tests/grib/test_grib_copy.py
+++ b/tests/grib/test_grib_copy.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from earthkit.data import FieldList
+from earthkit.data import from_source
+from earthkit.data.core.temporary import temp_file
+
+here = os.path.dirname(__file__)
+sys.path.insert(0, here)
+from grib_fixtures import load_grib_data  # noqa: E402
+
+
+@pytest.mark.parametrize("fl_type", ["file", "array", "memory"])
+def test_grib_copy_core(fl_type):
+    ds_ori, _ = load_grib_data("test4.grib", fl_type)
+
+    def _func1(field, key, original_metadata):
+        return original_metadata[key] + 100
+
+    def _func2(field, key, original_metadata):
+        return field.mars_area
+
+    def _func3(field, key, original_metadata):
+        return original_metadata.get("param") + "_" + str(original_metadata.get("levelist"))
+
+    # ---------------
+    # field
+    # ---------------
+
+    f = ds_ori[0].copy(
+        param="q",
+        levelist=_func1,
+        mars_area=_func2,
+        name=_func3,
+    )
+
+    assert f.metadata("param") == "q"
+    assert f.metadata("shortName") == "t"
+    assert f.metadata("level") == 500
+    assert f.metadata("levelist") == 600
+    assert f.metadata("date", "param") == (20070101, "q")
+    assert f.metadata("param", "date") == ("q", 20070101)
+    assert np.allclose(np.array(f.metadata("mars_area")), np.array([90.0, 0.0, -90.0, 359.0]))
+    assert f.metadata("name") == "t_500"
+
+    # TODO: apply wrapped metadata to namespaces
+    assert f.metadata(namespace="mars") == {
+        "class": "ea",
+        "date": 20070101,
+        "domain": "g",
+        "expver": "0001",
+        "levelist": 500,
+        "levtype": "pl",
+        "param": "t",
+        "step": 0,
+        "stream": "oper",
+        "time": 1200,
+        "type": "an",
+    }
+
+    # write back to grib
+    # we can only have ecCodes keys
+    with temp_file() as tmp:
+        f = ds_ori[0].copy(
+            param="q",
+            levelist=_func1,
+        )
+
+        f.save(tmp)
+        f_saved = from_source("file", tmp)[0]
+        assert f_saved.metadata("param") == "q"
+        assert f_saved.metadata("shortName") == "q"
+        assert f_saved.metadata("level") == 600
+        assert f_saved.metadata("levelist") == 600
+
+    # ---------------
+    # fieldlist
+    # ---------------
+
+    fields = []
+    for i in range(2):
+        f = ds_ori[i].copy(
+            param="q",
+            levelist=_func1,
+        )
+        fields.append(f)
+
+    ds = FieldList.from_fields(fields)
+
+    assert ds.metadata("param") == ["q", "q"]
+    assert ds.metadata("shortName") == ["t", "z"]
+    assert ds.metadata("level") == [500, 500]
+    assert ds.metadata("levelist") == [600, 600]
+
+    # write back to grib
+    with temp_file() as tmp:
+        ds.save(tmp)
+        ds_saved = from_source("file", tmp)
+        assert ds_saved.metadata("param") == ["q", "q"]
+        assert ds_saved.metadata("shortName") == ["q", "q"]
+        assert ds_saved.metadata("level") == [600, 600]
+        assert ds_saved.metadata("levelist") == [600, 600]
+
+    # TODO: implement the following
+    # serialise
+    # pickled_f = pickle.dumps(ds)
+    # ds_1 = pickle.loads(pickled_f)
+
+    # assert ds_1.metadata("param") == ["q", "q"]
+    # assert ds_1.metadata("shortName") == ["q", "q"]
+    # assert ds_1.metadata("level") == [600, 600]
+    # assert ds_1.metadata("levelist") == [600, 600]


### PR DESCRIPTION
This PR adds the `copy()` method to fields. The result is a new field containing:

- reference to the values/values accessor in the original field
- a wrapped metadata object updated with the kwargs

The original field is kept unaltered.

E.g. if `f` is a field with "level" = 500:

```python
>>> f_new = f.copy(level=700)
>>> f.metadata("level")
>>> f_new.metadata("level")
500
700
```

The kwargs can contain callables with the signature described below:

```python

def _func(field, key, original_metadata):
    return original_metadata[key] + 100

f_new = f.copy(level=_func)
print(f.metadata("level"))
print(f_new.metadata("level"))
```
```
500
600
```
