### PR TITLE
Override `eccodes.Message.copy`

### DIFF
--- a/src/earthkit/data/utils/message.py
+++ b/src/earthkit/data/utils/message.py
@@ -227,6 +227,9 @@ class CodesHandle(eccodes.Message):
     def get_long(self, name):
         return self.get(name, ktype=int)
 
+    def copy(self):
+        return self.clone()
+
     @check_clone_kwargs
     def clone(self, **kwargs):
         return self._from_raw_handle(eccodes.codes_clone(self._handle, **kwargs))


### PR DESCRIPTION
### Description
Addresses the issue https://github.com/ecmwf/earthkit-data/issues/882 by overriding `eccodes.Message.copy` to use `CodesHandle.clone` instead.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 