### PR TITLE
fix two performance bottlenecks in the gribjump source

### DIFF
--- a/tests/sources/test_gribjump.py
+++ b/tests/sources/test_gribjump.py
@@ -192,7 +192,6 @@ def ds_expected_with_coords():
             "levelist": "1000",
             "levtype": "pl",
             "stream": "oper",
-            "param": "129",
             "time": "1200",
             "type": "fc",
             "Conventions": "CF-1.8",


### PR DESCRIPTION
Fixes two small performance bottlenecks that made retrieval for large time-series unnecessarily slow:

1. If `fetch_coords_from_fdb=True`, the reference latitudes and longitudes were read from the reference field again for each individually retrieved field. Originally, I somehow assumed they would be cached together with the `GribMetadata` object and only noticed this issue recently during some benchmarks. I propose to simply fix this for now by explicitly caching latitudes/longitudes.
2. If `indices` instead of `ranges` were used, they would get converted into a list of ranges ([by this function](https://github.com/ecmwf/gribjump/blob/42199463205cb4e7a004b7ca6e0095a2658c15e9/python/pygribjump/src/pygribjump/pygribjump.py#L191C1-L196C42)) again for each single field. As a simple fix, I propose that we just convert indices to ranges once directly in this source. I will follow up on this in a future PR to find a cleaner fix.

I performed a few ad-hoc benchmarks for these two fixes:
1. Retrieving one month of hydrological reanalysis data shows that the wall-clock time with the same configuration (same fdb, #threads, ~1k random points) goes from ~1 min to ~18 seconds.
2. When retrieving 4 years of hydrological reanalysis data, ~14% of that time were spent in repeated calls to ([`ExtractionRequest.from_indices`](https://github.com/ecmwf/gribjump/blob/42199463205cb4e7a004b7ca6e0095a2658c15e9/python/pygribjump/src/pygribjump/pygribjump.py#L191C1-L196C42)). This fix would remove this overhead.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 