### PR TITLE
Fix xr-engine remapping when lazy_load=False

### DIFF
--- a/src/earthkit/data/utils/xarray/fieldlist.py
+++ b/src/earthkit/data/utils/xarray/fieldlist.py
@@ -147,7 +147,7 @@ class XArrayInputFieldList(FieldList):
     def group(self, key, values):
         groups = defaultdict(list)
         for f in self.ds:
-            v = str(f.metadata(key, default=None))
+            v = str(f.metadata(key, remapping=self.remapping, default=None))
             if v in values:
                 groups[v].append(f)
 

--- a/tests/xr_engine/test_xr_remapping.py
+++ b/tests/xr_engine/test_xr_remapping.py
@@ -24,11 +24,14 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
 
 
 @pytest.mark.cache
-def test_xr_remapping_1():
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_xr_remapping_1(lazy_load):
     ds0 = from_source(
         "url", earthkit_remote_test_data_file("test-data/xr_engine/level/mixed_pl_ml_small.grib")
     )
-    ds = ds0.to_xarray(variable_key="_k", remapping={"_k": "{param}_{levelist}_{levtype}"})
+    ds = ds0.to_xarray(
+        variable_key="_k", remapping={"_k": "{param}_{levelist}_{levtype}"}, lazy_load=lazy_load
+    )
 
     data_vars = ["t_137_ml", "t_500_pl", "t_700_pl", "t_90_ml", "u_137_ml", "u_500_pl", "u_700_pl", "u_90_ml"]
     assert [v for v in ds.data_vars] == data_vars
@@ -38,6 +41,7 @@ def test_xr_remapping_1():
 
 
 @pytest.mark.cache
+@pytest.mark.parametrize("lazy_load", [True, False])
 @pytest.mark.parametrize(
     "kwargs,coords,dims",
     [
@@ -74,9 +78,9 @@ def test_xr_remapping_1():
         ),
     ],
 )
-def test_xr_remapping_2(kwargs, coords, dims):
+def test_xr_remapping_2(lazy_load, kwargs, coords, dims):
     ds0 = from_source("url", earthkit_remote_test_data_file("test-data/xr_engine/level/pl_small.grib"))
-    ds = ds0.to_xarray(**kwargs)
+    ds = ds0.to_xarray(lazy_load=lazy_load, **kwargs)
 
     data_vars = ["r", "t"]
 


### PR DESCRIPTION
### Description

This PR fixes the following bug in the xarray engine:

```
import earthkit.data as ekd
fl = ekd.from_source('sample', 'test.grib')
ds = fl.to_xarray(remapping={"param": "{param}_{levtype}"}, lazy_load=False)
print(ds)
```
results with
```
<xarray.Dataset> Size: 240B
Dimensions:    (latitude: 11, longitude: 19)
Coordinates:
  * latitude   (latitude) float64 88B 73.0 69.0 65.0 61.0 ... 41.0 37.0 33.0
  * longitude  (longitude) float64 152B -27.0 -23.0 -19.0 ... 37.0 41.0 45.0
Data variables:
    *empty*
Attributes:
    Conventions:  CF-1.8
    institution:  ECMWF
```
i.e. no variables present in the dataset, while the result should be
```
<xarray.Dataset> Size: 4kB
Dimensions:    (latitude: 11, longitude: 19)
Coordinates:
  * latitude   (latitude) float64 88B 73.0 69.0 65.0 61.0 ... 41.0 37.0 33.0
  * longitude  (longitude) float64 152B -27.0 -23.0 -19.0 ... 37.0 41.0 45.0
Data variables:
    2t_sfc     (latitude, longitude) float64 2kB ...
    msl_sfc    (latitude, longitude) float64 2kB ...
Attributes:
    class:        od
    stream:       oper
    levtype:      sfc
    type:         an
    expver:       0001
    date:         20200513
    time:         1200
    domain:       g
    number:       0
    Conventions:  CF-1.8
    institution:  ECMWF
```

The fix is made by handling the remapping in the method [`XArrayInputFieldList.group()`](https://github.com/ecmwf/earthkit-data/blob/c4ef88a71440cf9eacf9c79820568f873ef12667/src/earthkit/data/utils/xarray/fieldlist.py#L150) like it is the case for [`XArrayInputFieldList.sel()`](https://github.com/ecmwf/earthkit-data/blob/c4ef88a71440cf9eacf9c79820568f873ef12667/src/earthkit/data/utils/xarray/fieldlist.py#L162). The relation of this bug to `lazy_load` switch is due to the fact that:
* when `lazy_load=False` then `.group()` method is used in [`MemoryBackendDataBuilder.pre_build_variables`](https://github.com/ecmwf/earthkit-data/blob/c4ef88a71440cf9eacf9c79820568f873ef12667/src/earthkit/data/utils/xarray/builder.py#L507);
* when `lazy_load=True` then `.sel()` method is used in [`TensorBackendDataBuilder.pre_build_variables`](https://github.com/ecmwf/earthkit-data/blob/c4ef88a71440cf9eacf9c79820568f873ef12667/src/earthkit/data/utils/xarray/builder.py#L468);
* which of the two above classes are involved depends on `lazy_load`; see [here](https://github.com/ecmwf/earthkit-data/blob/c4ef88a71440cf9eacf9c79820568f873ef12667/src/earthkit/data/utils/xarray/builder.py#L550).

A test for this fix was added.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 