### PR TITLE
Fix handling empty slices of a tensor

### DIFF
--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -1100,12 +1100,29 @@ class FieldList(Index):
             r[0] = vals
             for i, f in enumerate(it, start=1):
                 r[i] = _vals(f)
-            return r
         else:
-            # In this case no information about a field shape, dtype, array backend can be derived.
-            # This must be managed by the caller: see e.g.
-            # src/earthkit/data/indexing/tensor.py:FieldListSparseTensor.to_array
-            return None
+            # create an empty array using the right namespace and dtype
+
+            # first, resolve the array namespace xp
+            if accessor == "to_numpy":
+                # the namespace should be numpy
+                assert (
+                    "array_backend" not in kwargs
+                ), "Cannot use 'array_backend' keyword when converting a field list to numpy"
+                numpy_backend = get_backend("numpy")
+                xp = numpy_backend.namespace
+            else:
+                array_backend = kwargs.get("array_backend")
+                if array_backend is not None:
+                    xp = array_backend.namespace
+                else:
+                    xp = array_namespace()  # default array namespace
+
+            dtype = kwargs.get("dtype")
+
+            r = xp.empty((0,), dtype=dtype)  # create an array of shape (0, )
+
+        return r
 
     def to_numpy(self, **kwargs):
         r"""Return all the fields' values as an ndarray. It is formed as the array of the

--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -169,7 +169,7 @@ class Field(Base):
         dtype: str, array.dtype or None
             Typecode or data-type of the array. When it is :obj:`None` the default
             type used by the underlying data accessor is used. For GRIB it is ``float64``.
-        array_backend: str, module or None
+        array_backend: str, module, :obj:`ArrayBackend` or None
             The array backend to be used. When it is :obj:`None` the underlying array format
             of the field is used.
         index: array indexing object, optional
@@ -822,7 +822,7 @@ class Field(Base):
             the original field. If :obj:`None`, the default type used by the underlying
             data accessor is used. For GRIB it is ``float64``. Only used when  ``values``
             is not provided.
-        array_backend: str, module or None
+        array_backend: str, module, :obj:`ArrayBackend` or None
             Control the array backend of the values when they are extracted from
             the original field. If :obj:`None`, the underlying array format
             of the field is used. Only used when ``values`` is not provided.
@@ -1267,7 +1267,7 @@ class FieldList(Index):
             return array_namespace(r[0]).stack(r)
 
         elif len(self) == 0:
-            return array_namespace(r[0]).array_ns.stack([])
+            return array_namespace().empty((0,), dtype=dtype)  # empty array from a default array namespace
         else:
             raise ValueError("Fields do not have the same grid geometry")
 
@@ -1564,7 +1564,7 @@ class FieldList(Index):
 
         """
         if self._is_shared_grid():
-            return self[0].to_latlon(**kwargs)
+            return self[0].to_latlon(index=index, **kwargs)
         elif len(self) == 0:
             return dict(lat=None, lon=None)
         else:

--- a/src/earthkit/data/indexing/tensor.py
+++ b/src/earthkit/data/indexing/tensor.py
@@ -424,9 +424,11 @@ class FieldListTensor(TensorCore):
                 )
 
         if arr is None:
-            if array_backend is None:
-                array_backend = array_namespace()  # default array namespace
-            arr = array_backend.empty((0,), dtype=dtype)  # create an array of shape (0, )
+            if array_backend is not None:
+                xp = array_backend.namespace
+            else:
+                xp = array_namespace()  # default array namespace
+            arr = xp.empty((0,), dtype=dtype)  # create an array of shape (0, )
 
         return arr, current_field_shape
 

--- a/src/earthkit/data/indexing/tensor.py
+++ b/src/earthkit/data/indexing/tensor.py
@@ -426,9 +426,7 @@ class FieldListTensor(TensorCore):
         if arr is None:
             if array_backend is None:
                 array_backend = array_namespace()  # default array namespace
-            arr = array_backend.empty(
-                (0,), dtype=dtype
-            )  # create an array of shape (0, ) with a backend default dtype
+            arr = array_backend.empty((0,), dtype=dtype)  # create an array of shape (0, )
 
         return arr, current_field_shape
 

