### PR TITLE
Use thread safe cached property

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-forked
+- pytest-reraise
 - pytest-timeout
 - sphinx>=7.2.6
 - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ optional-dependencies.test = [
   "pytest",
   "pytest-cov",
   "pytest-forked",
+  "pytest-reraise",
   "pytest-timeout",
 ]
 optional-dependencies.wekeo = [ "hda>=2.22" ]

--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -10,7 +10,6 @@
 import math
 from abc import abstractmethod
 from collections import defaultdict
-from functools import cached_property
 
 import deprecation
 from earthkit.utils.array import array_namespace
@@ -24,6 +23,7 @@ from earthkit.data.core.index import MaskIndex
 from earthkit.data.core.index import MultiIndex
 from earthkit.data.decorators import cached_method
 from earthkit.data.decorators import detect_out_filename
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils.metadata.args import metadata_argument
 
 
@@ -41,7 +41,7 @@ class FieldListIndices:
         self.fs = field_list
         self.user_indices = dict()
 
-    @cached_property
+    @thread_safe_cached_property
     def default_index_keys(self):
         if len(self.fs) > 0:
             return self.fs[0]._metadata.index_keys()
@@ -57,7 +57,7 @@ class FieldListIndices:
 
         return sorted(list(values))
 
-    @cached_property
+    @thread_safe_cached_property
     def default_indices(self):
         indices = defaultdict(set)
         keys = self.default_index_keys
@@ -1007,7 +1007,7 @@ class FieldList(Index):
         else:
             return False
 
-    @cached_property
+    @thread_safe_cached_property
     def _md_indices(self):
         return FieldListIndices(self)
 

--- a/src/earthkit/data/decorators.py
+++ b/src/earthkit/data/decorators.py
@@ -323,3 +323,24 @@ def cached_method(method):
         return getattr(self, name)
 
     return wrapped
+
+
+class thread_safe_cached_property:
+    def __init__(self, method):
+        self.method = method
+        self.name = f"_c_{method.__name__}"
+        self.lock = threading.Lock()
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        if hasattr(instance, self.name):
+            return getattr(instance, self.name)
+
+        with self.lock:
+            if hasattr(instance, self.name):
+                return getattr(instance, self.name)
+            value = self.method(instance)
+            setattr(instance, self.name, value)
+            return value

--- a/src/earthkit/data/decorators.py
+++ b/src/earthkit/data/decorators.py
@@ -328,11 +328,22 @@ def cached_method(method):
 class thread_safe_cached_property:
     """A thread-safe cached property decorator.
 
-    This was implemented because a the functools.cached_property is not thread-safe
+    It was implemented because a the functools.cached_property is not thread-safe
     from Python 3.12.
+
+    Parameters
+    ----------
+    method: property method
+        The property method to be decorated.
+
+    The :obj:`__get__` method of the decorator only runs on lookups. On first call
+    it gets the underlying property's value and stores it as the hidden ``name`` attribute
+    of the instance it was called on. Subsequent calls return the cached value, i.e. the
+    hidden ``name`` attribute.
     """
 
     def __init__(self, method):
+        print("created", method)
         self.method = method
         self.name = f"_c_{method.__name__}"
         self.lock = threading.Lock()

--- a/src/earthkit/data/decorators.py
+++ b/src/earthkit/data/decorators.py
@@ -326,12 +326,18 @@ def cached_method(method):
 
 
 class thread_safe_cached_property:
+    """A thread-safe cached property decorator.
+
+    This was implemented because a the functools.cached_property is not thread-safe
+    from Python 3.12.
+    """
+
     def __init__(self, method):
         self.method = method
         self.name = f"_c_{method.__name__}"
         self.lock = threading.Lock()
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         if instance is None:
             return self
 

