### PR TITLE
Semantics of xr-engine decode_timedelta kwarg fixed

### DIFF
--- a/src/earthkit/data/utils/xarray/coord.py
+++ b/src/earthkit/data/utils/xarray/coord.py
@@ -10,6 +10,8 @@
 import datetime
 import logging
 
+import numpy as np
+
 from .dim import DATE_KEYS
 from .dim import DATETIME_KEYS
 from .dim import LEVEL_KEYS
@@ -144,6 +146,12 @@ class StepCoord(Coord):
     }
 
     def convert(self, profile):
+        if len(self.vals) == 0:
+            return self.vals
+        x = self.vals[0]
+        if isinstance(x, datetime.timedelta) or hasattr(x, "dtype") and np.issubdtype(x, np.timedelta64):
+            return self.vals
+
         from earthkit.data.utils.dates import to_timedelta
 
         vals = [to_timedelta(x) for x in self.vals]

--- a/tests/xr_engine/test_xr_attrs.py
+++ b/tests/xr_engine/test_xr_attrs.py
@@ -9,7 +9,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-import datetime
 import os
 import sys
 

--- a/tests/xr_engine/test_xr_attrs.py
+++ b/tests/xr_engine/test_xr_attrs.py
@@ -13,6 +13,7 @@ import datetime
 import os
 import sys
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -56,7 +57,7 @@ def _get_attrs_for_key_2(key, metadata):
             {
                 "date": [20240603, 20240604],
                 "time": [0, 1200],
-                "step_timedelta": [datetime.timedelta(hours=0), datetime.timedelta(hours=6)],
+                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
                 "levelist": [500, 700],
             },
             {"date": 2, "time": 2, "step_timedelta": 2, "levelist": 2},
@@ -75,11 +76,11 @@ def _get_attrs_for_key_2(key, metadata):
             {
                 "date": [20240603, 20240604],
                 "time": [0, 1200],
-                "step_timedelta": [datetime.timedelta(hours=0), datetime.timedelta(hours=6)],
+                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
                 "levelist": [500, 700],
             },
             {"date": 2, "time": 2, "step_timedelta": 2, "levelist": 2},
-            {"levtype": 2},
+            {"levtype": "pl"},
         ),
         (
             {
@@ -94,7 +95,7 @@ def _get_attrs_for_key_2(key, metadata):
             {
                 "date": [20240603, 20240604],
                 "time": [0, 1200],
-                "step_timedelta": [datetime.timedelta(hours=0), datetime.timedelta(hours=6)],
+                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
                 "levelist": [500, 700],
             },
             {"date": 2, "time": 2, "step_timedelta": 2, "levelist": 2},
@@ -113,11 +114,11 @@ def _get_attrs_for_key_2(key, metadata):
             {
                 "date": [20240603, 20240604],
                 "time": [0, 1200],
-                "step_timedelta": [datetime.timedelta(hours=0), datetime.timedelta(hours=6)],
+                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
                 "levelist": [500, 700],
             },
             {"date": 2, "time": 2, "step_timedelta": 2, "levelist": 2},
-            {"levtype": 2},
+            {"levtype": "pl"},
         ),
     ],
 )
@@ -129,7 +130,7 @@ def test_xr_dims_as_attrs(allow_holes, lazy_load, kwargs, coords, dims, attrs):
     compare_dims(ds, dims, sizes=True)
 
     for k, v in attrs.items():
-        ds["t"].attrs[k] == v
+        assert ds["t"].attrs[k] == v
 
 
 @pytest.mark.cache
