### PR TITLE
fix: Wrong reference to not_implemented

### DIFF
--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -802,7 +802,7 @@ class Field(Base):
             If ``metadata`` is a :class:`Metadata` object and ``**kwargs`` is not empty.
 
         """
-        self.not_implemented()
+        self._not_implemented()
 
     def copy(self, *, values=None, flatten=False, dtype=None, array_backend=None, metadata=None):
         r"""Create a new :class:`ArrayField` by copying the values and metadata.


### PR DESCRIPTION

### Description
The abstract clone method in fieldlist was missing a _ when calling not_implemented

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 