### PR TITLE
Use correct environment variable name in doc

### DIFF
--- a/docs/guide/config.rst
+++ b/docs/guide/config.rst
@@ -105,7 +105,7 @@ Then, set the environment variable ``EARTHKIT_DATA_URL_DOWNLOAD_TIMEOUT``.
 
 .. code-block:: bash
 
-    export EARTHKIT_REGRID_URL_DOWNLOAD_TIMEOUT=5
+    export EARTHKIT_DATA_URL_DOWNLOAD_TIMEOUT=5
 
 .. code-block:: python
 


### PR DESCRIPTION
### Description
Fixes a typo in the [Environment variables section of the config tutorial](https://earthkit-data.readthedocs.io/en/latest/guide/config.html#config-env), which references `EARTHKIT_REGRID_URL_DOWNLOAD_TIMEOUT` instead of `EARTHKIT_DATA_URL_DOWNLOAD_TIMEOUT`. I went through the example with both variants and got the desired result only with the change.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 