### PR TITLE
The file-pattern source does not return the expected object

### DIFF
--- a/docs/examples/files.ipynb
+++ b/docs/examples/files.ipynb
@@ -186,6 +186,14 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/cgr/git/earthkit-data/src/earthkit/data/readers/netcdf/fieldlist.py:318: FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.\n",
+      "  return xr.open_dataset(self.path_or_url)\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -508,10 +516,9 @@
     }
    ],
    "source": [
-    "\n",
-    "fs = ekd.from_source(\"file-pattern\", \"./test{id}.grib\",\n",
+    "ds = ekd.from_source(\"file-pattern\", \"./test{id}.grib\",\n",
     "                        {\"id\": [4, 6]})\n",
-    "fs.ls()"
+    "ds.ls()"
    ]
   },
   {
@@ -531,9 +538,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev_ecc",
+   "display_name": "dev",
    "language": "python",
-   "name": "dev_ecc"
+   "name": "dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -545,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/docs/release_notes/version_0.14_updates.rst
+++ b/docs/release_notes/version_0.14_updates.rst
@@ -1,6 +1,15 @@
 Version 0.14 Updates
 /////////////////////////
 
+Version 0.14.2
+===============
+
+Fixes
++++++++++++++++++
+
+- Fixed issue when the :ref:`data-sources-file-pattern` source did not return the right data object when the ``hive_partitioning`` option was set to ``False`` (:pr:`697`).
+- Fixed issue when disabling the ``add_earthkit_attrs`` option in :py:meth:`~data.readers.grib.index.GribFieldList.to_xarray` caused a crash (:pr:`696`).
+
 
 Version 0.14.1
 ===============

--- a/src/earthkit/data/sources/file_pattern.py
+++ b/src/earthkit/data/sources/file_pattern.py
@@ -97,7 +97,7 @@ class FilePattern(MultiSource):
         if self.hive_partitioning:
             return HiveFilePattern(self.pattern, self.params)
         else:
-            return self
+            return super().mutate()
 
 
 source = FilePattern

--- a/tests/sources/test_file_pattern.py
+++ b/tests/sources/test_file_pattern.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+from earthkit.data import from_source
+from earthkit.data.testing import earthkit_examples_file
+
+
+def test_file_pattern_source_grib():
+    ds = from_source("file-pattern", earthkit_examples_file("test{id}.grib"), {"id": [4, 6]})
+
+    assert len(ds) == 10
+    assert ds.metadata("param") == ["t", "z", "t", "z", "t", "u", "v", "t", "u", "v"]


### PR DESCRIPTION
This PR fixes the issue when the `file-pattern` source used with the ``hive_partitioning=False`` option did not return the expected data object (e.g. for GRIB data did not return a FieldList).