--- a/src/earthkit/data/utils/xarray/builder.py
+++ b/src/earthkit/data/utils/xarray/builder.py
@@ -173,14 +173,14 @@ class VariableBuilder:
 
 
 class TensorBackendArray(xarray.backends.common.BackendArray):
-    def __init__(self, tensor, dims, shape, xp, dtype, var_name):
+    def __init__(self, tensor, dims, shape, array_backend, dtype, var_name):
         super().__init__()
         self.tensor = tensor
         self.dims = dims
         self.shape = shape
         self._var_name = var_name
         self.dtype = dtype
-        self.xp = xp
+        self.array_backend = array_backend
 
         from dask.utils import SerializableLock
 
@@ -228,7 +228,7 @@ class TensorBackendArray(xarray.backends.common.BackendArray):
             # LOG.debug(f"   {field_index=}")
 
             try:
-                result = r.to_array(index=field_index, array_backend=self.xp, dtype=self.dtype)
+                result = r.to_array(index=field_index, array_backend=self.array_backend, dtype=self.dtype)
             except Exception as e:
                 LOG.exception("Error in to_array:", e)
                 raise
@@ -521,7 +521,7 @@ class TensorBackendDataBuilder(BackendDataBuilder):
             tensor,
             var_dims,
             tensor.full_shape,
-            self.array_backend.namespace,
+            self.array_backend,
             self.dtype,
             name,
         )

--- a/tests/xr_engine/test_xr_slice.py
+++ b/tests/xr_engine/test_xr_slice.py
@@ -92,7 +92,7 @@ from earthkit.data.testing import earthkit_remote_test_data_file
         ),
     ],
 )
-def test_xr_tensor_empty_slices(allow_holes, lazy_load, file, variables, sel_dicts, shapes):
+def test_xr_empty_slices(allow_holes, lazy_load, file, variables, sel_dicts, shapes):
     kwargs = dict(squeeze=False, allow_holes=allow_holes, lazy_load=lazy_load)
 
     ds_ek = from_source("url", earthkit_remote_test_data_file("xr_engine", "grid", file))

