### PR TITLE
Make earthkit attributes optional in Xarray engine

### DIFF
--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -252,6 +252,9 @@ class XarrayMixIn:
                 default value (None) expands to [] unless the ``profile`` overwrites it.
             * coord_attrs: dict, None
                 To be documented. Default is None.
+            * add_earthkit_attrs: bool, None
+                If True, add earthkit specific attributes to the dataset. Its default value
+                (None) expands to True unless the ``profile`` overwrites it.
             * rename_attrs: dict, None
                 A dictionary of attribute to rename. Default is None.
             * remapping: dict, None

--- a/src/earthkit/data/utils/xarray/builder.py
+++ b/src/earthkit/data/utils/xarray/builder.py
@@ -117,7 +117,8 @@ class VariableBuilder:
         # TODO: do we need a strict mode here? The extra cost has to be justified
         if keys_strict:
             assert strict
-            res.update(self.tensor.source.unique_values(keys_strict))
+            v, _ = self.tensor.source.unique_values(keys_strict)
+            res.update(v)
 
         self._attrs = res
         self._attrs.update(fixed_attrs)
@@ -618,7 +619,7 @@ class SplitDatasetBuilder(DatasetBuilder):
         # LOG.debug(f"split_dims={self.split_dims}")
         ds_xr = XArrayInputFieldList(self.ds, keys=self.profile.index_keys, remapping=remapping)
 
-        vals = ds_xr.unique_values(*keys)
+        vals, _ = ds_xr.unique_values(*keys)
 
         return ds_xr, vals
 

--- a/src/earthkit/data/utils/xarray/coord.py
+++ b/src/earthkit/data/utils/xarray/coord.py
@@ -77,7 +77,7 @@ class Coord:
 
     def attrs(self, name, profile):
         attrs = profile.attrs.coord_attrs.get(name, {})
-        if self.component:
+        if profile.add_earthkit_attrs and self.component:
             attrs["_earthkit"] = {"keys": self.component[0], "values": self.component[1]}
         return attrs
 

--- a/src/earthkit/data/utils/xarray/defaults.yaml
+++ b/src/earthkit/data/utils/xarray/defaults.yaml
@@ -20,6 +20,7 @@ attrs_mode: "fixed"
 attrs: []
 variable_attrs: []
 global_attrs: []
+add_earthkit_attrs: true
 rename_attrs:
   cfName: standard_name
   name: long_name

--- a/src/earthkit/data/utils/xarray/engine.py
+++ b/src/earthkit/data/utils/xarray/engine.py
@@ -43,6 +43,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
         variable_attrs=None,
         global_attrs=None,
         coord_attrs=None,
+        add_earthkit_attrs=None,
         rename_attrs=None,
         remapping=None,
         flatten_values=None,
@@ -210,6 +211,9 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
             default value (None) expands to [] unless the ``profile`` overwrites it.
         coord_attrs: dict, None
             To be documented. Default is None.
+        add_earthkit_attrs: bool, None
+            If True, add earthkit specific attributes to the dataset. Its default value
+            (None) expands to True unless the ``profile`` overwrites it.
         rename_attrs: dict, None
             A dictionary of attribute to rename. Default is None.
         remapping: dict, None
@@ -265,6 +269,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
                 variable_attrs=variable_attrs,
                 global_attrs=global_attrs,
                 coord_attrs=coord_attrs,
+                add_earthkit_attrs=add_earthkit_attrs,
                 rename_attrs=rename_attrs,
                 add_valid_time_coord=add_valid_time_coord,
                 add_geo_coords=add_geo_coords,

--- a/src/earthkit/data/utils/xarray/fieldlist.py
+++ b/src/earthkit/data/utils/xarray/fieldlist.py
@@ -102,7 +102,7 @@ class IndexDB:
 
 
 class XArrayInputFieldList(FieldList):
-    def __init__(self, fieldlist, keys=None, db=None, remapping=None, scan_only=False):
+    def __init__(self, fieldlist, keys=None, db=None, remapping=None, scan_only=False, component=True):
         super().__init__()
         self.ds = fieldlist
 
@@ -114,7 +114,7 @@ class XArrayInputFieldList(FieldList):
         if db is not None:
             self.db = db
         elif keys:
-            self.db = IndexDB(*self.unique_values(keys, component=True))
+            self.db = IndexDB(*self.unique_values(keys, component=component))
 
         assert self.db
 
@@ -225,7 +225,7 @@ class XArrayInputFieldList(FieldList):
         if component:
             return indices, components
         else:
-            return indices
+            return indices, None
 
 
 class ReleasableField:

--- a/src/earthkit/data/utils/xarray/fieldlist.py
+++ b/src/earthkit/data/utils/xarray/fieldlist.py
@@ -48,6 +48,7 @@ class IndexSelection(Selection):
 
 class IndexDB:
     def __init__(self, index, component):
+        # print(f"IndexDB: {index=}, {component=}")
         self._index = index if index is not None else dict()
         self._component = component if component is not None else dict()
 
@@ -56,7 +57,7 @@ class IndexDB:
         if key not in self._index:
             # # LOG.debug(f"Key={key} not found in IndexDB")
             if maker is not None:
-                self._index[key] = maker(key)[key]
+                self._index[key] = maker(key)[0][key]
             else:
                 raise KeyError(f"Could not find index for {key=}")
         return self._index[key]

--- a/src/earthkit/data/utils/xarray/profile.py
+++ b/src/earthkit/data/utils/xarray/profile.py
@@ -146,6 +146,8 @@ class Profile:
             kwargs.pop("rename_attrs"),
         )
 
+        self.add_earthkit_attrs = kwargs.pop("add_earthkit_attrs")
+
         # generic
         self.decode_times = kwargs.pop("decode_times")
         self.decode_timedelta = kwargs.pop("decode_timedelta")

--- a/src/earthkit/data/utils/xarray/splitter.py
+++ b/src/earthkit/data/utils/xarray/splitter.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 class Splitter(metaclass=ABCMeta):
     @staticmethod
     def grids(ds):
-        v = ds.unique_values(["md5GridSection"])
+        v, _ = ds.unique_values(["md5GridSection"])
         return v["md5GridSection"]
 
     @abstractmethod

--- a/tests/xr_engine/test_xr_engine.py
+++ b/tests/xr_engine/test_xr_engine.py
@@ -505,3 +505,23 @@ def test_xr_engine_single_field():
     for k, v in coords_ref_full.items():
         assert np.allclose(ds.coords[k].values, v)
     assert [v for v in ds.data_vars] == data_vars
+
+
+@pytest.mark.cache
+@pytest.mark.parametrize("add", [False, True])
+def test_xr_engine_add_earthkit_attrs(add):
+    ds_ek = from_source("url", earthkit_remote_test_data_file("test-data/xr_engine/level/pl.grib"))
+    ds_ek = ds_ek[0]
+
+    ds = ds_ek.to_xarray(
+        time_dim_mode="raw",
+        decode_times=False,
+        decode_timedelta=False,
+        add_valid_time_coord=False,
+        add_earthkit_attrs=add,
+    )
+
+    if add:
+        assert "_earthkit" in ds["t"].attrs
+    else:
+        assert "_earthkit" not in ds["t"].attrs


### PR DESCRIPTION
This PR adds the `add_earthkit_attrs` kwarg to `to_xarray()`.

```rst
* add_earthkit_attrs: bool, None
   If True, add earthkit specific attributes to the dataset. Its default value
   (None) expands to True unless the ``profile`` overwrites it.
```