### PR TITLE
feat: support string format specification for output file path template

### DIFF
--- a/src/earthkit/data/readers/grib/output.py
+++ b/src/earthkit/data/readers/grib/output.py
@@ -451,7 +451,8 @@ class GribOutput:
             return self.fileobj, None
 
         if self.split_output:
-            path = self.filename.format(**{k: handle.get(k) for k in self.split_output})
+            keys = {k.split(":")[0]: handle.get(k.split(":")[0]) for k in self.split_output}
+            path = self.filename.format(**keys)
         else:
             path = self.filename
 

--- a/tests/grib/test_grib_output.py
+++ b/tests/grib/test_grib_output.py
@@ -332,6 +332,7 @@ def test_grib_output_field_template(array):
         ("{shortName}", {"t": 2, "u": 2, "v": 2}),
         ("{shortName}_{level}", {"t_1000": 1, "t_850": 1, "u_1000": 1, "u_850": 1, "v_1000": 1, "v_850": 1}),
         ("{date}_{time}_{step}", {"20180801_1200_0": 6}),
+        ("{date}_{time}_{step:03}", {"20180801_1200_000": 6}),
     ],
 )
 def test_grib_output_filename_pattern(pattern, expected_value):


### PR DESCRIPTION
# Purpose
Earthkit data currently allows specifying an output file name template such as `"output/{date}-{time}-{step}.grib2"`. In some cases, users might want to add some format specifiers, for instance zero-padding for the `step` value, like so: `"output/{date}-{time}-{step:03}.grib2"`. 

# Code changes
After the regex groups are extracted from the template string, split them with `:` and take the first element to get the values from the handles. 