--- a/src/earthkit/data/decorators.py
+++ b/src/earthkit/data/decorators.py
@@ -343,7 +343,6 @@ class thread_safe_cached_property:
     """
 
     def __init__(self, method):
-        print("created", method)
         self.method = method
         self.name = f"_c_{method.__name__}"
         self.lock = threading.Lock()

--- a/src/earthkit/data/readers/geotiff.py
+++ b/src/earthkit/data/readers/geotiff.py
@@ -7,7 +7,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-from functools import cached_property
 
 import numpy as np
 
@@ -15,6 +14,7 @@ from earthkit.data.core.fieldlist import Field
 from earthkit.data.core.fieldlist import FieldList
 from earthkit.data.core.geography import Geography
 from earthkit.data.core.metadata import RawMetadata
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils.bbox import BoundingBox
 
 from . import Reader
@@ -129,7 +129,7 @@ class GeoTIFFField(Field):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.band},{self._da.name})"
 
-    @cached_property
+    @thread_safe_cached_property
     def _metadata(self):
         return GeoTIFFMetadata(self, self.band, geography=self._geo)
 

--- a/src/earthkit/data/readers/grib/codes.py
+++ b/src/earthkit/data/readers/grib/codes.py
@@ -9,12 +9,12 @@
 
 import logging
 import os
-from functools import cached_property
 
 import eccodes
 import numpy as np
 
 from earthkit.data.core.fieldlist import Field
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.indexing.fieldlist import ClonedFieldCore
 from earthkit.data.readers.grib.metadata import GribFieldMetadata
 from earthkit.data.utils.message import CodesHandle
@@ -307,7 +307,7 @@ class GribField(Field):
             self._offset = int(self.handle.get("offset"))
         return self._offset
 
-    @cached_property
+    @thread_safe_cached_property
     def _metadata(self):
         cache = self._use_metadata_cache
         if cache:

--- a/src/earthkit/data/readers/grib/metadata.py
+++ b/src/earthkit/data/readers/grib/metadata.py
@@ -10,13 +10,13 @@
 import logging
 import warnings
 from abc import abstractmethod
-from functools import cached_property
 
 from earthkit.data.core.geography import Geography
 from earthkit.data.core.metadata import Metadata
 from earthkit.data.core.metadata import MetadataAccessor
 from earthkit.data.core.metadata import MetadataCacheHandler
 from earthkit.data.core.metadata import WrappedMetadata
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.indexing.database import GRIB_KEYS_NAMES
 from earthkit.data.readers.grib.gridspec import make_gridspec
 from earthkit.data.utils.bbox import BoundingBox
@@ -35,7 +35,7 @@ class GribFieldGeography(Geography):
         self.metadata = metadata
         self.check_rotated_support()
 
-    @cached_property
+    @thread_safe_cached_property
     def spectral(self):
         return self.metadata._handle.get("gridType", "") == "sh"
 
@@ -206,12 +206,12 @@ class GribFieldGeography(Geography):
             self.metadata.get("angleOfRotationInDegrees"),
         )
 
-    @cached_property
+    @thread_safe_cached_property
     def rotated(self):
         grid_type = self.metadata.get("gridType")
         return "rotated" in grid_type
 
-    @cached_property
+    @thread_safe_cached_property
     def rotated_iterator(self):
         return self.metadata.get("iteratorDisableUnrotate") is not None
 
@@ -542,7 +542,7 @@ class GribMetadata(Metadata):
                     r[k] = self.get(k)
         return r
 
-    @cached_property
+    @thread_safe_cached_property
     def geography(self):
         return GribFieldGeography(self)
 

--- a/src/earthkit/data/readers/grib/virtual.py
+++ b/src/earthkit/data/readers/grib/virtual.py
@@ -8,10 +8,10 @@
 #
 
 import logging
-from functools import cached_property
 
 from earthkit.data.core.fieldlist import Field
 from earthkit.data.core.metadata import WrappedMetadata
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils.dates import date_to_grib
 from earthkit.data.utils.dates import datetime_from_grib
 from earthkit.data.utils.dates import time_to_grib
@@ -140,7 +140,7 @@ class VirtualGribFieldList(GribFieldList):
     def mutate(self):
         return self
 
-    @cached_property
+    @thread_safe_cached_property
     def reference(self):
         return self.retriever.get(self.request_mapper.request_at(0))[0]
 

--- a/src/earthkit/data/readers/netcdf/field.py
+++ b/src/earthkit/data/readers/netcdf/field.py
@@ -9,7 +9,6 @@
 
 import logging
 from datetime import timedelta
-from functools import cached_property
 
 import numpy as np
 
@@ -17,6 +16,7 @@ from earthkit.data.core.fieldlist import Field
 from earthkit.data.core.geography import Geography
 from earthkit.data.core.metadata import MetadataAccessor
 from earthkit.data.core.metadata import RawMetadata
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.indexing.fieldlist import ClonedFieldCore
 from earthkit.data.utils.bbox import BoundingBox
 from earthkit.data.utils.dates import to_datetime
@@ -153,7 +153,7 @@ class XArrayMetadata(RawMetadata):
             return self
         return None
 
-    @cached_property
+    @thread_safe_cached_property
     def geography(self):
         return XArrayFieldGeography(self, self._field._ds, self._field.variable)
 
@@ -245,7 +245,7 @@ class XArrayField(Field):
             + ")"
         )
 
-    @cached_property
+    @thread_safe_cached_property
     def _metadata(self):
         return XArrayMetadata(self)
 
@@ -277,7 +277,7 @@ class XArrayField(Field):
         else:
             return self._to_numpy().astype(dtype, copy=False)
 
-    @cached_property
+    @thread_safe_cached_property
     def grid_mapping(self):
         def tidy(x):
             if isinstance(x, np.ndarray):
@@ -317,6 +317,6 @@ class NetCDFMetadata(XArrayMetadata):
 
 
 class NetCDFField(XArrayField):
-    @cached_property
+    @thread_safe_cached_property
     def _metadata(self):
         return NetCDFMetadata(self)

--- a/src/earthkit/data/readers/netcdf/fieldlist.py
+++ b/src/earthkit/data/readers/netcdf/fieldlist.py
@@ -8,7 +8,6 @@
 #
 
 import logging
-from functools import cached_property
 from itertools import product
 
 import deprecation
@@ -16,6 +15,7 @@ import deprecation
 from earthkit.data.core.fieldlist import FieldList
 from earthkit.data.core.index import MaskIndex
 from earthkit.data.core.index import MultiIndex
+from earthkit.data.decorators import thread_safe_cached_property
 
 from .coords import LevelCoordinate
 from .coords import OtherCoordinate
@@ -245,7 +245,7 @@ class XArrayFieldList(XArrayFieldListCore):
         self._ds = ds
         super().__init__(**kwargs)
 
-    @cached_property
+    @thread_safe_cached_property
     def xr_dataset(self):
         return self._ds
 
@@ -311,7 +311,7 @@ class NetCDFFieldListFromFileOrURL(NetCDFFieldList):
         super().__init__(path_or_url, **kwargs)
         self.path_or_url = path_or_url
 
-    @cached_property
+    @thread_safe_cached_property
     def xr_dataset(self):
         import xarray as xr
 

--- a/src/earthkit/data/sources/cds.py
+++ b/src/earthkit/data/sources/cds.py
@@ -10,7 +10,6 @@
 import itertools
 import logging
 import sys
-from functools import cached_property
 
 try:
     import cdsapi
@@ -21,6 +20,7 @@ import yaml
 
 from earthkit.data.core.thread import SoftThreadPool
 from earthkit.data.decorators import normalize
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils import ensure_iterable
 from earthkit.data.utils.progbar import tqdm
 
@@ -149,7 +149,7 @@ class CdsRetriever(FileSource):
     def _normalize_request(**kwargs):
         return kwargs
 
-    @cached_property
+    @thread_safe_cached_property
     def requests(self):
         requests = []
         for arg in self._args:

--- a/src/earthkit/data/sources/forcings.py
+++ b/src/earthkit/data/sources/forcings.py
@@ -10,7 +10,6 @@
 import datetime
 import itertools
 import logging
-from functools import cached_property
 
 import numpy as np
 
@@ -20,6 +19,7 @@ from earthkit.data.core.index import MaskIndex
 from earthkit.data.core.metadata import RawMetadata
 from earthkit.data.decorators import cached_method
 from earthkit.data.decorators import normalize
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.indexing.fieldlist import ClonedFieldCore
 from earthkit.data.utils.dates import to_datetime
 
@@ -245,7 +245,7 @@ class ForcingField(Field):
         # self._shape = shape
         # self._geometry = self.maker.field.metadata().geography
 
-    @cached_property
+    @thread_safe_cached_property
     def _metadata(self):
         d = dict(
             valid_datetime=self.date if isinstance(self.date, str) else self.date.isoformat(),

--- a/src/earthkit/data/sources/stream.py
+++ b/src/earthkit/data/sources/stream.py
@@ -9,9 +9,9 @@
 
 import itertools
 import logging
-from functools import cached_property
 
 from earthkit.data.core.fieldlist import FieldList
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.readers import stream_reader
 from earthkit.data.sources.memory import MemoryBaseSource
 
@@ -33,7 +33,7 @@ class StreamMemorySource(MemoryBaseSource):
             raise ValueError(f"Invalid stream={stream}")
         self._stream = stream
 
-    @cached_property
+    @thread_safe_cached_property
     def _reader(self):
         reader = stream_reader(self, self._stream.stream, True, **self._kwargs)
         if reader is None:
@@ -74,7 +74,7 @@ class StreamSource(Source):
                 return StreamFieldList(self._reader, **self._kwargs)
         return self
 
-    @cached_property
+    @thread_safe_cached_property
     def _reader(self):
         reader = stream_reader(self, self._stream.stream, False, **self._kwargs)
         if reader is None:

--- a/src/earthkit/data/utils/metadata/dict.py
+++ b/src/earthkit/data/utils/metadata/dict.py
@@ -9,7 +9,6 @@
 
 import copy
 import logging
-from functools import cached_property
 from math import prod
 
 import numpy as np
@@ -17,6 +16,7 @@ import numpy as np
 from earthkit.data.core.geography import Geography
 from earthkit.data.core.metadata import Metadata
 from earthkit.data.core.metadata import MetadataAccessor
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils.bbox import BoundingBox
 from earthkit.data.utils.dates import datetime_from_grib
 from earthkit.data.utils.dates import to_datetime
@@ -469,7 +469,7 @@ class UserMetadata(Metadata):
             if k in self._data:
                 return self._data[k]
 
-    @cached_property
+    @thread_safe_cached_property
     def geography(self):
         return make_geography(self, values_shape=self._shape)
 

--- a/src/earthkit/data/utils/patterns.py
+++ b/src/earthkit/data/utils/patterns.py
@@ -11,7 +11,6 @@ import itertools
 import logging
 import os
 import re
-from functools import cached_property
 from pathlib import Path
 from typing import Any as TypingAny
 from typing import Dict
@@ -19,6 +18,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
+
+from earthkit.data.decorators import thread_safe_cached_property
 
 from .dates import to_datetime
 from .dates import to_timedelta
@@ -662,7 +663,7 @@ class Pattern:
             t += f"\n {p}"
         return t
 
-    @cached_property
+    @thread_safe_cached_property
     def regex(self) -> re.Pattern:
         t = ""
         for p in self.pattern:

--- a/src/earthkit/data/utils/request.py
+++ b/src/earthkit/data/utils/request.py
@@ -10,7 +10,8 @@
 import logging
 from abc import ABCMeta
 from abc import abstractmethod
-from functools import cached_property
+
+from earthkit.data.decorators import thread_safe_cached_property
 
 LOG = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class RequestMapper(metaclass=ABCMeta):
     def __init__(self, request, **kwargs):
         self.request = request
 
-    @cached_property
+    @thread_safe_cached_property
     def field_requests(self):
         return self._build()
 

--- a/src/earthkit/data/utils/xarray/attrs.py
+++ b/src/earthkit/data/utils/xarray/attrs.py
@@ -12,8 +12,8 @@ import os
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import defaultdict
-from functools import cached_property
 
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils import ensure_dict
 from earthkit.data.utils import ensure_iterable
 
@@ -36,7 +36,7 @@ class CFAttrs:
         else:
             raise ValueError(f"CF attributes file not found! path={path}")
 
-    @cached_property
+    @thread_safe_cached_property
     def attrs(self):
         return self._load()
 

--- a/src/earthkit/data/utils/xarray/profile.py
+++ b/src/earthkit/data/utils/xarray/profile.py
@@ -12,8 +12,8 @@ import os
 import threading
 from abc import ABCMeta
 from abc import abstractmethod
-from functools import cached_property
 
+from earthkit.data.decorators import thread_safe_cached_property
 from earthkit.data.utils import ensure_dict
 from earthkit.data.utils import ensure_iterable
 
@@ -68,7 +68,7 @@ class ProfileConf:
                 else:
                     raise ValueError(f"Profile {name} not found! path={path}")
 
-    @cached_property
+    @thread_safe_cached_property
     def defaults(self):
         here = os.path.dirname(__file__)
         path = os.path.join(here, "defaults.yaml")

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -47,6 +47,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytest-forked
+- pytest-reraise
 - pytest-timeout
 - sphinx
 - sphinx-autoapi

--- a/tests/thread/test_thread_cached_property.py
+++ b/tests/thread/test_thread_cached_property.py
@@ -23,12 +23,14 @@ class _A:
 
     @thread_safe_cached_property
     def data(self):
+        """Property data"""
         time.sleep(1)
         self.count += 1
         return self.count
 
     @thread_safe_cached_property
     def data_static(self):
+        """Property data_static"""
         time.sleep(1)
         self.count_static += 1
         return self.count_static
@@ -142,3 +144,8 @@ def test_thread_cached_property_4(reraise):
     assert b.count_static == 1
     assert a.data_static == 1
     assert b.data_static == 1
+
+
+def test_thread_cached_property_docstring():
+    _A.data.__doc__ == "Property data"
+    _A.data_static.__doc__ == "Property data_static"

--- a/tests/thread/test_thread_cached_property.py
+++ b/tests/thread/test_thread_cached_property.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import threading
+import time
+
+from earthkit.data.decorators import thread_safe_cached_property
+
+
+class _A:
+    count_static = 0
+
+    def __init__(self, count=0):
+        self.count = count
+
+    @thread_safe_cached_property
+    def data(self):
+        time.sleep(1)
+        self.count += 1
+        return self.count
+
+    @thread_safe_cached_property
+    def data_static(self):
+        time.sleep(1)
+        self.count_static += 1
+        return self.count_static
+
+
+def test_thread_cached_property_1(reraise):
+    a = _A()
+
+    def worker(n):
+        with reraise:
+            assert a.data == 1, f"Thread {n} failed"
+
+    threads = []
+    nums = list(range(10))
+
+    for n in nums:
+        thread = threading.Thread(target=worker, args=(n,))
+        # print("Starting thread", n, flush=True)
+        thread.start()
+        threads.append(thread)
+
+    for n, thread in zip(nums, threads):
+        # print("Joining thread", n, flush=True)
+        thread.join()
+
+    assert a.data == 1
+    assert a.count == 1
+    assert a.data == 1
+
+
+def test_thread_cached_property_2(reraise):
+    a = _A(0)
+    b = _A(1)
+
+    def worker(n):
+        with reraise:
+            assert a.data == 1, f"a, thread {n} failed"
+            assert b.data == 2, f"b, thread {n} failed"
+
+    threads = []
+    nums = list(range(10))
+
+    for n in nums:
+        thread = threading.Thread(target=worker, args=(n,))
+        # print("Starting thread", n, flush=True)
+        thread.start()
+        threads.append(thread)
+
+    for n, thread in zip(nums, threads):
+        # print("Joining thread", n, flush=True)
+        thread.join()
+
+    assert a.data == 1
+    assert b.data == 2
+    assert a.count == 1
+    assert b.count == 2
+    assert a.data == 1
+    assert b.data == 2
+
+
+def test_thread_cached_property_3(reraise):
+    a = _A()
+
+    def worker(n):
+        with reraise:
+            assert a.data_static == 1, f"Thread {n} failed"
+
+    threads = []
+    nums = list(range(10))
+
+    for n in nums:
+        thread = threading.Thread(target=worker, args=(n,))
+        # print("Starting thread", n, flush=True)
+        thread.start()
+        threads.append(thread)
+
+    for n, thread in zip(nums, threads):
+        # print("Joining thread", n, flush=True)
+        thread.join()
+
+    assert a.data_static == 1
+    assert a.count_static == 1
+    assert a.data_static == 1
+
+
+def test_thread_cached_property_4(reraise):
+    a = _A(0)
+    b = _A(1)
+
+    def worker(n):
+        with reraise:
+            assert a.data_static == 1, f"a, thread {n} failed"
+            assert b.data_static == 1, f"b, thread {n} failed"
+
+    threads = []
+    nums = list(range(10))
+
+    for n in nums:
+        thread = threading.Thread(target=worker, args=(n,))
+        # print("Starting thread", n, flush=True)
+        thread.start()
+        threads.append(thread)
+
+    for n, thread in zip(nums, threads):
+        # print("Joining thread", n, flush=True)
+        thread.join()
+
+    assert a.data_static == 1
+    assert b.data_static == 1
+    assert a.count_static == 1
+    assert b.count_static == 1
+    assert a.data_static == 1
+    assert b.data_static == 1


### PR DESCRIPTION
### Description

This PR replaces the usage of `functools.cached_property` with a custom thread safe implementation: `earthkit.data.decorators.cached_property`. This was a necessary step since the thread safety in `functools.cached_property` was removed in Python 3.12.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 