### PR TITLE
Feature/geo as optional dependency

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,6 +45,7 @@ Alternatively, you can install the following components:
     - fdb: provides access to the :ref:`data-sources-fdb` source
     - polytope: provides access to the :ref:`data-sources-polytope` source
     - odb: provides full support for the :ref:`odb` data type
+    - geo: enables to use Field.points_unrotated()
     - geopandas: adds GeoJSON/GeoPandas support
     - projection: adds projection support
     - covjsonkit: provides access to CoverageJSON data served by the :ref:`data-sources-polytope` source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "array-api-compat",
   "cfgrib>=0.9.10.1",
   "dask",
-  "earthkit-geo>=0.2",
   "earthkit-meteo>=0.0.1",
   "eccodes>=1.7",
   "entrypoints",
@@ -50,6 +49,7 @@ optional-dependencies.all = [
   "cartopy",
   "cdsapi>=0.7.2",
   "covjsonkit>=0.0.28",
+  "earthkit-geo>=0.2",
   "ecmwf-api-client>=1.6.1",
   "ecmwf-opendata>=0.3.3",
   "geopandas",
@@ -66,6 +66,7 @@ optional-dependencies.dev = [
   "cdsapi>=0.7.2",
   "covjsonkit>=0.0.28",
   "earthkit-data-demo-source",
+  "earthkit-geo>=0.2",
   "ecmwf-api-client>=1.6.1",
   "ecmwf-opendata>=0.3.3",
   "geopandas",
@@ -92,6 +93,7 @@ optional-dependencies.docs = [
 ]
 optional-dependencies.ecmwf-opendata = [ "ecmwf-opendata>=0.3.3" ]
 optional-dependencies.fdb = [ "pyfdb>=0.1" ]
+optional-dependencies.geo = [ "earthkit-geo>=0.2" ]
 optional-dependencies.geopandas = [ "geopandas" ]
 optional-dependencies.geotiff = [ "pyproj", "rasterio", "rioxarray" ]
 optional-dependencies.mars = [ "ecmwf-api-client>=1.6.1" ]

--- a/src/earthkit/data/readers/grib/metadata.py
+++ b/src/earthkit/data/readers/grib/metadata.py
@@ -223,7 +223,12 @@ class GribFieldGeography(Geography):
             return self.latitudes(**kwargs)
 
         if not self.rotated_iterator:
-            from earthkit.geo.rotate import unrotate
+            try:
+                from earthkit.geo.rotate import unrotate
+            except ImportError:
+                raise ImportError(
+                    "GribFieldGeography.latitudes_unrotated requires 'earthkit-geo' to be installed"
+                )
 
             grid_type = self.metadata.get("gridType")
             warnings.warn(f"ecCodes does not support rotated iterator for {grid_type}")
@@ -240,7 +245,12 @@ class GribFieldGeography(Geography):
             return self.longitudes(**kwargs)
 
         if not self.rotated_iterator:
-            from earthkit.geo.rotate import unrotate
+            try:
+                from earthkit.geo.rotate import unrotate
+            except ImportError:
+                raise ImportError(
+                    "GribFieldGeography.longitudes_unrotated requires 'earthkit-geo' to be installed"
+                )
 
             grid_type = self.metadata.get("gridType")
             warnings.warn(f"ecCodes does not support rotated iterator for {grid_type}")

--- a/src/earthkit/data/testing.py
+++ b/src/earthkit/data/testing.py
@@ -133,6 +133,7 @@ if not NO_CUPY:
         NO_CUPY = True
 
 NO_S3_AUTH = not modules_installed("aws_requests_auth")
+NO_GEO = not modules_installed("earthkit-data")
 
 
 def MISSING(*modules):

--- a/tests/grib/test_grib_geography.py
+++ b/tests/grib/test_grib_geography.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import earthkit.data
+from earthkit.data.testing import NO_GEO
 from earthkit.data.testing import check_array_type
 from earthkit.data.testing import earthkit_examples_file
 from earthkit.data.testing import earthkit_test_data_file
@@ -291,6 +292,7 @@ def test_grib_mars_grid(path, expected_value):
         assert np.allclose(np.asarray(ds[0].mars_grid), np.asarray(expected_value))
 
 
+@pytest.mark.skipif(NO_GEO, reason="No earthkit-geo support")
 def test_grib_grid_points_rotated_ll():
     """The"""
     ds = earthkit.data.from_source("file", earthkit_test_data_file("rotated_wind_20x20.grib"))
@@ -320,6 +322,7 @@ def test_grib_grid_points_rotated_ll():
     assert np.allclose(res[1], ref[1])
 
 
+@pytest.mark.skipif(NO_GEO, reason="No earthkit-geo support")
 def test_grib_grid_points_rotated_rgg():
     ds = earthkit.data.from_source("file", earthkit_test_data_file("rotated_N32_subarea.grib"))
 


### PR DESCRIPTION
This PR makes `earthkit-geo` an optional dependency.  To install it we need to use:

```bash
pip install earthkit-data[geo]
```

It is also installed with:

```bash
pip install earthkit-data[all]
```

`earthkit-geo` is currently only used for the `Field.points_unrotated()` method.