### PR TITLE
Add array_api to top level

### DIFF
--- a/src/earthkit/data/__init__.py
+++ b/src/earthkit/data/__init__.py
@@ -28,6 +28,7 @@ from .sources import Source
 from .sources import from_source
 from .sources import from_source_lazily
 from .sources.array_list import ArrayField
+from .utils import array as array_api
 from .utils.examples import download_example_file
 from .utils.examples import remote_example_file
 
@@ -35,6 +36,7 @@ settings = config
 
 __all__ = [
     "ALL",
+    "array_api",
     "ArrayField",
     "cache",
     "download_example_file",


### PR DESCRIPTION
Add `.utils.array` as `array_api` to top level.

```python
from earthkit.data import array_api
 
an = array_api.get_backend(mask).module

```

Will allow for easier utilisation of the array api backends.