### PR TITLE
Add more fieldlist methods to fields

### DIFF
--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -510,7 +510,7 @@ list-of-dicts
 
   Other keys:
 
-    Other keys can be used to store additional metadata. They are not used by the field functionalities.
+    Other keys can be used to store additional metadata.
 
   Further examples:
 

--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -760,6 +760,48 @@ class Field(Base):
             self._metadata.override(**kwargs),
         )
 
+    def to_xarray(self, *args, **kwargs):
+        """Convert the Field into an Xarray Dataset.
+
+        Parameters
+        ----------
+        *args: tuple
+            Positional arguments passed to :obj:`FieldList.to_xarray`.
+        **kwargs: dict, optional
+            Other keyword arguments passed to :obj:`FieldList.to_xarray`.
+
+        Returns
+        -------
+        Xarray Dataset
+
+        """
+        return self._to_fieldlist().to_xarray(*args, **kwargs)
+
+    def ls(self, *args, **kwargs):
+        r"""Generate a list like summary using a set of metadata keys.
+
+        Parameters
+        ----------
+        *args: tuple
+            Positional arguments passed to :obj:`FieldList.ls`.
+        **kwargs: dict, optional
+            Other keyword arguments passed to :obj:`FieldList.ls`.
+
+        Returns
+        -------
+        Pandas DataFrame
+            DataFrame with one row.
+
+        """
+        return self._to_fieldlist().ls(*args, **kwargs)
+
+    def describe(self, *args, **kwargs):
+        r"""Generate a summary of the Field."""
+        return self._to_fieldlist().describe(*args, **kwargs)
+
+    def _to_fieldlist(self):
+        return FieldList.from_fields([self])
+
     @staticmethod
     def _flatten(v):
         """Flatten the array without copying the data."
@@ -1229,8 +1271,7 @@ class FieldList(Index):
             return []
 
     def head(self, n=5, **kwargs):
-        r"""Generate a list like summary of the first ``n``
-        :obj:`GribField <data.readers.grib.codes.GribField>`\ s using a set of metadata keys.
+        r"""Generate a list like summary of the first ``n`` :obj:`Field`\ s.
         Same as calling :obj:`ls` with ``n``.
 
         Parameters
@@ -1266,8 +1307,7 @@ class FieldList(Index):
         return self.ls(n=n, **kwargs)
 
     def tail(self, n=5, **kwargs):
-        r"""Generate a list like summary of the last ``n``
-        :obj:`GribField <data.readers.grib.codes.GribField>`\ s using a set of metadata keys.
+        r"""Generate a list like summary of the last ``n`` :obj:`Field`\ s.
         Same as calling :obj:`ls` with ``-n``.
 
         Parameters

--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -297,7 +297,7 @@ class XarrayMixIn:
 
         Returns
         -------
-        xarray Dataset or list of xarray Datasets
+        Xarray Dataset or list of Xarray Datasets
 
 
         The default values of ``xarray_open_dataset_kwargs`` or ``**kwargs`` passed

--- a/tests/grib/test_grib_summary.py
+++ b/tests/grib/test_grib_summary.py
@@ -146,6 +146,35 @@ def test_grib_describe(fl_type):
 
 
 @pytest.mark.parametrize("fl_type", FL_TYPES)
+def test_grib_describe_single_field(fl_type):
+    f_in, _ = load_grib_data("tuv_pl.grib", fl_type)
+    f = f_in[0]
+
+    # full contents
+    df = f.describe()
+    df = df.data
+
+    ref = {
+        "level": {("t", "isobaricInhPa"): "1000"},
+        "date": {("t", "isobaricInhPa"): "20180801"},
+        "time": {("t", "isobaricInhPa"): "1200"},
+        "step": {("t", "isobaricInhPa"): "0"},
+        "paramId": {("t", "isobaricInhPa"): "130"},
+        "class": {("t", "isobaricInhPa"): "od"},
+        "stream": {("t", "isobaricInhPa"): "oper"},
+        "type": {("t", "isobaricInhPa"): "an"},
+        "experimentVersionNumber": {("t", "isobaricInhPa"): "0001"},
+    }
+
+    assert ref == df.to_dict()
+
+    # repeated use
+    df = f.describe()
+    df = df.data
+    assert ref == df.to_dict()
+
+
+@pytest.mark.parametrize("fl_type", FL_TYPES)
 def test_grib_ls(fl_type):
     f, _ = load_grib_data("tuv_pl.grib", fl_type)
 
@@ -308,6 +337,52 @@ def test_grib_ls_num(fl_type):
     assert ref == df.to_dict()
 
     df = f.ls(-2)
+    assert ref == df.to_dict()
+
+
+@pytest.mark.parametrize("fl_type", FL_TYPES)
+def test_grib_ls_single_field(fl_type):
+    f, _ = load_grib_data("tuv_pl.grib", fl_type)
+
+    # default keys
+    f1 = f[0]
+    df = f1.ls()
+
+    ref = {
+        "centre": {0: "ecmf"},
+        "shortName": {0: "t"},
+        "typeOfLevel": {
+            0: "isobaricInhPa",
+        },
+        "level": {0: 1000},
+        "dataDate": {0: 20180801},
+        "dataTime": {0: 1200},
+        "stepRange": {0: "0"},
+        "dataType": {0: "an"},
+        "number": {0: 0},
+        "gridType": {0: "regular_ll"},
+    }
+
+    assert ref == df.to_dict()
+
+    # extra keys
+    f1 = f[0]
+    df = f1.ls(extra_keys=["paramId"])
+
+    ref = {
+        "centre": {0: "ecmf"},
+        "shortName": {0: "t"},
+        "typeOfLevel": {0: "isobaricInhPa"},
+        "level": {0: 1000},
+        "dataDate": {0: 20180801},
+        "dataTime": {0: 1200},
+        "stepRange": {0: "0"},
+        "dataType": {0: "an"},
+        "number": {0: 0},
+        "gridType": {0: "regular_ll"},
+        "paramId": {0: 130},
+    }
+
     assert ref == df.to_dict()
 
 


### PR DESCRIPTION
This PR adds the following methods, which already exist for Fieldlists, to Fields:

- to_xarray()
- ls()
- describe() 