### PR TITLE
Fix crash when chunks used in Xarray created from GRIB data

### DIFF
--- a/docs/release_notes/version_0.13_updates.rst
+++ b/docs/release_notes/version_0.13_updates.rst
@@ -2,6 +2,15 @@ Version 0.13 Updates
 /////////////////////////
 
 
+Version 0.13.7  
+===============
+
+Fixes
+++++++++++
+
+- Fixed issue when Xarray created from GRIB with chunks fails in computations  (:pr:`669`).
+
+
 Version 0.13.6
 ===============
 

--- a/docs/release_notes/version_0.13_updates.rst
+++ b/docs/release_notes/version_0.13_updates.rst
@@ -2,7 +2,7 @@ Version 0.13 Updates
 /////////////////////////
 
 
-Version 0.13.7  
+Version 0.13.7
 ===============
 
 Fixes

--- a/docs/release_notes/version_0.13_updates.rst
+++ b/docs/release_notes/version_0.13_updates.rst
@@ -8,7 +8,7 @@ Version 0.13.7
 Fixes
 ++++++++++
 
-- Fixed issue when Xarray created from GRIB with chunks fails in computations  (:pr:`669`).
+- Fixed issue when Xarray created from GRIB with chunks failed in computations  (:pr:`669`).
 
 
 Version 0.13.6

--- a/src/earthkit/data/readers/grib/index/__init__.py
+++ b/src/earthkit/data/readers/grib/index/__init__.py
@@ -264,16 +264,14 @@ class GribFieldManager:
 
     def field(self, n, create):
         if self.cache is not None:
-            if n in self.cache:
-                return self.cache[n]
-            else:
-                with self.lock:
-                    if n not in self.cache:
-                        field = create(n)
-                        self._field_created()
-                        self.cache[n] = field
-                        return field
+            with self.lock:
+                if n in self.cache:
                     return self.cache[n]
+                else:
+                    field = create(n)
+                    self._field_created()
+                    self.cache[n] = field
+                    return field
         else:
             self._field_created()
             return create(n)
@@ -319,8 +317,8 @@ class GribHandleManager:
 
     def handle(self, field, create):
         if self.policy == "cache":
+            key = (field.path, field._offset)
             with self.lock:
-                key = (field.path, field._offset)
                 if key in self.cache:
                     return self.cache[key]
                 else:
@@ -334,6 +332,7 @@ class GribHandleManager:
                     if field._handle is None:
                         field._handle = create()
                         self._handle_created()
+                    return field._handle
             return field._handle
         elif self.policy == "temporary":
             self._handle_created()

--- a/tests/xr_engine/test_xr_chunks.py
+++ b/tests/xr_engine/test_xr_chunks.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+import numpy as np
+import pytest
+
+from earthkit.data import config
+from earthkit.data import from_source
+from earthkit.data.testing import earthkit_remote_test_data_file
+
+
+@pytest.mark.cache
+@pytest.mark.parametrize(
+    "field_policy",
+    [
+        {"grib-field-policy": "persistent"},
+        {"grib-field-policy": "temporary"},
+    ],
+)
+@pytest.mark.parametrize(
+    "handle_policy",
+    [
+        {"grib-handle-policy": "persistent"},
+        {"grib-handle-policy": "temporary"},
+        {"grib-handle-policy": "cache", "grib-handle-cache-size": 1},
+        {"grib-handle-policy": "cache", "grib-handle-cache-size": 10},
+        {"grib-handle-policy": "cache", "grib-handle-cache-size": 100},
+        {"grib-handle-policy": "cache", "grib-handle-cache-size": 300},
+    ],
+)
+@pytest.mark.parametrize(
+    "_kwargs",
+    [
+        {},
+        {"chunks": "auto"},
+        {"chunks": {"valid_time": 1}},
+        {"chunks": {"valid_time": 10}},
+        {"chunks": {"valid_time": (100, 200, 432), "latitude": (4, 5, 4), "longitude": (13, 3, 8)}},
+        {"chunks": -1},
+    ],
+)
+def test_xr_engine_chunk(field_policy, handle_policy, _kwargs):
+    with config.temporary(**field_policy, **handle_policy):
+        ds_in = from_source(
+            "url", earthkit_remote_test_data_file("test-data", "xr_engine", "date", "t2_1_year_hourly.grib")
+        )
+
+        ds = ds_in.to_xarray(time_dim_mode="valid_time", **_kwargs)
+
+        assert ds is not None
+
+        r = ds["2t"].mean("valid_time").load()
+
+        assert np.isclose(r.values.mean(), 275.9938876277779)

--- a/tests/xr_engine/test_xr_chunks.py
+++ b/tests/xr_engine/test_xr_chunks.py
@@ -18,6 +18,7 @@ from earthkit.data import from_source
 from earthkit.data.testing import earthkit_remote_test_data_file
 
 
+@pytest.mark.long_test
 @pytest.mark.cache
 @pytest.mark.parametrize(
     "field_policy",
@@ -48,7 +49,39 @@ from earthkit.data.testing import earthkit_remote_test_data_file
         {"chunks": -1},
     ],
 )
-def test_xr_engine_chunk(field_policy, handle_policy, _kwargs):
+def test_xr_engine_chunk_1(field_policy, handle_policy, _kwargs):
+    with config.temporary(**field_policy, **handle_policy):
+        ds_in = from_source(
+            "url", earthkit_remote_test_data_file("test-data", "xr_engine", "date", "t2_1_year_hourly.grib")
+        )
+
+        ds = ds_in.to_xarray(time_dim_mode="valid_time", **_kwargs)
+
+        assert ds is not None
+
+        r = ds["2t"].mean("valid_time").load()
+
+        assert np.isclose(r.values.mean(), 275.9938876277779)
+
+
+# This test is a copy of the previous one, but only using the default config
+@pytest.mark.cache
+@pytest.mark.parametrize(
+    "_kwargs",
+    [
+        {},
+        {"chunks": "auto"},
+        {"chunks": {"valid_time": 1}},
+        {"chunks": {"valid_time": 10}},
+        {"chunks": {"valid_time": (100, 200, 432), "latitude": (4, 5, 4), "longitude": (13, 3, 8)}},
+        {"chunks": -1},
+    ],
+)
+def test_xr_engine_chunk_2(_kwargs):
+    # the default settings
+    field_policy = {"grib-field-policy": "persistent"}
+    handle_policy = {"grib-handle-policy": "cache", "grib-handle-cache-size": 1}
+
     with config.temporary(**field_policy, **handle_policy):
         ds_in = from_source(
             "url", earthkit_remote_test_data_file("test-data", "xr_engine", "date", "t2_1_year_hourly.grib")


### PR DESCRIPTION
This PR fixes the following issue:

Assume the input grib contains a large number or large fields and we want to use chunking (dask) to process it as an xarray. Then the following computation crashes due to a multithreading problem:

```python
ds_in = from_source("file", "t2.grib")
ds = ds_in.to_xarray(time_dim_mode="valid_time", chunks="auto")

# this line crashes
avg = ds["2t"].mean("valid_time").load()
```