### PR TITLE
Bump earthkit-utils to 0.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - earthkit-meteo>=0.0.1
   - covjsonkit>=0.1.1
   - earthkit-geo>=0.2.0
-  - earthkit-utils>=0.0.1
+  - earthkit-utils>=0.1.0
 - tqdm>=4.63.0
 - lru-dict
 - markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "dask",
   "deprecation",
   "earthkit-meteo>=0.0.1",
-  "earthkit-utils>=0.0.1",
+  "earthkit-utils>=0.1",
   "eccodes>=1.7",
   "entrypoints",
   "filelock",

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -32,7 +32,7 @@ dependencies:
   - git+https://github.com/ecmwf/earthkit-data-demo-source
   - covjsonkit>=0.1.1
   - earthkit-geo>=0.2.0
-  - earthkit-utils>=0.0.1
+  - earthkit-utils>=0.1.0
 - tqdm>=4.63.0
 - lru-dict
 - markdown


### PR DESCRIPTION
### Description

When running unit tests on the latest development branch I noticed that a few tests were failing because they depend on a method that was only recently added in earthkit-utils in the newly published version `0.1.0`.

E.g. when running `pytest tests/xr_engine/test_xr_engine.py -k test_xr_engine_detailed_check_1`, I get the following error message which disappears once I `pip install earthkit-utils==0.1.0`.

Am I missing something or should we simply bump the minimum required version?

```
.venv/lib/python3.12/site-packages/xarray/backends/api.py:715: in open_dataset
    backend_ds = backend.open_dataset(
src/earthkit/data/utils/xarray/engine.py:367: in open_dataset
    return SingleDatasetBuilder(fieldlist, profile, from_xr=True, backend_kwargs=_kwargs).build()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/utils/xarray/builder.py:631: in build
    grid=self.grid(ds_sorted),
         ^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/utils/xarray/builder.py:607: in grid
    self.grids[key] = TensorGrid(ds[0], self.profile.flatten_values)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/utils/xarray/grid.py:98: in __init__
    self.dims, self.coords, self.coords_dim = self.build(field, flatten_values)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/utils/xarray/grid.py:155: in build
    lat, lon = grid.to_latlon(field_shape)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/utils/xarray/grid.py:45: in to_latlon
    ll = self.field.to_latlon(flatten=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/core/fieldlist.py:373: in to_latlon
    lon, lat = self.data(("lon", "lat"), flatten=flatten, dtype=dtype, index=index)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/core/fieldlist.py:265: in data
    v = _keys[k](dtype=dtype)
        ^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/readers/grib/metadata.py:58: in longitudes
    return self.metadata._handle.get_longitudes(dtype=dtype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/readers/grib/codes.py:239: in get_longitudes
    return LONGITUDE_ACCESSOR.get(self._handle, dtype=dtype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/readers/grib/codes.py:90: in get
    dtype = self.to_numpy_dtype(dtype)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dtype = None

    @staticmethod
    def to_numpy_dtype(dtype):
>       from earthkit.utils.array.dtype import to_numpy_dtype
E       ModuleNotFoundError: No module named 'earthkit.utils.array.dtype'

src/earthkit/data/readers/grib/codes.py:53: ModuleNotFoundError
```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 