### PR TITLE
Fix crash when getting gridSpec GRIB metadata key

### DIFF
--- a/docs/release_notes/version_0.14_updates.rst
+++ b/docs/release_notes/version_0.14_updates.rst
@@ -8,7 +8,7 @@ Version 0.14.4
 Fixes
 ++++++
 
-- Fixed issue when getting the "gridSpec" GRIB metadata key with a default value caused a crash when ecCodes 2.41.0 was used. (:pr:`720`).
+- Fixed issue when getting the "gridSpec" GRIB metadata key with a default value caused a crash when ecCodes 2.41.0 was used. (:pr:`719`).
 - Now, dependencies for GeoTIFF support are not installed when earthkit-data is installed with ``pip install earthkit-data[all]``. This step was necessary to make installation work when GDAL is not available. These dependencies need to be installed separately with ``pip install earthkit-data[geotiff]``. See :ref:`install`. (:pr:`718`).
 
 

--- a/docs/release_notes/version_0.14_updates.rst
+++ b/docs/release_notes/version_0.14_updates.rst
@@ -8,7 +8,8 @@ Version 0.14.4
 Fixes
 ++++++
 
-- Now, dependencies for GeoTIFF support are not installed when earthkit-data is installed with ``pip install earthkit-data[all]``. This step was necessary to make installation work when GDAL is not available. These dependencies need to be installed separately with ``pip install earthkit-data[geotiff]``. See :ref:`install`.
+- Fixed issue when getting the "gridSpec" GRIB metadata key with a default value caused a crash when ecCodes 2.41.0 was used. (:pr:`720`).
+- Now, dependencies for GeoTIFF support are not installed when earthkit-data is installed with ``pip install earthkit-data[all]``. This step was necessary to make installation work when GDAL is not available. These dependencies need to be installed separately with ``pip install earthkit-data[geotiff]``. See :ref:`install`. (:pr:`718`).
 
 
 Version 0.14.3

--- a/src/earthkit/data/readers/grib/codes.py
+++ b/src/earthkit/data/readers/grib/codes.py
@@ -151,6 +151,16 @@ class GribCodesHandle(CodesHandle):
             return self.get_values()
         elif name == "md5GridSection":
             return self.get_md5GridSection()
+        elif name == "gridSpec":
+            # Temporary measure because from ecCodes 2.41.0, when we ask for the gridSpec
+            # ecCodes raises a gribapi.errors.FunctionNotImplementedError exception, which is
+            # not caught by the  high level eccodes API even if a default value is provided.
+            if "default" in kwargs:
+                try:
+                    return super().get(name, ktype, **kwargs)
+                except Exception as e:
+                    if "FunctionNotImplementedError" in str(type(e)):
+                        return kwargs.get("default", None)
 
         return super().get(name, ktype, **kwargs)
 

--- a/tests/grib/test_grib_metadata.py
+++ b/tests/grib/test_grib_metadata.py
@@ -544,6 +544,13 @@ def test_grib_tilde_shortname(fl_type):
     assert f[0].metadata(namespace="parameter")["shortName"] == "106"
 
 
+def test_grib_gridspec_key():
+    ds = from_source("file", earthkit_examples_file("test.grib"))
+
+    ds[0].metadata("gridSpec", default=None)  # Should not raise an error
+    ds.metadata("gridSpec", default=None)  # Should not raise an error
+
+
 if __name__ == "__main__":
     from earthkit.data.testing import main
 


### PR DESCRIPTION
With ecCodes 2.41.0 when we get the `gridSpec` key with a `default` value an exception not caught in the high-level ecCodes Python API is raised.

```
ds[0].metadata("gridSpec", default=None)
...

... python3.11/site-packages/eccodes/highlevel/message.py:68: in get
    return self._get(name, ktype=ktype)

 gribapi.errors.FunctionNotImplementedError: Function not yet implemented
```
This PR provides a fix for it in the earthkit-data GRIB interface ensuring that:

```python
ds[0].metadata("gridSpec", default=None)
```

works with all ecCodes versions.

