### PR TITLE
Fix syntax warning in patterns

### DIFF
--- a/src/earthkit/data/utils/patterns.py
+++ b/src/earthkit/data/utils/patterns.py
@@ -669,7 +669,7 @@ class Pattern:
             if isinstance(p, Constant):
                 t += p.value
             else:
-                t += f"(?P<{p.name}>\S+)"
+                t += rf"(?P<{p.name}>\S+)"
 
         t = rf"^{t}$"
         return re.compile(t)


### PR DESCRIPTION
### Description

Fix SyntaxWarning

```
/earthkit/data/utils/patterns.py:672: SyntaxWarning: invalid escape sequence '\S'
  t += f"(?P<{p.name}>\S+)"
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 