### PR TITLE
Remove bitmap key from geography namespace when getting GRIB metadata…

### DIFF
--- a/docs/release_notes/version_0.14_updates.rst
+++ b/docs/release_notes/version_0.14_updates.rst
@@ -1,6 +1,14 @@
 Version 0.14 Updates
 /////////////////////////
 
+Version 0.14.3
+===============
+
+Fixes
++++++++++++++++++
+
+- Fixed issue when getting GRIB metadata for the "geography" namespace caused a crash when the "bitmap" key was present in the namespace. The "bitmap" key is now ignored in the "geography" namespace.
+
 Version 0.14.2
 ===============
 

--- a/src/earthkit/data/readers/grib/codes.py
+++ b/src/earthkit/data/readers/grib/codes.py
@@ -191,6 +191,7 @@ class GribCodesHandle(CodesHandle):
             "latitudes",
             "longitudes",
             "values",
+            "bitmap",
         }
         for key in self.keys(namespace=namespace):
             if key not in ignore:


### PR DESCRIPTION
… (#702)