@@ -388,7 +389,7 @@ def test_xr_dims_as_attrs_3(lazy_load, allow_holes, idx, kwargs, coords, dims, v
             {
                 "date": [20240603, 20240604],
                 "time": [0, 1200],
-                "step_timedelta": [datetime.timedelta(hours=0), datetime.timedelta(hours=6)],
+                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
                 "levelist": [500, 700],
             },
             {"date": 2, "time": 2, "step_timedelta": 2, "levelist": 2},

--- a/tests/xr_engine/test_xr_incomplete_tensor.py
+++ b/tests/xr_engine/test_xr_incomplete_tensor.py
@@ -26,6 +26,7 @@ from earthkit.data.testing import earthkit_remote_test_data_file
             {
                 "profile": "mars",
                 "time_dim_mode": "raw",
+                "dim_roles": {"step": "step"},
                 "decode_times": False,
                 "allow_holes": True,
             },
@@ -97,6 +98,7 @@ def test_xr_incomplete_tensor_holes(lazy_load, kwargs, dim_keys, or_mask_spec, n
             {
                 "profile": "mars",
                 "time_dim_mode": "raw",
+                "dim_roles": {"step": "step"},
                 "dims_as_attrs": ["step"],
                 "decode_times": False,
                 "allow_holes": True,
@@ -155,7 +157,7 @@ def test_xr_incomplete_tensor_holes2(
     assert len(ds_ek_masked) == nfields
 
     ds = ds_ek_masked.to_xarray(**kwargs)
-    assert ds["t"].attrs["step"] == pd.Timedelta(0, "s")
+    assert ds["t"].attrs["step"] == 0
 
     kwargs_with_full_tensor = kwargs.copy()
     kwargs_with_full_tensor["allow_holes"] = False
@@ -186,6 +188,7 @@ def test_xr_incomplete_tensor_holes2(
             {
                 "profile": "mars",
                 "time_dim_mode": "raw",
+                "dim_roles": {"step": "step"},
                 "decode_times": False,
                 "allow_holes": True,
             },

--- a/tests/xr_engine/test_xr_time.py
+++ b/tests/xr_engine/test_xr_time.py
@@ -31,6 +31,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
     [
         (
             {
+                "profile": None,
                 "time_dim_mode": "raw",
                 "decode_times": False,
                 "decode_timedelta": False,
@@ -41,6 +42,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "raw",
                 "dim_name_from_role_name": True,
             },
@@ -53,6 +55,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "forecast",
                 "decode_times": False,
                 "decode_timedelta": False,
@@ -71,6 +74,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "forecast",
                 "dim_name_from_role_name": True,
             },
@@ -87,6 +91,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "valid_time",
                 "decode_times": False,
                 "decode_timedelta": False,
@@ -108,6 +113,7 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "valid_time",
                 "decode_times": True,
                 "decode_timedelta": True,
@@ -129,23 +135,25 @@ from xr_engine_fixtures import compare_dims  # noqa: E402
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "raw",
                 "decode_times": False,
                 "decode_timedelta": False,
                 "dim_name_from_role_name": False,
             },
-            {"date": [20240603, 20240604], "time": [0, 1200], "step_timedelta": [0, 6]},
-            ("step_timedelta", "hours"),
+            {"date": [20240603, 20240604], "time": [0, 1200], "step": [0, 6]},
+            ("step", "hours"),
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "raw",
                 "dim_name_from_role_name": False,
             },
             {
                 "date": [np.datetime64("2024-06-03", "ns"), np.datetime64("2024-06-04", "ns")],
                 "time": [np.timedelta64(0, "s"), np.timedelta64(43200, "s")],
-                "step_timedelta": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
+                "step": [np.timedelta64(0, "h"), np.timedelta64(6, "h")],
             },
             None,
         ),
@@ -296,10 +304,9 @@ def test_xr_time_seasonal_monthly_indexing_date(allow_holes, kwargs, dims, step_
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "raw",
                 "dim_roles": {"step": "forecastMonth"},
-                "decode_times": False,
-                "decode_timedelta": False,
                 "ensure_dims": ["number", "date", "time", "forecastMonth"],
                 "dim_name_from_role_name": False,
             },
@@ -360,8 +367,8 @@ def test_xr_time_seasonal_monthly_indexing_date(allow_holes, kwargs, dims, step_
             {
                 "time_dim_mode": "raw",
                 "dim_roles": {"step": "forecastMonth"},
-                "decode_times": False,
-                "decode_timedelta": False,
+                "decode_times": True,
+                "decode_timedelta": True,
                 "ensure_dims": ["number", "date", "time", "step"],
                 "dim_name_from_role_name": True,
             },
@@ -402,6 +409,7 @@ def test_xr_time_seasonal_monthly_simple(allow_holes, kwargs, dims, step_units):
     [
         (
             {
+                "profile": None,
                 "time_dim_mode": "forecast",
                 "add_valid_time_coord": True,
                 "decode_times": False,
@@ -469,6 +477,7 @@ def test_xr_time_seasonal_monthly_simple(allow_holes, kwargs, dims, step_units):
         ),
         (
             {
+                "profile": None,
                 "time_dim_mode": "forecast",
                 "add_valid_time_coord": True,
                 "decode_times": False,
@@ -480,9 +489,9 @@ def test_xr_time_seasonal_monthly_simple(allow_holes, kwargs, dims, step_units):
                     np.datetime64("2024-06-03T00", "ns"),
                     np.datetime64("2024-06-03T12", "ns"),
                 ],
-                "step_timedelta": [0, 6],
+                "step": [0, 6],
             },
-            ("step_timedelta", "hours"),
+            ("step", "hours"),
             {
                 "valid_time": [
                     [np.datetime64("2024-06-03T00", "ns"), np.datetime64("2024-06-03T06", "ns")],

--- a/tests/xr_engine/xr_engine_fixtures.py
+++ b/tests/xr_engine/xr_engine_fixtures.py
@@ -87,7 +87,7 @@ def compare_coord(ds, name, ref_vals, mode="coord"):
                 assert vals[i] == ref_vals[i], f"{name=} {vals[i]} != {ref_vals[i]}"
         # other arrays
         else:
-            assert np.allclose(ds.coords[name].values, vals), f"{name=} {ds.coords[name].values} != {vals}"
+            assert np.allclose(vals, ref_vals), f"{name=} {vals} != {ref_vals}"
 
 
 def compare_dim_order(ds, dims, order_ref_var, check_coord=True):


### PR DESCRIPTION
### Description

The `decode_timedelta` kwargs will conform to the docstring in the xr-engine method `.to_xarray()`:
If the coordinate `step` has `int` or `str` values (e.g. when issued from the GRIB key `step`) and `decode_timedelta=True`, then a conversion to `timedelta` is applied. In other cases the `step` coordinate remain unchanged (either as `int` or `timedelta`, if it was issued from the `step_timedelta` key)

Several xr-engine tests were adjusted or corrected to accomodate this change.
Also, the coordinate comparison test (in xr-engine tests) was fixed.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 