### PR TITLE
Feature/mars command env var

### DIFF
--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -811,7 +811,7 @@ mars
 
   To figure out which data you need, or discover relevant data available in MARS, see the publicly accessible `MARS catalog`_ (or this `access restricted catalog <https://apps.ecmwf.int/mars-catalogue/>`_).
 
-  If the ``use-standalone-mars-client-when-available`` :ref:`settings <settings>` is True and the MARS client is installed (as at ECMWF) the MARS access is direct. In this case the MARS client command can be specified via the ``MARS_CLIENT_EXECUTABLE`` environment variable, when it is not set the ``"/usr/local/bin/mars"`` path will be used.
+  If the ``use-standalone-mars-client-when-available`` :ref:`settings <settings>` is True and the MARS client is installed (e.g. at ECMWF) the MARS access is direct. In this case the MARS client command can be specified via the ``MARS_CLIENT_EXECUTABLE`` environment variable. When it is not set the ``"/usr/local/bin/mars"`` path will be used.
 
   If the standalone MARS client is not available or not enabled the `web API`_ will be used. In order to use the `web API`_ you will need to register and retrieve an access token. For a more extensive documentation about MARS, please refer to the `MARS user documentation`_.
 

--- a/docs/guide/sources.rst
+++ b/docs/guide/sources.rst
@@ -811,7 +811,9 @@ mars
 
   To figure out which data you need, or discover relevant data available in MARS, see the publicly accessible `MARS catalog`_ (or this `access restricted catalog <https://apps.ecmwf.int/mars-catalogue/>`_).
 
-  The MARS access is direct when the MARS client is installed (as at ECMWF) and the ``use-standalone-mars-client-when-available`` :ref:`settings <settings>` is True (this is the default), otherwise it will use the `web API`_. In order to use the `web API`_ you will need to register and retrieve an access token. For a more extensive documentation about MARS, please refer to the `MARS user documentation`_.
+  If the ``use-standalone-mars-client-when-available`` :ref:`settings <settings>` is True and the MARS client is installed (as at ECMWF) the MARS access is direct. In this case the MARS client command can be specified via the ``MARS_CLIENT_EXECUTABLE`` environment variable, when it is not set the ``"/usr/local/bin/mars"`` path will be used.
+
+  If the standalone MARS client is not available or not enabled the `web API`_ will be used. In order to use the `web API`_ you will need to register and retrieve an access token. For a more extensive documentation about MARS, please refer to the `MARS user documentation`_.
 
   :param tuple *args: positional arguments specifying the request as a dict
   :param bool prompt: if ``True``, it can offer a prompt to specify the credentials for `web API`_ and write them into the default RC file ``~/.ecmwfapirc``. The prompt only appears when:

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -57,7 +57,8 @@ class StandaloneMarsClient:
 
     @staticmethod
     def enabled():
-        return StandaloneMarsClient.command(check=True) is not None
+        cmd = StandaloneMarsClient.command(check=True)
+        return cmd is not None and cmd != ""
 
     @staticmethod
     def command(check=True):

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -25,8 +25,6 @@ def _no_log(msg):
 
 
 class StandaloneMarsClient:
-    EXE = "/usr/local/bin/mars"
-
     def __init__(self, log="default"):
         self.log = log
 
@@ -59,16 +57,23 @@ class StandaloneMarsClient:
 
     @staticmethod
     def enabled():
-        if SETTINGS.get("use-standalone-mars-client-when-available"):
-            return os.path.exists(StandaloneMarsClient.EXE)
-        return False
+        return StandaloneMarsClient.command(check=True) is not None
+
+    @staticmethod
+    def command(check=True):
+        cmd = os.environ.get("MARS_CLIENT_COMMAND", "/usr/local/bin/mars")
+        if check:
+            if SETTINGS.get("use-standalone-mars-client-when-available"):
+                if os.path.exists(cmd):
+                    return cmd
+        else:
+            return cmd
 
 
 class MarsRetriever(ECMWFApi):
     def service(self):
-        if SETTINGS.get("use-standalone-mars-client-when-available"):
-            if os.path.exists(StandaloneMarsClient.EXE):
-                return StandaloneMarsClient(self.log)
+        if StandaloneMarsClient.enabled():
+            return StandaloneMarsClient(self.log)
 
         if self.prompt:
             prompt = MARSAPIKeyPrompt()

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -25,6 +25,8 @@ def _no_log(msg):
 
 
 class StandaloneMarsClient:
+    COMMAND = os.environ.get("MARS_CLIENT_COMMAND", "/usr/local/bin/mars")
+
     def __init__(self, log="default"):
         self.log = log
 
@@ -52,23 +54,17 @@ class StandaloneMarsClient:
                 raise ValueError(f"Unsupported log type={type(self.log)}")
 
             subprocess.run(
-                [self.EXE, filename], env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"), check=True, **log
+                [self.COMMAND, filename],
+                env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"),
+                check=True,
+                **log,
             )
 
     @staticmethod
     def enabled():
-        cmd = StandaloneMarsClient.command(check=True)
-        return cmd is not None and cmd != ""
-
-    @staticmethod
-    def command(check=True):
-        cmd = os.environ.get("MARS_CLIENT_COMMAND", "/usr/local/bin/mars")
-        if check:
-            if SETTINGS.get("use-standalone-mars-client-when-available"):
-                if os.path.exists(cmd):
-                    return cmd
-        else:
-            return cmd
+        return SETTINGS.get("use-standalone-mars-client-when-available") and os.path.exists(
+            StandaloneMarsClient.COMMAND
+        )
 
 
 class MarsRetriever(ECMWFApi):

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -25,8 +25,6 @@ def _no_log(msg):
 
 
 class StandaloneMarsClient:
-    COMMAND = os.environ.get("MARS_CLIENT_COMMAND", "/usr/local/bin/mars")
-
     def __init__(self, log="default"):
         self.log = log
 
@@ -54,16 +52,20 @@ class StandaloneMarsClient:
                 raise ValueError(f"Unsupported log type={type(self.log)}")
 
             subprocess.run(
-                [self.COMMAND, filename],
+                [self.command(), filename],
                 env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"),
                 check=True,
                 **log,
             )
 
     @staticmethod
+    def command():
+        return os.environ.get("MARS_CLIENT_COMMAND", "/usr/local/bin/mars")
+
+    @staticmethod
     def enabled():
         return SETTINGS.get("use-standalone-mars-client-when-available") and os.path.exists(
-            StandaloneMarsClient.COMMAND
+            StandaloneMarsClient.command()
         )
 
 


### PR DESCRIPTION
The PR allows to specify the path to the standalone MARS client via the `MARS_CLIENT_COMMAND` environment variable. The path defaults to `/usr/local/bin/mars`