### PR TITLE
Enable converting fields with UserMetadata into Xarray

### DIFF
--- a/src/earthkit/data/indexing/fieldlist.py
+++ b/src/earthkit/data/indexing/fieldlist.py
@@ -55,7 +55,7 @@ class SimpleFieldList(FieldList):
     def to_xarray(self, *args, **kwargs):
         # TODO make it generic
         if len(self) > 0:
-            if self[0]._metadata.data_format() == "grib":
+            if self[0]._metadata.data_format() in ("grib", "dict"):
                 from earthkit.data.readers.grib.xarray import XarrayMixIn
 
                 class _C(XarrayMixIn, SimpleFieldList):

--- a/src/earthkit/data/utils/metadata/dict.py
+++ b/src/earthkit/data/utils/metadata/dict.py
@@ -180,6 +180,9 @@ class NoGeography(Geography):
     def mars_grid(self):
         raise NotImplementedError("mars_grid is not implemented for this geography")
 
+    def grid_type(self):
+        return "none"
+
 
 class UserGeography(Geography):
     def __init__(self, metadata, shape=None):
@@ -252,6 +255,9 @@ class UserGeography(Geography):
     def mars_grid(self):
         raise NotImplementedError("mars_grid is not implemented for this geography")
 
+    def grid_type(self):
+        return "_unstructured"
+
 
 class DistinctLLGeography(UserGeography):
     def __init__(self, metadata):
@@ -298,9 +304,11 @@ class DistinctLLGeography(UserGeography):
         Ni = len(self._distinct_longitudes())
         return (Nj, Ni)
 
+    def grid_type(self):
+        return "_distinct_ll"
+
 
 class RegularDistinctLLGeography(DistinctLLGeography):
-
     def dx(self):
         x = self.metadata.get("DxInDegrees", None)
         if x is None:
@@ -326,6 +334,9 @@ class RegularDistinctLLGeography(DistinctLLGeography):
     def mars_grid(self):
         return [self.dx(), self.dy()]
 
+    def grid_type(self):
+        return "_regular_ll"
+
 
 class UserMetadata(Metadata):
     ALIASES = [
@@ -342,6 +353,7 @@ class UserMetadata(Metadata):
         "valid_datetime": "valid_datetime",
         "step_timedelta": "step_timedelta",
         "param_level": "param_level",
+        "_grid_type": "gridType",
     }
 
     LS_KEYS = ["param", "level", "base_datetime", "valid_datetime", "step", "number"]
@@ -442,6 +454,11 @@ class UserMetadata(Metadata):
 
     def param_level(self):
         return f"{self.get('param')}{self.get('level', default='')}"
+
+    def _grid_type(self):
+        if "gridType" in self._data:
+            return self._data["gridType"]
+        return self.geography.grid_type()
 
     def _get_one(self, keys):
         for k in keys:

