### PR TITLE
Run nightly tests on gpu-enabled hpc nodes

### DIFF
--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -1,0 +1,26 @@
+build:
+  modules:
+  - ninja
+  dependencies:
+  - ecmwf/ecbuild@develop
+  - MathisRosenhauer/libaec@refs/tags/v1.1.3
+  - ecmwf/eccodes@develop
+  - ecmwf/eckit@develop
+  - ecmwf/odc@develop
+  python_dependencies:
+  - ecmwf/eccodes-python@develop
+  - ecmwf/cfgrib@master
+  - ecmwf/pdbufr@master
+  - ecmwf/pyodc@develop
+  env:
+  - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
+  - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions
+  parallel: 64
+  queue: ng
+  gpus: 1
+  toml_opt_dep_sections: all,test,ci
+  pytest_cmd: |
+    python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+    #python -m pytest -v -m 'notebook'
+    #python -m pytest --forked -vv -m 'no_cache_init'
+    #python -m coverage report

--- a/.github/workflows/nightly-hpc-gpu.yml
+++ b/.github/workflows/nightly-hpc-gpu.yml
@@ -1,0 +1,21 @@
+name: nightly-hpc-gpu
+
+on:
+  workflow_dispatch:
+
+  # Run at 04:00 UTC every day (on default branch)
+  schedule:
+  - cron: "0 04 * * *"
+
+jobs:
+  test-hpc-gpu:
+    runs-on: [self-hosted, linux, hpc]
+    steps:
+    - uses: ecmwf/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ secrets.HPC_CI_TESTING_SSH_USER }}
+        repository: ecmwf/earthkit-data@${{ github.event.pull_request.head.sha || github.sha }}
+        build_config: .github/ci-hpc-gpu-config.yml
+        python_version: "3.10"


### PR DESCRIPTION
### Description

The tests will run each night, and can also be triggered manually if desired. Perhaps the pytest command will need to be modified in order to enable gpu-based mechanisms - edit .github/ci-hpc-gpu-config.yml in order to do this.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 