### PR TITLE
Use order key in generated healpix gridspecs

### DIFF
--- a/src/earthkit/data/conf/gridspec.yaml
+++ b/src/earthkit/data/conf/gridspec.yaml
@@ -39,7 +39,7 @@ grib_key_map:
   J: J
   K: K
   M: M
-  orderingConvention: ordering
+  orderingConvention: order
   Nside: n_side
 definitions:
   _1: &area
@@ -167,4 +167,4 @@ types:
     - type
     - grid:
       - H
-    - ordering
+    - order

--- a/src/earthkit/data/conf/gridspec_schema.json
+++ b/src/earthkit/data/conf/gridspec_schema.json
@@ -154,7 +154,7 @@
             "type": "integer",
             "minimum": 1
         },
-        "ordering": {
+        "order": {
             "description": "Healpix grid ordering",
             "enum": [
                 "ring",
@@ -427,7 +427,7 @@
             "then": {
                 "required": [
                     "grid",
-                    "ordering"
+                    "order"
                 ],
                 "properties": {
                     "grid": {

--- a/tests/core/test_gridspec.py
+++ b/tests/core/test_gridspec.py
@@ -52,9 +52,9 @@ with open(earthkit_conf_file("gridspec_schema.json"), "r") as f:
             "ny": 44,
             "orientation": 0.0,
         },
-        {"grid": "H8", "ordering": "ring"},
-        {"type": "healpix", "grid": "H8", "ordering": "ring"},
-        {"type": "healpix", "grid": "H8", "ordering": "nested"},
+        {"grid": "H8", "order": "ring"},
+        {"type": "healpix", "grid": "H8", "order": "ring"},
+        {"type": "healpix", "grid": "H8", "order": "nested"},
     ],
 )
 def test_gridspec_schema_valid(gridspec):
@@ -81,9 +81,9 @@ def test_gridspec_schema_valid(gridspec):
         {"type": "reduced_gg", "grid": "48"},
         {"type": "reduced_gg", "grid": "F048"},
         {"type": "reduced_gg", "grid": "N"},
-        {"grid": "H8", "ordering": "a"},
-        {"type": "healpix", "ordering": "ring"},
-        {"type": "healpix", "grid": 4, "ordering": "ring"},
+        {"grid": "H8", "order": "a"},
+        {"type": "healpix", "order": "ring"},
+        {"type": "healpix", "grid": 4, "order": "ring"},
     ],
 )
 def test_gridspec_schema_invalid(gridspec):

--- a/tests/data/gridspec/healpix.yaml
+++ b/tests/data/gridspec/healpix.yaml
@@ -1,7 +1,7 @@
 - file: healpix/H16_ring.grib2
   gridspec:
     grid: H16
-    ordering: ring
+    order: ring
     type: healpix
   metadata:
     N: 16
@@ -16,7 +16,7 @@
 - file: healpix/H16_nested.grib2
   gridspec:
     grid: H16
-    ordering: nested
+    order: nested
     type: healpix
   metadata:
     N: 16


### PR DESCRIPTION
### Description

With this PR the (legacy, i.e. not based on eckit.geo) gridspec generated for HEALPix grids includes the `order` key instead of `ordering`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 