### PR TITLE
Rename fill to fill_metadata in to_xarray

### DIFF
--- a/docs/examples/xarray_engine_mono_variable.ipynb
+++ b/docs/examples/xarray_engine_mono_variable.ipynb
@@ -1444,7 +1444,7 @@
    "id": "7db65a70-e815-4e81-835e-2a705251355d",
    "metadata": {},
    "source": [
-    "We add the ensemble member as an additional dimension to the generated Xarray. Because the input is not ensemble data the value of the \"number\" ecCodes key can be missing. So we need to provide a meaningful default with the ``fill`` kwarg to be able to build the \"number\" dimension. "
+    "We add the ensemble member as an additional dimension to the generated Xarray. Because the input is not ensemble data the value of the \"number\" ecCodes key can be missing. So we need to provide a meaningful default with the ``fill_metadata`` kwarg to be able to build the \"number\" dimension. "
    ]
   },
   {
@@ -2137,7 +2137,7 @@
     "                     chunks={\"valid_time\": 1},                    \n",
     "                     flatten_values=True,                   \n",
     "                     add_earthkit_attrs=False,   \n",
-    "                     fill={\"number\": 0},\n",
+    "                     fill_metadata={\"number\": 0},\n",
     "                    )\n",
     "ds"
    ]

--- a/docs/release_notes/version_0.16_updates.rst
+++ b/docs/release_notes/version_0.16_updates.rst
@@ -9,7 +9,7 @@ Xarray engine
 ++++++++++++++++++++++++++++++
 
 - Implemented mono variable (single dataarray containing all the parameters from a GRIB fieldlist) in Xarray engine (:pr:`734`). See the notebook example :ref:`/examples/xarray_engine_mono_variable.ipynb`
-- Allowed specifying metadata defaults for :py:meth:`~data.readers.grib.index.GribFieldList.to_xarray` (:pr:`738`) via the ``fill`` option.See the notebook example :ref:`/examples/xarray_engine_mono_variable.ipynb`
+- Allowed specifying metadata defaults for :py:meth:`~data.readers.grib.index.GribFieldList.to_xarray` (:pr:`738`) via the ``fill_metadata`` option.See the notebook example :ref:`/examples/xarray_engine_mono_variable.ipynb`
 - Improved the Xarray support in the encoders (:pr:`750`).
 
 

--- a/src/earthkit/data/readers/grib/xarray.py
+++ b/src/earthkit/data/readers/grib/xarray.py
@@ -320,8 +320,8 @@ class XarrayMixIn:
                 (None) expands to True unless the ``profile`` overwrites it.
             * rename_attrs: dict, None
                 A dictionary of attribute to rename. Default is None.
-            * fill: dict, None
-                Define fill values to metadata keys. Default is None.
+            * fill_metadata: dict, None
+                Define fill_metadata values to metadata keys. Default is None.
             * remapping: dict, None
                 Define new metadata keys for indexing. Default is None.
             * lazy_load: bool, None

--- a/src/earthkit/data/utils/xarray/engine.py
+++ b/src/earthkit/data/utils/xarray/engine.py
@@ -47,7 +47,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
         coord_attrs=None,
         add_earthkit_attrs=None,
         rename_attrs=None,
-        fill=None,
+        fill_metadata=None,
         remapping=None,
         flatten_values=None,
         lazy_load=None,
@@ -282,7 +282,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
             (None) expands to True unless the ``profile`` overwrites it.
         rename_attrs: dict, None
             A dictionary of attribute to rename. Default is None.
-        fill: dict, None
+        fill_metadata: dict, None
             Define fill values to metadata keys. Default is None.
         remapping: dict, None
             Define new metadata keys for indexing. Default is None.
@@ -352,7 +352,7 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
                 add_valid_time_coord=add_valid_time_coord,
                 add_geo_coords=add_geo_coords,
                 flatten_values=flatten_values,
-                fill=fill,
+                fill_metadata=fill_metadata,
                 remapping=remapping,
                 decode_times=decode_times,
                 decode_timedelta=decode_timedelta,

--- a/src/earthkit/data/utils/xarray/profile.py
+++ b/src/earthkit/data/utils/xarray/profile.py
@@ -186,7 +186,7 @@ class MonoVariable(ProfileVariable):
 
 
 class Profile:
-    USER_ONLY_OPTIONS = ["remapping", "patches", "fill"]
+    USER_ONLY_OPTIONS = ["remapping", "patches", "fill_metadata"]
     DEFAULT_PROFILE_NAME = "mars"
 
     def __init__(
@@ -204,10 +204,10 @@ class Profile:
         patches = dict()
 
         # defaults
-        fill_md = kwargs.pop("fill", None)
+        fill_md = kwargs.pop("fill_metadata", None)
         if fill_md:
             if not isinstance(fill_md, dict):
-                raise ValueError("fill must be a dict!")
+                raise ValueError("fill_metadata must be a dict!")
             for k, v in fill_md.items():
                 if isinstance(v, (str, int, float, bool)):
                     patches[k] = lambda x: x if x is not None else v

--- a/tests/xr_engine/test_xr_ens.py
+++ b/tests/xr_engine/test_xr_ens.py
@@ -74,7 +74,7 @@ def test_xr_number_dim_missing():
         "url", earthkit_remote_test_data_file("test-data", "xr_engine", "date", "t2_td2_1_year.grib")
     )
 
-    ds = ds_ek[10].to_xarray(time_dim_mode="valid_time", ensure_dims="number", fill={"number": 10})
+    ds = ds_ek[10].to_xarray(time_dim_mode="valid_time", ensure_dims="number", fill_metadata={"number": 10})
     assert ds is not None
 
     dims = {"number": [10]}


### PR DESCRIPTION
### Description

Rename the `fill` option (added in #738) to `fill_metadata` in `to_xarray()`
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 