### PR TITLE
feat: add strftimedelta pattern

### DIFF
--- a/src/earthkit/data/utils/patterns.py
+++ b/src/earthkit/data/utils/patterns.py
@@ -75,11 +75,14 @@ class DatetimeDelta:
 
     def substitute(self, value, name):
         sign = -1 if self.delta[0] == "-" else 1
-        search_delta = re.search(r"\d(.*)", self.delta)
-        if search_delta:
-            delta = search_delta.group(0)
+        if re.fullmatch(r"[-\+]?\d+[hms]?", self.delta):
+            delta = re.search(r"\d+[hms]?", self.delta).group(0)
         else:
-            raise ValueError("Invalid value '{}' for delta, expected a number".format(self.delta))
+            raise ValueError(
+                "Invalid value '{}' for delta, expected time in hour (h), minute (m) or second (s)".format(
+                    self.delta
+                )
+            )
 
         valid_date = to_datetime(value) + sign * to_timedelta(delta)
         return valid_date.strftime(self.format)

--- a/src/earthkit/data/utils/patterns.py
+++ b/src/earthkit/data/utils/patterns.py
@@ -11,6 +11,7 @@ import itertools
 import re
 
 from .dates import to_datetime
+from .dates import to_timedelta
 
 RE1 = re.compile(r"{([^}]*)}")
 RE2 = re.compile(r"\(([^}]*)\)")
@@ -62,6 +63,28 @@ class Datetime:
         return to_datetime(value).strftime(self.format)
 
 
+class DatetimeDelta:
+    def __init__(self, params):
+        params_list = params.split(";")
+        if len(params_list) != 2:
+            raise ValueError(
+                "Invalid parameters '{}' for class DatetimeDelta, expected (delta;format)".format(params)
+            )
+        self.delta = params_list[0].strip()
+        self.format = params_list[1].strip()
+
+    def substitute(self, value, name):
+        sign = -1 if self.delta[0] == "-" else 1
+        search_delta = re.search(r"\d(.*)", self.delta)
+        if search_delta:
+            delta = search_delta.group(0)
+        else:
+            raise ValueError("Invalid value '{}' for delta, expected a number".format(self.delta))
+
+        valid_date = to_datetime(value) + sign * to_timedelta(delta)
+        return valid_date.strftime(self.format)
+
+
 class Str:
     def __init__(self, format="%s"):
         self.format = format
@@ -78,6 +101,7 @@ TYPES = {
     "float": Float,
     "date": Datetime,
     "strftime": Datetime,
+    "strftimedelta": DatetimeDelta,
     "enum": Enum,
 }
 

--- a/tests/utils/test_patterns.py
+++ b/tests/utils/test_patterns.py
@@ -26,6 +26,16 @@ from earthkit.data.utils.patterns import Pattern
             {"my_date": datetime.datetime(2020, 5, 13), "name": ["t2", "msl"]},
             ["test_2020-05-13_t2.grib", "test_2020-05-13_msl.grib"],
         ),
+        (
+            "test_{date:strftimedelta(-6;%Y-%m-%d_%H)}.grib",
+            {"date": [datetime.datetime(2020, 5, 11), datetime.datetime(2020, 5, 11, 6)]},
+            ["test_2020-05-10_18.grib", "test_2020-05-11_00.grib"],
+        ),
+        (
+            "test_{date:strftimedelta(60m;%Y-%m-%d_%H)}.grib",
+            {"date": [datetime.datetime(2020, 5, 11), datetime.datetime(2020, 5, 11, 6)]},
+            ["test_2020-05-11_01.grib", "test_2020-05-11_07.grib"],
+        ),
     ],
 )
 def test_pattern_core(pattern, values, expected_value):


### PR DESCRIPTION
Suggestion for a new pattern type to support passing a date with a timedelta. The syntax would look as the following.

```py
Pattern("/path/to/data/{date:strftimedelta(-6h;%Y%m%d)}{date:strftimedelta(-6h;%H)}_006")
```

Would allow an easier selection of data at validity time in forecast files.