### PR TITLE
Fix missing coordinate attributes in generated Xarray

### DIFF
--- a/src/earthkit/data/utils/xarray/coord.py
+++ b/src/earthkit/data/utils/xarray/coord.py
@@ -21,6 +21,8 @@ LOG = logging.getLogger(__name__)
 
 
 class Coord:
+    LOOKUP_NAME = None
+
     def __init__(self, name, vals, dims=None, ds=None, component=None):
         self.name = name
         self.vals = vals
@@ -77,6 +79,8 @@ class Coord:
 
     def attrs(self, name, profile):
         attrs = profile.attrs.coord_attrs.get(name, {})
+        if not attrs and self.LOOKUP_NAME:
+            attrs = profile.attrs.coord_attrs.get(self.LOOKUP_NAME, {})
         if profile.add_earthkit_attrs and self.component:
             attrs["_earthkit"] = {"keys": self.component[0], "values": self.component[1]}
         return attrs
@@ -131,6 +135,7 @@ class TimeCoord(Coord):
 
 
 class StepCoord(Coord):
+    LOOKUP_NAME = "step"
     resolution = None
     RESOLUTION_UNITS = {
         datetime.timedelta(hours=1): "hours",

--- a/src/earthkit/data/utils/xarray/defaults.yaml
+++ b/src/earthkit/data/utils/xarray/defaults.yaml
@@ -73,6 +73,10 @@ coord_attrs:
     # "units": "hours",
     standard_name: forecast_period
     long_name: time since forecast_reference_time
+  forecast_period:
+    # "units": "hours",
+    standard_name: forecast_period
+    long_name: time since forecast_reference_time
   valid_time:
     # "units": "seconds since 1970-01-01T00:00:00",
     # "calendar": "proleptic_gregorian",


### PR DESCRIPTION
### Description

Fixed issue when the attributes were not added to some coordinates (e.g. step) when Xarray generated with the Xarray engine.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 