### PR TITLE
docs: fix typo in xarray engine examples

### DIFF
--- a/docs/examples/xarray_engine_temporal.ipynb
+++ b/docs/examples/xarray_engine_temporal.ipynb
@@ -2072,7 +2072,7 @@
     "tags": []
    },
    "source": [
-    "When ``add_valid_time_dim=True`` it adds the coordine`valid_time` containing the valid times for all the different temporal dimensions as datetime64. When ``time_dim_mode=\"valid_time\"`` this coordinate is always added irrespective of the value of ``add_valid_time_dim``."
+    "When ``add_valid_time_coord=True`` it adds the coordinate `valid_time` containing the valid times for all the different temporal dimensions as datetime64. When ``time_dim_mode=\"valid_time\"`` this coordinate is always added irrespective of the value of ``add_valid_time_coord``."
    ]
   },
   {


### PR DESCRIPTION
### Description

This PR proposes a simple fix for a typo `add_valid_time_dim -> add_valid_time_coord` that might lead to users copy-pasting a nonexistent parameter name (as this just happened to me). :)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 