--- a/tests/xr_engine/test_xr_lod.py
+++ b/tests/xr_engine/test_xr_lod.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from earthkit.data import from_source
+
+here = os.path.dirname(__file__)
+sys.path.insert(0, here)
+from xr_engine_fixtures import compare_dims  # noqa: E402
+
+
+@pytest.fixture
+def xr_lod_latlon():
+    prototype = {
+        "latitudes": [10.0, 0.0, -10.0],
+        "longitudes": [20, 40.0],
+        "values": [1, 2, 3, 4, 5, 6],
+        "valid_datetime": "2018-08-01T09:00:00Z",
+    }
+
+    d = [
+        {"param": "t", "level": 500, **prototype},
+        {"param": "t", "level": 850, **prototype},
+        {"param": "u", "level": 500, **prototype},
+        {"param": "u", "level": 850, **prototype},
+    ]
+    ds = from_source("list-of-dicts", d)
+    return ds
+
+
+@pytest.fixture
+def xr_lod_nongeo():
+    prototype = {
+        "values": [1, 2, 3, 4, 5, 6],
+        "valid_datetime": "2018-08-01T09:00:00Z",
+    }
+
+    d = [
+        {"param": "t", "level": 500, **prototype},
+        {"param": "t", "level": 850, **prototype},
+        {"param": "u", "level": 500, **prototype},
+        {"param": "u", "level": 850, **prototype},
+    ]
+    ds = from_source("list-of-dicts", d)
+    return ds
+
+
+@pytest.fixture
+def xr_lod_forecast():
+    prototype = {
+        "latitudes": [10.0, 0.0, -10.0],
+        "longitudes": [20, 40.0],
+        "values": [1, 2, 3, 4, 5, 6],
+        "base_datetime": "2018-08-01T09:00:00Z",
+    }
+
+    d = [
+        {"param": "t", "level": 500, "step": 0, **prototype},
+        {"param": "t", "level": 500, "step": 6, **prototype},
+        {"param": "u", "level": 500, "step": 0, **prototype},
+        {"param": "u", "level": 500, "step": 6, **prototype},
+    ]
+    ds = from_source("list-of-dicts", d)
+    return ds
+
+
+def test_xr_engine_lod_latlon(xr_lod_latlon):
+    ds_in = xr_lod_latlon
+    ds = ds_in.to_xarray(time_dim_mode="raw")
+
+    assert ds is not None
+    assert ds["t"].shape == (2, 3, 2)
+    assert ds["u"].shape == (2, 3, 2)
+    assert np.allclose(ds["latitude"].values, np.array([10.0, 0.0, -10.0]))
+    assert np.allclose(ds["longitude"].values, np.array([20.0, 40.0]))
+
+
+def test_xr_engine_lod_nongeo(xr_lod_nongeo):
+    ds_in = xr_lod_nongeo
+    ds = ds_in.to_xarray(time_dim_mode="raw")
+
+    assert ds is not None
+    assert ds["t"].shape == (2, 6)
+    assert ds["u"].shape == (2, 6)
+
+    ref = np.array(
+        [
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 3, 4, 5, 6],
+        ]
+    )
+    assert np.allclose(ds["t"].values, ref)
+    assert np.allclose(ds["u"].values, ref)
+
+
+def test_xr_engine_lod_forecast(xr_lod_forecast):
+    ds_in = xr_lod_forecast
+    ds = ds_in.to_xarray(time_dim_mode="forecast")
+
+    assert ds is not None
+    assert ds["t"].shape == (2, 3, 2)
+    assert ds["u"].shape == (2, 3, 2)
+
+    dims = {"step": [np.timedelta64(0, "h"), np.timedelta64(6, "h")]}
+    compare_dims(ds, dims, order_ref_var="t")
+
+    assert np.allclose(ds["latitude"].values, np.array([10.0, 0.0, -10.0]))
+    assert np.allclose(ds["longitude"].values, np.array([20.0, 40.0]))


### PR DESCRIPTION
With this PR the examples below work:

# data with geography
```python
import earthkit.data as ekd

prototype = {
        "latitudes": [10.0, 0.0, -10.0],
        "longitudes": [20, 40.0],
        "values": [1, 2, 3, 4, 5, 6],
        "valid_datetime": "2018-08-01T09:00:00Z",
    }

d = [
        {"param": "t", "level": 500, **prototype},
        {"param": "t", "level": 850, **prototype},
        {"param": "u", "level": 500, **prototype},
        {"param": "u", "level": 850, **prototype},
    ]

ds = ekd.from_source("list-of-dicts", d)
a = ds.to_xarray()
```

# data without geography
```python
import earthkit.data as ekd

prototype = {
        "values": [1, 2, 3, 4, 5, 6],
        "valid_datetime": "2018-08-01T09:00:00Z",
    }

d = [
        {"param": "t", "level": 500, **prototype},
        {"param": "t", "level": 850, **prototype},
        {"param": "u", "level": 500, **prototype},
        {"param": "u", "level": 850, **prototype},
    ]

ds = ekd.from_source("list-of-dicts", d)
a = ds.to_xarray()
```