### PR TITLE
Bypass open_dataset in to_xarray

### DIFF
--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -268,6 +268,11 @@ class XarrayMixIn:
                 Typecode or data-type of the array data.
             * array_module: module
                 The module to use for array operations. Default is numpy.
+            * direct_backend: bool, None
+                If True, the backend is used directly bypassing :py:meth:`xarray.open_dataset`
+                and ignoring all non-backend related kwargs. If False, the data is read via
+                :py:meth:`xarray.open_dataset`. Its default value (None) expands
+                to False unless the ``profile`` overwrites it.
 
             When ``engine="cfgrib"`` the following engine specific kwargs are supported:
 
@@ -367,9 +372,13 @@ class XarrayMixIn:
         # print(f"{kwargs=}")
         # print(f"{xarray_open_dataset_kwargs=}")
 
+        # separate backend_kwargs from other_kwargs
+        backend_kwargs = xarray_open_dataset_kwargs.pop("backend_kwargs", None)
+        other_kwargs = xarray_open_dataset_kwargs
+
         from earthkit.data.utils.xarray.builder import from_earthkit
 
-        return from_earthkit(self, **xarray_open_dataset_kwargs)
+        return from_earthkit(self, backend_kwargs=backend_kwargs, other_kwargs=other_kwargs)
 
     def to_xarray_cfgrib(self, user_kwargs):
         xarray_open_dataset_kwargs = {}

--- a/src/earthkit/data/utils/xarray/defaults.yaml
+++ b/src/earthkit/data/utils/xarray/defaults.yaml
@@ -37,6 +37,7 @@ array_module: numpy
 # other
 lazy_load: true
 release_source: false
+direct_backend: false
 strict: false
 errors: raise
 

--- a/src/earthkit/data/utils/xarray/engine.py
+++ b/src/earthkit/data/utils/xarray/engine.py
@@ -270,7 +270,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
         else:
             from .builder import SingleDatasetBuilder
 
-            return SingleDatasetBuilder(fieldlist, **_kwargs).build()
+            return SingleDatasetBuilder(fieldlist, from_xr=True, backend_kwargs=_kwargs).build()
 
     @classmethod
     def guess_can_open(cls, filename_or_obj):

--- a/src/earthkit/data/utils/xarray/profile.py
+++ b/src/earthkit/data/utils/xarray/profile.py
@@ -88,6 +88,7 @@ PROFILE_CONF = ProfileConf()
 
 class Profile:
     USER_ONLY_OPTIONS = ["remapping", "patches"]
+    DEFAULT_PROFILE_NAME = "mars"
 
     def __init__(
         self,
@@ -147,6 +148,7 @@ class Profile:
         self.decode_timedelta = kwargs.pop("decode_timedelta")
         self.lazy_load = kwargs.pop("lazy_load")
         self.release_source = kwargs.pop("release_source")
+        self.direct_backend = kwargs.pop("direct_backend")
         self.strict = kwargs.pop("strict")
         self.errors = kwargs.pop("errors")
 
@@ -174,6 +176,10 @@ class Profile:
     @staticmethod
     def make(name_or_def, *args, **kwargs):
         # print("name_or_def", name_or_def)
+
+        if isinstance(name_or_def, Profile):
+            return name_or_def
+
         if name_or_def is None:
             name_or_def = {}
 

--- a/tests/xr_engine/test_xr_engine.py
+++ b/tests/xr_engine/test_xr_engine.py
@@ -243,7 +243,8 @@ def test_xr_engine_detailed_check(api):
 @pytest.mark.parametrize("stream", [False, True])
 @pytest.mark.parametrize("lazy_load", [False, True])
 @pytest.mark.parametrize("release_source", [False, True])
-def test_xr_engine_detailed_flatten_check(stream, lazy_load, release_source):
+@pytest.mark.parametrize("direct_backend", [False, True])
+def test_xr_engine_detailed_flatten_check(stream, lazy_load, release_source, direct_backend):
     filename = "test-data/xr_engine/level/pl.grib"
     ds_ek, ds_ek_ref = load_grib_data(filename, "url", stream=stream)
 
@@ -257,6 +258,7 @@ def test_xr_engine_detailed_flatten_check(stream, lazy_load, release_source):
                 "add_valid_time_coord": False,
                 "lazy_load": lazy_load,
                 "release_source": release_source,
+                "direct_backend": direct_backend,
             }
         }
     }
@@ -415,6 +417,32 @@ def test_xr_engine_detailed_flatten_check(stream, lazy_load, release_source):
     assert np.allclose(r.values, vals_ref)
 
 
+@pytest.mark.cache
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"split_dims": ["step"]},
+        {"split_dims": None},
+        {"direct_backend": None},
+        {"direct_backend": True},
+        {"direct_backend": False},
+    ],
+)
+def test_xr_engine_invalid_kwargs(kwargs):
+    ds_ek = from_source("url", earthkit_remote_test_data_file("test-data", "xr_engine", "level", "pl.grib"))
+
+    import xarray as xr
+
+    with pytest.raises(TypeError):
+        xr.open_dataset(
+            ds_ek.path,
+            engine="earthkit",
+            time_dim_mode="raw",
+            **kwargs,
+        )
+
+
+@pytest.mark.cache
 def test_xr_engine_dtype():
     ds_ek = from_source("url", earthkit_remote_test_data_file("test-data/xr_engine/level/pl.grib"))
 


### PR DESCRIPTION
This PR adds the `direct_backend` option to `to_xarray()`. If True, the backend is used directly bypassing `xarray.open_dataset()` and ignoring all non-backend related kwargs. If False, the data is read via `xarray.open_dataset()`. Its default value (None) expands to False unless the `profile` overwrites it.