### PR TITLE
Prevent calling eccodes.codes_set_key_vals with an empty dict

### DIFF
--- a/src/earthkit/data/utils/message.py
+++ b/src/earthkit/data/utils/message.py
@@ -228,13 +228,14 @@ class CodesHandle(eccodes.Message):
         return self._from_raw_handle(eccodes.codes_clone(self._handle, **kwargs))
 
     def set_multiple(self, values):
-        try:
-            assert self.path is None, "Only cloned handles can have values changed"
-            eccodes.codes_set_key_vals(self._handle, values)
-        except Exception as e:
-            LOG.error(f"Error setting: {values}")
-            LOG.exception(e)
-            raise
+        if values:
+            try:
+                assert self.path is None, "Only cloned handles can have values changed"
+                eccodes.codes_set_key_vals(self._handle, values)
+            except Exception as e:
+                LOG.error(f"Error setting: {values}")
+                LOG.exception(e)
+                raise
 
     def set_long(self, name, value):
         try:

--- a/tests/sources/test_mars.py
+++ b/tests/sources/test_mars.py
@@ -165,6 +165,25 @@ def test_mars_grib_log_4():
         assert t
 
 
+@pytest.mark.long_test
+@pytest.mark.download
+def test_mars_grib_save():
+    ds = from_source(
+        "mars",
+        param="2t",
+        levtype="sfc",
+        grid=[30, 30],
+        date=-1,
+    )
+    assert len(ds) == 1
+
+    with temp_file() as tmp:
+        ds.save(tmp)
+
+        ds1 = from_source("file", tmp)
+        assert len(ds1) == 1
+
+
 if __name__ == "__main__":
     from earthkit.data.testing import main
 


### PR DESCRIPTION
This PR prevents eccodes from printing to LOG.error when `eccodes.codes_set_key_vals()` is called with an empty dictionary.

Originally this error message was generated:

```
gribapi.errors.InvalidKeyValueError: Empty key/values argument
Failed to set metadata at once: Empty key/values argument
```