### PR TITLE
Fix lazy fdb fields return incorrect step_timedelta

### DIFF
--- a/src/earthkit/data/readers/grib/virtual.py
+++ b/src/earthkit/data/readers/grib/virtual.py
@@ -93,6 +93,8 @@ class VirtualGribField(Field):
         if key in self.metadata_alias and key in self.request:
             return self.request[self.metadata_alias[key]]
 
+        if key == "step_timedelta":
+            return to_timedelta(self.request.get("step", 0))
         if key == "number":
             return 0
         if key == "validityDate":

--- a/tests/lazy/test_lazy_fdb.py
+++ b/tests/lazy/test_lazy_fdb.py
@@ -9,6 +9,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import datetime
 import os
 
 import numpy as np
@@ -72,6 +73,9 @@ def test_lazy_fdb():
             "%",
             "relative_humidity",
         ]
+
+        assert ds[0].metadata("step_timedelta") == datetime.timedelta(hours=0)
+        assert ds[4].metadata("step_timedelta") == datetime.timedelta(hours=6)
 
         assert not hasattr(ds, "path")
         assert not hasattr(ds[0], "path")


### PR DESCRIPTION
### Description

Fixed issue when fields loaded from FDB lazily returned incorrect `step_timedelta` metadata.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 