### PR TITLE
Add grid_spec to Xarray earthkit accessor

### DIFF
--- a/src/earthkit/data/utils/xarray/engine.py
+++ b/src/earthkit/data/utils/xarray/engine.py
@@ -504,6 +504,14 @@ class XarrayEarthkitDataArray(XarrayEarthkit):
         da.data = moved
         return da
 
+    @property
+    def grid_spec(self):
+        """Return the grid specification of the DataArray."""
+        try:
+            return self.metadata.gridspec
+        except Exception:
+            return None
+
 
 @xarray.register_dataset_accessor("earthkit")
 class XarrayEarthkitDataSet(XarrayEarthkit):
@@ -544,3 +552,14 @@ class XarrayEarthkitDataSet(XarrayEarthkit):
         for name, var in ds.data_vars.items():
             ds[name].data = to_device(var.data, device, *args, array_backend=array_backend, **kwargs)
         return ds
+
+    @property
+    def grid_spec(self):
+        """Return the grid specification of the DataSet."""
+        try:
+            # return grid spec of the first data variable
+            var = list(self._obj.data_vars.values())[0]
+            return var.earthkit.grid_spec
+
+        except Exception:
+            return None

--- a/tests/xr_engine/test_xr_grid.py
+++ b/tests/xr_engine/test_xr_grid.py
@@ -88,3 +88,24 @@ def test_xr_engine_add_geo_coords(add_geo_coords):
     else:
         assert "latitude" not in a.coords
         assert "longitude" not in a.coords
+
+
+@pytest.mark.cache
+def test_xr_engine_gridspec():
+    ds = from_source(
+        "url", earthkit_remote_test_data_file("test-data", "xr_engine", "grid", "reduced_gg_O32.grib1")
+    )
+
+    r = ds.to_xarray()
+
+    gs = r["r"].earthkit.grid_spec
+    assert gs["type"] == "reduced_gg"
+    assert gs["grid"] == "O32"
+
+    gs = r["t"].earthkit.grid_spec
+    assert gs["type"] == "reduced_gg"
+    assert gs["grid"] == "O32"
+
+    gs = r.earthkit.grid_spec
+    assert gs["type"] == "reduced_gg"
+    assert gs["grid"] == "O32"


### PR DESCRIPTION
This PR adds the `grid_spec` property to the Xarray `earthkit` accessor.

```python
a = ekd.from_source("file", "tr_O32.grib").to_xarray()

a["t"].earthkit.grid_spec
a.earthkit.grid_spec
```

When the gridspec is not available returns None.

Please note:
- the name is `grid_spec` and not `gridspec`. This should be reviewed/discussed
- the gridspec is generated with a temporary code in earthkit-data and most probably differs from the canonical gridspec. Once the (canonical) gridspec is available via ecCodes the gridspec code will be removed from earthkit-data and `earthkit.grid_spec` will return the canonical gridspec (fetched via ecCodes)