### PR TITLE
Fix of a regression caused by PR #791

### DIFF
--- a/src/earthkit/data/readers/__init__.py
+++ b/src/earthkit/data/readers/__init__.py
@@ -32,8 +32,6 @@ class Reader(Base, os.PathLike, metaclass=ReaderMeta):
 
     def __init__(self, source, path):
         LOG.debug("Reader for %s is %s", path, self.__class__.__name__)
-
-        self._source_kwargs = source._kwargs
         self._source = weakref.ref(source)
         self.path = path
         self.source_filename = self.source.source_filename

--- a/src/earthkit/data/readers/directory.py
+++ b/src/earthkit/data/readers/directory.py
@@ -47,6 +47,7 @@ class DirectoryReader(Reader):
     def __init__(self, source, path):
         super().__init__(source, path)
         self._content = []
+        self._source_kwargs = source._kwargs
 
         filter = make_file_filter(self.filter, self.path)
 

--- a/src/earthkit/data/readers/grib/file.py
+++ b/src/earthkit/data/readers/grib/file.py
@@ -35,6 +35,7 @@ class GRIBReader(GribFieldListInOneFile, Reader):
 
         Reader.__init__(self, source, path)
         GribFieldListInOneFile.__init__(self, path, parts=parts, positions=positions, **_kwargs)
+        self._source_kwargs = source._kwargs
 
     def __repr__(self):
         return "GRIBReader(%s)" % (self.path,)


### PR DESCRIPTION
### Description

Adding the attribute `_source_kwargs` to `Reader` class (PR #791) caused a regression, as demonstrated by the test `test_netcdf_opendap`.
This PR fixes the problem by moving the attribute to those subclasses of `Reader` where it is actually needed, that is `GRIBReader` and `DirectoryReader`.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 