### PR TITLE
Fix GRIB data reading from FDB streams in multiprocessing

### DIFF
--- a/docs/release_notes/version_0.13_updates.rst
+++ b/docs/release_notes/version_0.13_updates.rst
@@ -8,7 +8,7 @@ Version 0.13.2
 Fixes
 ++++++++++
 
-- Fixed issue when could not read GRIB data from FDB streams in parallel processes (:pr:`647`)
+- Fixed issue when could not read GRIB data from FDB streams in multiprocessing (:pr:`647`)
 
 
 Version 0.13.1

--- a/docs/release_notes/version_0.13_updates.rst
+++ b/docs/release_notes/version_0.13_updates.rst
@@ -2,6 +2,15 @@ Version 0.13 Updates
 /////////////////////////
 
 
+Version 0.13.2
+===============
+
+Fixes
+++++++++++
+
+- Fixed issue when could not read GRIB data from FDB streams in parallel processes (:pr:`647`)
+
+
 Version 0.13.1
 ===============
 

--- a/src/earthkit/data/indexing/fieldlist.py
+++ b/src/earthkit/data/indexing/fieldlist.py
@@ -27,7 +27,7 @@ class SimpleFieldList(FieldList):
         return len(self.fields)
 
     def __repr__(self) -> str:
-        return f"FieldArray({len(self.fields)})"
+        return f"SimpleFieldList({len(self)})"
 
     def __getstate__(self) -> dict:
         ret = {}

--- a/src/earthkit/data/readers/grib/memory.py
+++ b/src/earthkit/data/readers/grib/memory.py
@@ -185,8 +185,7 @@ class GribFieldListInMemory(SimpleFieldList):
 
     def __init__(self, source, reader, *args, **kwargs):
         """The reader must support __next__."""
-        if source is not None:
-            self._reader = reader
+        self._reader = reader
         self._loaded = False
 
     def __len__(self):
@@ -198,6 +197,7 @@ class GribFieldListInMemory(SimpleFieldList):
         return super().__getitem__(n)
 
     def _load(self):
+        # TODO: make it thread safe
         if not self._loaded:
             self.fields = [f for f in self._reader]
             self._loaded = True

--- a/src/earthkit/data/sources/stream.py
+++ b/src/earthkit/data/sources/stream.py
@@ -43,7 +43,7 @@ class StreamMemorySource(MemoryBaseSource):
     def mutate(self):
         source = self._reader.mutate_source()
         if source not in (None, self):
-            source._parent = self
+            # source._parent = self
             return source
         return self
 


### PR DESCRIPTION
Fixes the `test_fdb` case reported in  #646.