--- a/tests/xr_engine/test_xr_tensor.py
+++ b/tests/xr_engine/test_xr_tensor.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+import pytest
+
+from earthkit.data import from_source
+from earthkit.data.testing import earthkit_remote_test_data_file
+
+
+@pytest.mark.cache
+@pytest.mark.parametrize("allow_holes", [False, True])
+@pytest.mark.parametrize("lazy_load", [True, False])
+@pytest.mark.parametrize(
+    "file,variables,sel_dicts,shapes",
+    [
+        (
+            "regular_ll.grib2",
+            ["t", "r"],
+            [
+                {"step": slice("1h", "5h")},
+                {"step": "0h", "latitude": slice(31, 39)},
+                {"step": "0h", "latitude": [30, 40], "longitude": slice(11, 19)},
+                {"step": "0h", "latitude": 30, "longitude": 20},
+                {"step": slice("1h", "5h"), "latitude": 30, "longitude": 20},
+                {"step": slice("1h", "5h"), "latitude": 30, "longitude": slice(11, 19)},
+                {"step": slice("1h", "5h"), "latitude": [30], "longitude": slice(11, 19)},
+                {"step": slice("1h", "5h"), "latitude": slice(30, 20), "longitude": [0, 10, 20]},
+                {"step": slice("1h", "5h"), "latitude": slice(30, 20), "longitude": slice(11, 19)},
+                {"step": slice("1h", "5h"), "latitude": slice(29, 21), "longitude": slice(11, 19)},
+            ],
+            [(0, 19, 36), (0, 36), (2, 0), (), (0,), (0, 0), (0, 1, 0), (0, 2, 3), (0, 2, 0), (0, 0, 0)],
+        ),
+        (
+            "reduced_gg_O32.grib2",
+            ["t", "q"],
+            [
+                {"step": "0h"},
+                {"step": slice("1h", "5h")},
+                {"step": slice("1h", "5h"), "values": slice(1000)},
+                {"step": slice("1h", "5h"), "values": slice(0)},
+                {"values": slice(0)},
+                {"step": "0h", "values": slice(0)},
+                {"step": ["0h"], "values": slice(0)},
+            ],
+            [(5248,), (0, 5248), (0, 1000), (0, 0), (2, 0), (0,), (1, 0)],
+        ),
+        (
+            "reduced_rotated_gg_subarea_O32.grib1",
+            ["t", "r"],
+            [
+                {"step": ["0h"]},
+                {"step": "0h", "values": 224},
+                {"step": slice("1h", "5h"), "values": 224},
+                {"step": slice("1h", "5h")},
+                {"step": ["0h"], "values": slice(0)},
+                {"values": slice(0)},
+            ],
+            [(1, 225), (), (0,), (0, 225), (1, 0), (2, 0)],
+        ),
+        (
+            "healpix_H8_nested.grib2",
+            ["t", "r"],
+            [
+                {"step": "0h"},
+                {"step": slice("1h", "5h")},
+                {"step": ["0h"], "values": slice(500, 400, -2)},
+                {"step": slice("1h", "5h"), "values": slice(500, 400, -2)},
+            ],
+            [(768,), (0, 768), (1, 50), (0, 50)],
+        ),
+        (
+            "sh_t32.grib1",
+            ["t", "r"],
+            [
+                {"step": ["0h"]},
+                {"step": ["0h"], "values": slice(0)},
+                {"step": "0h", "values": slice(0)},
+                {"step": slice("1h", "5h"), "values": slice(0)},
+                {"step": "0h", "values": [1, 2, 10]},
+                {"step": slice("1h", "5h"), "values": [1, 2, 10]},
+            ],
+            [(1, 1122), (1, 0), (0,), (0, 0), (3,), (0, 3)],
+        ),
+    ],
+)
+def test_xr_tensor_empty_slices(allow_holes, lazy_load, file, variables, sel_dicts, shapes):
+    kwargs = dict(squeeze=False, allow_holes=allow_holes, lazy_load=lazy_load)
+
+    ds_ek = from_source("url", earthkit_remote_test_data_file("xr_engine", "grid", file))
+
+    ds = ds_ek.to_xarray(**kwargs).squeeze()
+    assert set(ds) == set(variables)
+
+    for sel_dict, shape in zip(sel_dicts, shapes):
+        _ds = ds.sel(**sel_dict)
+        for v in _ds:
+            assert _ds[v].shape == shape
+        _ds.load()


### PR DESCRIPTION
### Description

This PR fixes a problem in handling empty slices of Xarray objects whenever the underlying data in managed by a field list through a `FieldListTensor` object (e.g. when a GRIB file is converted to Xarray via `.to_xarray(lazy_load=True, ...)` method). Consider the following code:

```python3
from earthkit.data import from_source
from earthkit.data.testing import earthkit_remote_test_data_file

ds_ek = from_source("url", earthkit_remote_test_data_file("xr_engine/level/pl.grib"))
ds = ds_ek.to_xarray(lazy_load=True)

ds2 = ds.sel(level=slice(350, 360))  # in ds2, the level-dim has size 0
ds2.load()  # crashes

ds3 = ds.load().sel(level=slice(350, 360))   # this works, because the full ds is loaded into memory 
                                             # before extracting an empty slice
```

The problem with `ds2.load()` comes from the fact that the underlying field list is empty (i.e. `None`, see https://github.com/ecmwf/earthkit-data/blob/195942d2badd39fea1569c810af8f2686d1cfa9a/src/earthkit/data/core/fieldlist.py#L1108). 

This PR fixes this issue by properly handling the case of an empty field list, see: https://github.com/ecmwf/earthkit-data/blob/dbc9810475a158469db6da55c1036271b23c0ecc/src/earthkit/data/indexing/tensor.py#L433

A related code was refactored slightly to remove some code duplication between `to_numpy`, `to_array` methods within `FieldListTensor` and `FieldListSparseTensor` classes.

A relevant test was added.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 