### PR TITLE
Do not use eckit Grid.spec for gridspecs

### DIFF
--- a/src/earthkit/data/readers/grib/metadata.py
+++ b/src/earthkit/data/readers/grib/metadata.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import json
 import logging
 import warnings
 from abc import abstractmethod
@@ -70,6 +71,7 @@ class GeoBasedGribFieldGeography(Geography):
         from eckit.geo import Grid
 
         self._grid = Grid(grid_spec)
+        self._grid_spec = grid_spec
         self.metadata = metadata
 
     @thread_safe_cached_property
@@ -177,10 +179,16 @@ class GeoBasedGribFieldGeography(Geography):
         )
 
     def gridspec(self):
-        return self._grid.spec
+        # TODO: call Grid.spec once it is available in eckit
+        if isinstance(self._grid_spec, str):
+            return json.loads(self._grid_spec)
+        return self._grid_spec
 
     def grid_spec(self):
-        return self._grid.spec
+        # TODO: call Grid.spec once it is available in eckit
+        if isinstance(self._grid_spec, str):
+            return json.loads(self._grid_spec)
+        return self._grid_spec
 
     def resolution(self):
         return None
@@ -872,8 +880,8 @@ class GribMetadata(Metadata):
                 if grid_spec is not None and grid_spec != "":
                     return GeoBasedGribFieldGeography(grid_spec, self)
                 else:
-                    # no fallback in ecCodes for grids
-                    raise RuntimeError("Cannot get grid_spec from ecCodes handle")
+                    # fallback to non-eckit based geo support in ecCodes
+                    return GribFieldGeography(self)
 
             return GribFieldGeography(self)
 

--- a/tests/grib/test_grib_geography.py
+++ b/tests/grib/test_grib_geography.py
@@ -223,6 +223,59 @@ def test_grib_projection_mercator(fl_type):
     assert projection.globe == dict()
 
 
+@pytest.mark.parametrize("fl_type", FL_TYPES)
+@pytest.mark.parametrize(
+    "filename,expected_shape, expected_lat, expected_lon",
+    [
+        (
+            "mercator.grib",
+            (
+                225,
+                339,
+            ),
+            [16.9775, 16.9775, 16.9775, 16.9775],
+            [291.9722, 291.9841626, 291.9961252, 292.0080878],
+        ),
+        (
+            "rgg_small_subarea_cellarea_ref.grib",
+            (340,),
+            [89.87647835, 89.80635732, 89.73614327, 89.66589394],
+            [45.0, 38.57142857, 45.0, 40.0],
+        ),
+        (
+            "rotated_N32_subarea.grib",
+            (225,),
+            [85.489232, 84.81188, 83.171928, 81.086144],
+            [140.0, 110.950144, 92.460416, 82.07156],
+        ),
+        (
+            "rotated_wind_20x20.grib",
+            (9, 18),
+            [30.0, 29.351052, 27.504876, 24.734374],
+            [140.0, 136.09296, 132.770576, 130.469424],
+        ),
+        (
+            "ll_10_20.grib",
+            (
+                9,
+                36,
+            ),
+            [80.0, 80.0, 80.0, 80.0],
+            [0.0, 10.0, 20.0, 30.0],
+        ),
+    ],
+)
+def test_grib_latlon_various_grids(fl_type, filename, expected_shape, expected_lat, expected_lon):
+    ds, _ = load_grib_data(filename, fl_type, folder="data")
+    ll = ds[0].to_latlon = ds[0].to_latlon()
+    lat = ll["lat"]
+    lon = ll["lon"]
+    assert lat.shape == expected_shape
+    assert lon.shape == expected_shape
+    assert np.allclose(lat.flatten()[:4], expected_lat)
+    assert np.allclose(lon.flatten()[:4], expected_lon)
+
+
 @pytest.mark.parametrize(
     "path,expected_value",
     [


### PR DESCRIPTION
### Description

In the experimental geography code using `eckit.geo.Grid.spec` is disabled since it does not seem to work in the version used.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 