### PR TITLE
Add GeoTIFF encoder and tweak default kwargs when opening

### DIFF
--- a/docs/examples/geotiff.ipynb
+++ b/docs/examples/geotiff.ipynb
@@ -15,7 +15,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "id": "f3aafecd-7698-49a0-abce-fd36d06c645e",
    "metadata": {
     "editable": true,
@@ -226,6 +226,39 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0a7d8a88",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Projected CRS: +proj=tmerc +ellps=WGS84 +a=6378137.0 +b=6356752.3 ...>\n",
+       "Name: unknown\n",
+       "Axis Info [cartesian]:\n",
+       "- E[east]: Easting (metre)\n",
+       "- N[north]: Northing (metre)\n",
+       "Area of Use:\n",
+       "- undefined\n",
+       "Coordinate Operation:\n",
+       "- name: unknown\n",
+       "- method: Transverse Mercator\n",
+       "Datum: Unknown based on GRS 1980 ellipsoid\n",
+       "- Ellipsoid: GRS 1980\n",
+       "- Prime Meridian: Greenwich"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.projection()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f1b8c839-92f6-472e-80f0-3a992142f384",
    "metadata": {
@@ -241,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "e15881a3-16da-4337-8479-c1bf6075387c",
    "metadata": {
     "editable": true,
@@ -623,22 +656,23 @@
        "  stroke: currentColor;\n",
        "  fill: currentColor;\n",
        "}\n",
-       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.DataArray (band: 3, y: 294, x: 315)&gt; Size: 278kB\n",
-       "[277830 values with dtype=uint8]\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 1MB\n",
+       "Dimensions:      (x: 315, y: 294)\n",
        "Coordinates:\n",
-       "  * band         (band) int64 24B 1 2 3\n",
        "  * x            (x) float64 3kB 3.68e+05 3.681e+05 ... 3.839e+05 3.84e+05\n",
        "  * y            (y) float64 2kB 5.632e+06 5.632e+06 ... 5.616e+06 5.616e+06\n",
        "    spatial_ref  int64 8B 0\n",
+       "Data variables:\n",
+       "    band_1       (y, x) float32 370kB ...\n",
+       "    band_2       (y, x) float32 370kB ...\n",
+       "    band_3       (y, x) float32 370kB ...\n",
        "Attributes:\n",
-       "    AREA_OR_POINT:           Area\n",
-       "    TIFFTAG_RESOLUTIONUNIT:  2 (pixels/inch)\n",
        "    TIFFTAG_XRESOLUTION:     96\n",
        "    TIFFTAG_YRESOLUTION:     96\n",
-       "    scale_factor:            1.0\n",
-       "    add_offset:              0.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'></div><ul class='xr-dim-list'><li><span class='xr-has-index'>band</span>: 3</li><li><span class='xr-has-index'>y</span>: 294</li><li><span class='xr-has-index'>x</span>: 315</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-7b8064e3-32bb-4904-a73e-27b15ecb6c5b' class='xr-array-in' type='checkbox' checked><label for='section-7b8064e3-32bb-4904-a73e-27b15ecb6c5b' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>...</span></div><div class='xr-array-data'><pre>[277830 values with dtype=uint8]</pre></div></div></li><li class='xr-section-item'><input id='section-2be931e2-f5ae-4704-8c90-85c6418ae491' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2be931e2-f5ae-4704-8c90-85c6418ae491' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>1 2 3</div><input id='attrs-cbd97f10-231e-4f13-bfba-98ccc15a87a5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cbd97f10-231e-4f13-bfba-98ccc15a87a5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-487aa74b-4230-4455-9bbf-7323f38f94a0' class='xr-var-data-in' type='checkbox'><label for='data-487aa74b-4230-4455-9bbf-7323f38f94a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([1, 2, 3])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.68e+05 3.681e+05 ... 3.84e+05</div><input id='attrs-b08c16d0-6d47-408a-8bd0-f2ca0455199c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b08c16d0-6d47-408a-8bd0-f2ca0455199c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98380a4f-53a4-4acc-9893-bddbf788d46d' class='xr-var-data-in' type='checkbox'><label for='data-98380a4f-53a4-4acc-9893-bddbf788d46d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([368025.396825, 368076.190476, 368126.984127, ..., 383873.015873,\n",
-       "       383923.809524, 383974.603175])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.632e+06 5.632e+06 ... 5.616e+06</div><input id='attrs-9efaab25-6bfb-4df4-aeb7-f088a08d7a64' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9efaab25-6bfb-4df4-aeb7-f088a08d7a64' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85c69098-8866-4dd5-a98b-90d88d16d278' class='xr-var-data-in' type='checkbox'><label for='data-85c69098-8866-4dd5-a98b-90d88d16d278' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5631972.789116, 5631918.367347, 5631863.945578, ..., 5616136.054422,\n",
-       "       5616081.632653, 5616027.210884])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-195f59ec-e061-41f2-ba2c-db43d3349f81' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-195f59ec-e061-41f2-ba2c-db43d3349f81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e384e1c1-a781-4b32-a6ba-c9235212ab51' class='xr-var-data-in' type='checkbox'><label for='data-e384e1c1-a781-4b32-a6ba-c9235212ab51' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCS[&quot;ETRS89 / UTM zone 32N&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;latitude_of_origin&quot;,0],PARAMETER[&quot;central_meridian&quot;,9],PARAMETER[&quot;scale_factor&quot;,0.9996],PARAMETER[&quot;false_easting&quot;,500000],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;25832&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314140356</dd><dt><span>inverse_flattening :</span></dt><dd>298.257222101</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>GRS 1980</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>ETRS89</dd><dt><span>horizontal_datum_name :</span></dt><dd>European Terrestrial Reference System 1989</dd><dt><span>projected_crs_name :</span></dt><dd>ETRS89 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;ETRS89 / UTM zone 32N&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;latitude_of_origin&quot;,0],PARAMETER[&quot;central_meridian&quot;,9],PARAMETER[&quot;scale_factor&quot;,0.9996],PARAMETER[&quot;false_easting&quot;,500000],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;25832&quot;]]</dd><dt><span>GeoTransform :</span></dt><dd>368000.0 50.793650793650926 0.0 5632000.0 0.0 -54.4217687074807</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a762514d-6cf1-4003-a45b-8917a372aeb1' class='xr-section-summary-in' type='checkbox'  ><label for='section-a762514d-6cf1-4003-a45b-8917a372aeb1' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-aec6e155-0463-43cd-b2a9-2c2de10cf6a2' class='xr-index-data-in' type='checkbox'/><label for='index-aec6e155-0463-43cd-b2a9-2c2de10cf6a2' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([1, 2, 3], dtype=&#x27;int64&#x27;, name=&#x27;band&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ed964c1c-885c-4e0e-8aa2-510bb2f82ae6' class='xr-index-data-in' type='checkbox'/><label for='index-ed964c1c-885c-4e0e-8aa2-510bb2f82ae6' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 368025.3968253968,  368076.1904761905,  368126.9841269841,\n",
+       "    TIFFTAG_RESOLUTIONUNIT:  2 (pixels/inch)\n",
+       "    AREA_OR_POINT:           Area</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1662ab25-348c-4be9-9fc9-51d7ab868120' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1662ab25-348c-4be9-9fc9-51d7ab868120' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>x</span>: 315</li><li><span class='xr-has-index'>y</span>: 294</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b7a8f060-f5c1-45af-a3bb-bf25b2844b72' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b7a8f060-f5c1-45af-a3bb-bf25b2844b72' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>3.68e+05 3.681e+05 ... 3.84e+05</div><input id='attrs-57974df0-ef70-4a72-9ec7-abc323b6b43b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-57974df0-ef70-4a72-9ec7-abc323b6b43b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f6e5f085-e459-484d-8439-53bf038fb7c3' class='xr-var-data-in' type='checkbox'><label for='data-f6e5f085-e459-484d-8439-53bf038fb7c3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([368025.396825, 368076.190476, 368126.984127, ..., 383873.015873,\n",
+       "       383923.809524, 383974.603175])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.632e+06 5.632e+06 ... 5.616e+06</div><input id='attrs-4fa2c1a5-9afe-420b-9748-1b0fba46c023' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4fa2c1a5-9afe-420b-9748-1b0fba46c023' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-98427afb-01f3-4c62-82c3-d6fd196a1a66' class='xr-var-data-in' type='checkbox'><label for='data-98427afb-01f3-4c62-82c3-d6fd196a1a66' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5631972.789116, 5631918.367347, 5631863.945578, ..., 5616136.054422,\n",
+       "       5616081.632653, 5616027.210884])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-5a653ce4-5738-474b-832e-219b96e03545' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5a653ce4-5738-474b-832e-219b96e03545' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a5f0bc26-a6ad-472e-925f-08aa64911715' class='xr-var-data-in' type='checkbox'><label for='data-a5f0bc26-a6ad-472e-925f-08aa64911715' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCS[&quot;ETRS89 / UTM zone 32N&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;latitude_of_origin&quot;,0],PARAMETER[&quot;central_meridian&quot;,9],PARAMETER[&quot;scale_factor&quot;,0.9996],PARAMETER[&quot;false_easting&quot;,500000],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;25832&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314140356</dd><dt><span>inverse_flattening :</span></dt><dd>298.257222101</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>GRS 1980</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>ETRS89</dd><dt><span>horizontal_datum_name :</span></dt><dd>European Terrestrial Reference System 1989</dd><dt><span>projected_crs_name :</span></dt><dd>ETRS89 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;ETRS89 / UTM zone 32N&quot;,GEOGCS[&quot;ETRS89&quot;,DATUM[&quot;European_Terrestrial_Reference_System_1989&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;latitude_of_origin&quot;,0],PARAMETER[&quot;central_meridian&quot;,9],PARAMETER[&quot;scale_factor&quot;,0.9996],PARAMETER[&quot;false_easting&quot;,500000],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;25832&quot;]]</dd><dt><span>GeoTransform :</span></dt><dd>368000.0 50.793650793650926 0.0 5632000.0 0.0 -54.4217687074807</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5a167a70-1339-4d65-8e49-4708c1eba2f2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5a167a70-1339-4d65-8e49-4708c1eba2f2' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>band_1</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f3283700-76aa-493e-a749-e4e1c8ee835c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f3283700-76aa-493e-a749-e4e1c8ee835c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-81ed0043-081c-428b-973b-b49149fc65ca' class='xr-var-data-in' type='checkbox'><label for='data-81ed0043-081c-428b-973b-b49149fc65ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[92610 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_2</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ca96edc5-44b2-4d5c-9312-5a601f306183' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ca96edc5-44b2-4d5c-9312-5a601f306183' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c60c65ae-c831-438c-9189-f7bb018f683c' class='xr-var-data-in' type='checkbox'><label for='data-c60c65ae-c831-438c-9189-f7bb018f683c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[92610 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>band_3</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-44fdd877-0d26-4b65-8f07-1dd2e00093a6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-44fdd877-0d26-4b65-8f07-1dd2e00093a6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-675d9d29-45b6-46fe-bf6c-e892f59b66aa' class='xr-var-data-in' type='checkbox'><label for='data-675d9d29-45b6-46fe-bf6c-e892f59b66aa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>[92610 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7842134d-7a33-4bcf-a158-0a6785660f95' class='xr-section-summary-in' type='checkbox'  ><label for='section-7842134d-7a33-4bcf-a158-0a6785660f95' class='xr-section-summary' >Indexes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-3e1fb65d-9424-4146-88d3-70e874bfe3ad' class='xr-index-data-in' type='checkbox'/><label for='index-3e1fb65d-9424-4146-88d3-70e874bfe3ad' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 368025.3968253968,  368076.1904761905,  368126.9841269841,\n",
        "       368177.77777777775,  368228.5714285714,  368279.3650793651,\n",
        "        368330.1587301587, 368380.95238095237, 368431.74603174604,\n",
        "       368482.53968253965,\n",
@@ -647,7 +681,7 @@
        "        383669.8412698413,  383720.6349206349,  383771.4285714286,\n",
        "       383822.22222222225,  383873.0158730159,  383923.8095238095,\n",
        "        383974.6031746032],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=315))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-e09d708c-47f2-4a23-8d57-38dff5cafc49' class='xr-index-data-in' type='checkbox'/><label for='index-e09d708c-47f2-4a23-8d57-38dff5cafc49' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 5631972.789115646,  5631918.367346939,  5631863.945578231,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=315))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-b0366cc7-c984-4c81-834a-62702741e352' class='xr-index-data-in' type='checkbox'/><label for='index-b0366cc7-c984-4c81-834a-62702741e352' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 5631972.789115646,  5631918.367346939,  5631863.945578231,\n",
        "        5631809.523809523,  5631755.102040816,  5631700.680272109,\n",
        "        5631646.258503401, 5631591.8367346935,  5631537.414965986,\n",
        "        5631482.993197279,\n",
@@ -656,26 +690,27 @@
        "        5616353.741496599,  5616299.319727891,  5616244.897959184,\n",
        "        5616190.476190477,  5616136.054421769,  5616081.632653061,\n",
        "        5616027.210884354],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=294))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-bc113630-6574-4829-bf6c-146e83bf7daa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bc113630-6574-4829-bf6c-146e83bf7daa' class='xr-section-summary' >Attributes: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd><dt><span>TIFFTAG_RESOLUTIONUNIT :</span></dt><dd>2 (pixels/inch)</dd><dt><span>TIFFTAG_XRESOLUTION :</span></dt><dd>96</dd><dt><span>TIFFTAG_YRESOLUTION :</span></dt><dd>96</dd><dt><span>scale_factor :</span></dt><dd>1.0</dd><dt><span>add_offset :</span></dt><dd>0.0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=294))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-21eecde6-94e9-409b-b5ce-0ee2892fe8bb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-21eecde6-94e9-409b-b5ce-0ee2892fe8bb' class='xr-section-summary' >Attributes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>TIFFTAG_XRESOLUTION :</span></dt><dd>96</dd><dt><span>TIFFTAG_YRESOLUTION :</span></dt><dd>96</dd><dt><span>TIFFTAG_RESOLUTIONUNIT :</span></dt><dd>2 (pixels/inch)</dd><dt><span>AREA_OR_POINT :</span></dt><dd>Area</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
-       "<xarray.DataArray (band: 3, y: 294, x: 315)> Size: 278kB\n",
-       "[277830 values with dtype=uint8]\n",
+       "<xarray.Dataset> Size: 1MB\n",
+       "Dimensions:      (x: 315, y: 294)\n",
        "Coordinates:\n",
-       "  * band         (band) int64 24B 1 2 3\n",
        "  * x            (x) float64 3kB 3.68e+05 3.681e+05 ... 3.839e+05 3.84e+05\n",
        "  * y            (y) float64 2kB 5.632e+06 5.632e+06 ... 5.616e+06 5.616e+06\n",
        "    spatial_ref  int64 8B 0\n",
+       "Data variables:\n",
+       "    band_1       (y, x) float32 370kB ...\n",
+       "    band_2       (y, x) float32 370kB ...\n",
+       "    band_3       (y, x) float32 370kB ...\n",
        "Attributes:\n",
-       "    AREA_OR_POINT:           Area\n",
-       "    TIFFTAG_RESOLUTIONUNIT:  2 (pixels/inch)\n",
        "    TIFFTAG_XRESOLUTION:     96\n",
        "    TIFFTAG_YRESOLUTION:     96\n",
-       "    scale_factor:            1.0\n",
-       "    add_offset:              0.0"
+       "    TIFFTAG_RESOLUTIONUNIT:  2 (pixels/inch)\n",
+       "    AREA_OR_POINT:           Area"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -685,8 +720,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "0c28b67f-a6fa-4a47-aaa4-032f9c03e9f9",
    "metadata": {
     "editable": true,
@@ -695,15 +729,67 @@
     },
     "tags": []
    },
-   "outputs": [],
-   "source": []
+   "source": [
+    "Each band is loaded into its own variable and masking and scaling is applied by default.\n",
+    "Values from the bands are therefore returned as floats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9cfb0203",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Frozen({'band_1': dtype('float32'), 'band_2': dtype('float32'), 'band_3': dtype('float32')})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.to_xarray().dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f103acbe",
+   "metadata": {},
+   "source": [
+    "To obtain a dataset without this type conversion applied, specify `mask_and_scale=False` explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8a6cf45c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Frozen({'band_1': dtype('uint8'), 'band_2': dtype('uint8'), 'band_3': dtype('uint8')})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.to_xarray(mask_and_scale=False).dtypes"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev_ecc",
+   "display_name": "earthkit-data",
    "language": "python",
-   "name": "dev_ecc"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -715,7 +801,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/src/earthkit/data/encoders/__init__.py
+++ b/src/earthkit/data/encoders/__init__.py
@@ -20,6 +20,7 @@ LOG = logging.getLogger(__name__)
 _SUFFIXES = {
     (".grib", ".grb", "grib1", "grib2"): "grib",
     (".nc", ".nc3", ".nc4", ".netcdf"): "netcdf",
+    (".tiff", ".tif"): "geotiff",
 }
 
 

--- a/src/earthkit/data/encoders/geotiff.py
+++ b/src/earthkit/data/encoders/geotiff.py
@@ -1,0 +1,63 @@
+# (C) Copyright 2022 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import logging
+
+from . import EncodedData
+from . import Encoder
+
+LOG = logging.getLogger(__name__)
+
+
+class GeoTIFFEncodedData(EncodedData):
+
+    _GDAL_DRIVER = "GTiff"
+
+    def __init__(self, ds):
+        self.ds = ds
+
+    def to_bytes(self):
+        import rasterio.io
+
+        m = rasterio.io.MemoryFile
+        self.ds.rio.to_raster(m, driver=self._GDAL_DRIVER)
+        return m.getbuffer()
+
+    def to_file(self, f):
+        self.ds.rio.to_raster(f, driver=self._GDAL_DRIVER)
+
+    def metadata(self, key):
+        raise NotImplementedError
+
+
+class GeoTIFFEncoder(Encoder):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def encode(self, data, **kwargs):
+        if data is None:
+            raise ValueError("No data to encode")
+
+        from ..wrappers import get_wrapper
+
+        data = get_wrapper(data)
+        return data._encode(self, **kwargs)
+
+    def _encode(self, data, **kwargs):
+        return GeoTIFFEncodedData(data.to_xarray())
+
+    def _encode_field(self, field, **kwargs):
+        return self._encode(field, **kwargs)
+
+    def _encode_fieldlist(self, fieldlist, **kwargs):
+        return self._encode(fieldlist, **kwargs)
+
+
+encoder = GeoTIFFEncoder

--- a/src/earthkit/data/encoders/geotiff.py
+++ b/src/earthkit/data/encoders/geotiff.py
@@ -22,15 +22,20 @@ class GeoTIFFEncodedData(EncodedData):
     def __init__(self, ds):
         self.ds = ds
 
-    def to_bytes(self):
+    def to_bytes(self, **kwargs):
         import rasterio.io
 
-        m = rasterio.io.MemoryFile
-        self.ds.rio.to_raster(m, driver=self._GDAL_DRIVER)
+        m = rasterio.io.MemoryFile()
+        self._to_raster(m, **kwargs)
         return m.getbuffer()
 
-    def to_file(self, f):
-        self.ds.rio.to_raster(f, driver=self._GDAL_DRIVER)
+    def to_file(self, f, **kwargs):
+        self._to_raster(f, **kwargs)
+
+    def _to_raster(self, dst, **kwargs):
+        options = {"driver": self._GDAL_DRIVER}
+        options.update(kwargs)
+        self.ds.rio.to_raster(dst, **options)
 
     def metadata(self, key):
         raise NotImplementedError
@@ -51,7 +56,14 @@ class GeoTIFFEncoder(Encoder):
         return data._encode(self, **kwargs)
 
     def _encode(self, data, **kwargs):
-        return GeoTIFFEncodedData(data.to_xarray())
+        ds = data.to_xarray()
+        if ds.rio.crs is None:
+            crs = data.projection().to_cartopy_crs()
+            ds.rio.write_crs(crs, inplace=True)
+        for var in ds.data_vars:
+            if "_earthkit" in ds[var].attrs:
+                del ds[var].attrs["_earthkit"]
+        return GeoTIFFEncodedData(ds)
 
     def _encode_field(self, field, **kwargs):
         return self._encode(field, **kwargs)

--- a/src/earthkit/data/readers/geotiff.py
+++ b/src/earthkit/data/readers/geotiff.py
@@ -218,12 +218,6 @@ class GeoTIFFFieldList(FieldList):
     def describe(self, *args, **kwargs):
         self._not_implemented()
 
-    # def save(self, filename, append=False, **kwargs):
-    #     self._not_implemented()
-
-    # def write(self, f, **kwargs):
-    #     self._not_implemented()
-
 
 class GeoTIFFReader(GeoTIFFFieldList, Reader):
     def __init__(self, source, path):

--- a/src/earthkit/data/readers/geotiff.py
+++ b/src/earthkit/data/readers/geotiff.py
@@ -235,14 +235,11 @@ class GeoTIFFReader(GeoTIFFFieldList, Reader):
 
 
 def _match_magic(magic):
-    if magic is not None:
-        # https://docs.ogc.org/is/19-008r4/19-008r4.html#_tiff_core_test
-        # Bytes 0-1: 'II' (little endian) or 'MM' (big endian)
-        # Bytes 2-3: 42 as short in the corresponding byte order
-        # Bytes 4-7: offset to first image file directory
-        # ASCII: I = 73, M = 77, * = 42
-        return len(magic) >= 8 and magic[:4] in {b"II*\x00", b"MM\x00*"}
-    return False
+    # https://docs.ogc.org/is/19-008r4/19-008r4.html#_tiff_core_test
+    # Bytes 0-1: 'II' (little endian) or 'MM' (big endian)
+    # Bytes 2-3: 42 as short in the corresponding byte order
+    # Bytes 4-7: offset to first image file directory
+    return magic is not None and len(magic) >= 8 and magic[:4] in {b"II*\x00", b"MM\x00*"}
 
 
 def reader(source, path, *, magic=None, **kwargs):


### PR DESCRIPTION
Setting `band_as_variable` and `mask_and_scale` to `True` everywhere by default aligns better with what users likely expect as good defaults in most cases and should avoid some pitfalls in data format conversion. For now, this behaviour is documented in the example in the docs.