### PR TITLE
Perf/better tensor indexing

### DIFF
--- a/src/earthkit/data/indexing/tensor.py
+++ b/src/earthkit/data/indexing/tensor.py
@@ -236,7 +236,8 @@ class TensorCore(metaclass=ABCMeta):
                     if not isinstance(v, (list, tuple, np.ndarray)):
                         v = (v,)
                     r[k] = v
-                elif isinstance(idx, list):
+                else:
+                    # idx must be an iterable (list, numpy array, etc.)
                     r[k] = tuple([self._user_coords[k][i] for i in idx])
             else:
                 r[k] = self._user_coords[k]
@@ -400,7 +401,7 @@ class FieldListTensor(TensorCore):
 
     def _prepare_tensor_data(self, source_to_array_func, index=None):
         if index is not None:
-            if all(i == slice(None, None, None) for i in index):
+            if all(isinstance(i, slice) and i == slice(None, None, None) for i in index):
                 index = None
 
         if index is None:
@@ -419,12 +420,18 @@ class FieldListTensor(TensorCore):
                 # where `coord` is an item (not a 1-element list),
                 # * `self.user_shape` does not lose the dimension `dim`, even if `dim` is one of user dims
                 # * `field_shape` does lose the dimension `dim` if `dim` is a field dimension
-                current_field_shape = tuple(
-                    len(range(n)[_slice])
-                    for n, _slice in zip(self.field_shape, index)
-                    if not isinstance(_slice, int)
-                    # `_slice` can be either an `int` or a `slice`; if `int`, ignore it!
-                )
+                current_field_shape = []
+                for n, _idx in zip(self.field_shape, index):
+                    if isinstance(_idx, int):
+                        # simply, ignore this index
+                        continue
+                    if isinstance(_idx, slice):
+                        _size = len(range(n)[_idx])
+                    else:
+                        # _idx must be an iterable of integers
+                        _size = len(np.arange(n)[_idx])
+                    current_field_shape.append(_size)
+                current_field_shape = tuple(current_field_shape)
 
         return arr, current_field_shape
 
@@ -459,7 +466,11 @@ class FieldListTensor(TensorCore):
     def is_full_field(self, indexes):
         assert len(indexes) == len(self._field_shape)
         for i, s in enumerate(indexes):
-            if not (s is None or s == slice(None, None, None) or s == slice(0, self._field_shape[i], 1)):
+            if not (
+                s is None
+                or isinstance(s, slice)
+                and (s == slice(None, None, None) or s == slice(0, self._field_shape[i], 1))
+            ):
                 return False
         return True
 

--- a/src/earthkit/data/xr_engine/builder.py
+++ b/src/earthkit/data/xr_engine/builder.py
@@ -235,7 +235,7 @@ class TensorBackendArray(xarray.backends.common.BackendArray):
         return indexing.explicit_indexing_adapter(
             key,
             self.shape,
-            indexing.IndexingSupport.BASIC,
+            indexing.IndexingSupport.OUTER,
             self._raw_indexing_method,
         )
         # bug in xarray here? tries to create a NumpyIndexingAdapter instead of NdArrayLikeIndexingAdapter

--- a/tests/xr_engine/test_xr_engine_indexing.py
+++ b/tests/xr_engine/test_xr_engine_indexing.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+import numpy as np
+import pytest
+
+from earthkit.data import from_source
+from earthkit.data.utils.testing import earthkit_remote_test_data_file
+
+
+@pytest.mark.cache
+@pytest.mark.long_test
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("allow_holes", [False, True])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"chunks": "auto"},
+        {"chunks": {"valid_time": 100}},
+    ],
+)
+def test_xr_engine_daily_mean(allow_holes, kwargs):
+    ds_ek = from_source(
+        "url", earthkit_remote_test_data_file("era5-Europe-sfc-2m-temperature-3deg-2015-2017.grib")
+    ).to_fieldlist()
+    ds = ds_ek.to_xarray(time_dim_mode="valid_time", allow_holes=allow_holes, **kwargs)
+
+    daily_mean_ds = ds.groupby("valid_time.dayofyear").mean()
+    temp_variability_ds = daily_mean_ds.mean(["longitude", "latitude"]).std("dayofyear").compute()
+    assert np.allclose(temp_variability_ds["2t"].values, 5.840784279794131)
+
+    daily_anomaly_from_daily_mean_ds = (
+        ds.resample({"valid_time": "24h"}).mean().groupby("valid_time.dayofyear")
+        - ds.groupby("valid_time.dayofyear").mean()
+    )
+    max_abs_anomaly_ds = np.abs(daily_anomaly_from_daily_mean_ds).max().compute()
+    assert np.allclose(max_abs_anomaly_ds["2t"].values, 22.586798350016267)
+
+    monthly_mean_ds = ds.groupby("valid_time.month").mean()
+    daily_anomaly_from_monthly_mean_ds = (
+        ds.resample({"valid_time": "24h"}).mean().groupby("valid_time.month") - monthly_mean_ds
+    )
+    assert np.allclose(np.abs(daily_anomaly_from_monthly_mean_ds).max()["2t"].values, 28.98466590143022)


### PR DESCRIPTION
### Description

This PR addresses a performance issue which arises in certain xarray computational workflows involving earthkit lazy loaded GRIB data. 

For example, consider a 3-year time-series temperature data with 6h resolution (~4k fields, stored in GRIB). Calculating climatological daily mean for a given day of year requires taking an average of 12 fields scattered along the whole time axis (4 fields per day x 3 years). The existing indexing method of an earthkit-data tensor allows for `BASIC` indexing method only: each axis can be indexed with an int or a slice (see https://docs.xarray.dev/en/stable/internals/how-to-add-new-backend.html#indexing-examples):
https://github.com/ecmwf/earthkit-data/blob/11e7ed5ad1ae94e48b5e5926f821e98baba0373b/src/earthkit/data/xr_engine/builder.py#L238
In turns out, that when the GRIB data is opened with earthkit and converted into an xarray object with `.to_xarray()` method using (the default) lazy-loading, then the xarray calculation
```
ds.groupby("valid_time.dayofyear").mean()
```
triggers the following access pattern to the underlying GRIB fields: for each day of a year (`d`), a slice of the 3-year time-series of fields spanning from `year0 + day d` to `year2 + day d` (which covers ~2/3 of the time-series) is accessed and converted to (a numpy) array. In total, the above calculation of the climatological daily mean triggers ~365 x (2/3) x 4k accesses to the GRIB fields, or, in other terms, each of the ~4k fields is accessed ~ 365 x (2/3) times. Of course, an optimal execution of such a workflow should access each field just once.

The solution proposed here is to extend the earthkit tensor indexing to `OUTER` method, which, besides a single int or a slice, allows a *list of int's* as an indexer. In the scenario of the same computation as above (climatology daily mean), it allows xarray to use much more efficient access pattern to the underlying GRIB fields: for each day of year, only 12 fields that are actually needed are being accessed. It means that each field is accessed once. In this way, the execution time of the example computation drops from 3-5 minutes (depending on the platform) to ~1 sec.

A performance test based on the above example computation workflow and its variants has been added. A generous timeout  constraint (~3x larger than needed for a MacBook laptop) is imposed.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 