### PR TITLE
Source to access data from Zenodo based on record ID or DOI

### DIFF
--- a/docs/source/concepts/inputs/from_source.rst
+++ b/docs/source/concepts/inputs/from_source.rst
@@ -1298,7 +1298,7 @@ zenodo
   :param identifier: a record ID, URL or DOI.
   :type identifier: int, str
   :param only: the files to select from the record. Accepts a glob pattern that is matched against the file names in the record or an explicit list of file names to select. By default, all files in the record are selected.
-  :type filenames: str, sequence of str, None
+  :type only: str, sequence of str, None
   :param dict **kwargs: other keyword arguments passed to the :ref:`url <data-sources-url>` source.
 
 

--- a/docs/source/concepts/inputs/from_source.rst
+++ b/docs/source/concepts/inputs/from_source.rst
@@ -77,6 +77,8 @@ from_source
       - deprecated, use :ref:`data-sources-wekeo-cds` instead
     * - :ref:`data-sources-zarr`
       - load data from a `Zarr <https://zarr.readthedocs.io/en/stable/>`_ store
+    * - :ref:`data-sources-zenodo`
+      - retrieve data from a `Zenodo <https://zenodo.org/>`_ record
 
 ----------------------------------
 
@@ -1281,6 +1283,23 @@ zarr
 
   :param str path: path or URL to the Zarr store
 
+
+.. _data-sources-zenodo:
+
+zenodo
+--------
+
+.. py:function:: from_source("zenodo", identifier, only=None, **kwargs)
+  :noindex:
+
+  `Zenodo <https://zenodo.org/>`_ is an open repository for research data and related information.
+  The ``zenodo`` source provides access to files attached to a Zenodo record via the Zenodo API.
+
+  :param identifier: a record ID, URL or DOI.
+  :type identifier: int, str
+  :param only: the files to select from the record. Accepts a glob pattern that is matched against the file names in the record or an explicit list of file names to select. By default, all files in the record are selected.
+  :type filenames: str, sequence of str, None
+  :param dict **kwargs: other keyword arguments passed to the :ref:`url <data-sources-url>` source.
 
 
 .. _MARS catalog: https://apps.ecmwf.int/archive-catalogue/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "pandas",
   "pdbufr>=0.11",
   "pyyaml",
+  "requests",
   "tqdm>=4.63",
   "xarray>=0.19"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "pandas",
   "pdbufr>=0.11",
   "pyyaml",
+  "requests",
   "tqdm>=4.63",
   "xarray>=0.19"
 ]

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -445,6 +445,15 @@ def from_source(
 ) -> "Data": ...
 
 
+@overload
+def from_source(
+    name: Literal["zenodo"],
+    identifier: str | int,
+    only: str | list[str],
+    **kwargs,
+) -> "Data": ...
+
+
 def from_source(name: str, *args, lazily=False, **kwargs) -> "Data":
     if lazily:
         return from_source_lazily(name, *args, **kwargs)

--- a/src/earthkit/data/sources/zenodo.py
+++ b/src/earthkit/data/sources/zenodo.py
@@ -1,0 +1,65 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+import fnmatch
+import re
+
+import requests
+
+from earthkit.data.sources import Source
+from earthkit.data.sources import from_source_internal
+
+_DOI_PATTERN = re.compile(r"^(?:doi:\s*)?(10\.5281/zenodo\.\d+)$", flags=re.IGNORECASE)
+_URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records\/(\d+)\/?$")
+
+
+def _resolve_doi(doi):
+    r = requests.get(f"https://doi.org/{doi}")
+    r.raise_for_status()
+    return r.url
+
+
+def _get_file_list(record_id):
+    r = requests.get(f"https://zenodo.org/api/records/{record_id}")
+    r.raise_for_status()
+    return {f["key"] for f in r.json()["files"]}
+
+
+class Zenodo(Source):
+
+    def __init__(self, identifier, file="*", **kwargs):
+        super().__init__()
+        self.kwargs = kwargs
+
+        if match := _DOI_PATTERN.match(identifier):
+            identifier = _resolve_doi(match.group(1))
+
+        if isinstance(identifier, int):
+            self.record_id = identifier
+        elif match := _URL_PATTERN.match(identifier):
+            self.record_id = int(match.group(1))
+        elif identifier.isnumeric():
+            self.record_id = int(identifier)
+        else:
+            raise ValueError(f"unable to determine record ID from identifier {identifier}")
+
+        # Obtain the list of files in the record and match against provided pattern
+        record_files = _get_file_list(self.record_id)
+        if file is None:
+            self.files = record_files
+        else:
+            self.files = fnmatch.filter(record_files, file)
+            if not self.files:
+                raise FileNotFoundError(file)  # TODO
+
+    def mutate(self):
+        urls = [f"https://zenodo.org/records/{self.record_id}/files/{file}?download=1" for file in self.files]
+        return from_source_internal("url", urls, **self.kwargs)
+
+
+source = Zenodo

--- a/src/earthkit/data/sources/zenodo.py
+++ b/src/earthkit/data/sources/zenodo.py
@@ -7,59 +7,136 @@
 # does it submit to any jurisdiction.
 
 import fnmatch
+import logging
 import re
 
 import requests
 
-from earthkit.data.sources import Source
-from earthkit.data.sources import from_source_internal
+from earthkit.data.core.config import CONFIG
+from earthkit.data.sources import Source, from_source_internal
+
+LOG = logging.getLogger(__name__)
 
 _DOI_PATTERN = re.compile(r"^(?:doi:\s*)?(10\.5281/zenodo\.\d+)$", flags=re.IGNORECASE)
-_URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records\/(\d+)\/?$")
+_URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records?\/(\d+)\/?(?:\?.*)?$")
 
 
 def _resolve_doi(doi):
-    r = requests.get(f"https://doi.org/{doi}")
-    r.raise_for_status()
-    return r.url
+    timeout = CONFIG.get("url-download-timeout")
+
+    LOG.debug("Resolving DOI %s", doi)
+    try:
+        r = requests.get(f"https://doi.org/{doi}", timeout=timeout)
+        r.raise_for_status()
+    except requests.ConnectionError as e:
+        raise RuntimeError("Could not connect to doi.org") from e
+    except requests.Timeout as e:
+        raise RuntimeError(f"request to doi.org timed out after {timeout}s") from e
+    except requests.HTTPError as e:
+        raise RuntimeError(f"doi.org returned HTTP {r.status_code}") from e
+
+    resolved_url = r.url
+    LOG.debug(f"DOI {doi} resolved to {resolved_url}")
+
+    match = _URL_PATTERN.match(resolved_url)
+    if not match:
+        raise ValueError(f"DOI '{doi}' resolved to an unexpected URL: {resolved_url}. Expected a Zenodo record URL.")
+    return int(match.group(1))
 
 
-def _get_file_list(record_id):
-    r = requests.get(f"https://zenodo.org/api/records/{record_id}")
-    r.raise_for_status()
-    return {f["key"] for f in r.json()["files"]}
+def _get_record_files(record_id):
+    timeout = CONFIG.get("url-download-timeout")
+
+    api_url = f"https://zenodo.org/api/records/{record_id}"
+    LOG.debug(f"Fetching file list for record {record_id} from {api_url}")
+    try:
+        r = requests.get(api_url, timeout=timeout)
+        r.raise_for_status()
+    except requests.ConnectionError as e:
+        raise RuntimeError("could not connect to zenodo.org") from e
+    except requests.Timeout as e:
+        raise RuntimeError(f"request to zenodo.org timed out after {timeout}s.") from e
+    except requests.HTTPError as e:
+        raise RuntimeError(f"Zenodo API returned HTTP {r.status_code}") from e
+
+    try:
+        data = r.json()
+    except ValueError as e:
+        raise RuntimeError("failed to parse Zenodo API response") from e
+
+    if "files" not in data or not data["files"]:
+        raise RuntimeError(f"Record {record_id} has no accessible files. The record may be restricted or embargoed.")
+
+    files = [f["key"] for f in data["files"]]
+    LOG.debug(f"Record {record_id} contains {len(files)} file(s): {files!r}")
+
+    # Map of file name to its download URL, sorted by file name
+    return {name: f"https://zenodo.org/records/{record_id}/files/{name}?download=1" for name in sorted(files)}
 
 
 class Zenodo(Source):
+    """Source for downloading files from Zenodo records.
 
-    def __init__(self, identifier, file="*", **kwargs):
+    Parameters
+    ----------
+    identifier : int | str
+        Record ID, Zenodo URL or DOI.
+    filenames : str | Sequence[str] | None, optional
+        File selection with a glob string or an explicit list of file names.
+        By default, all files are selected.
+    **kwargs
+        Additional keyword arguments forwarded to the  URL source.
+    """
+
+    def __init__(self, identifier, filenames=None, **kwargs):
         super().__init__()
-        self.kwargs = kwargs
+        self._kwargs = kwargs
 
-        if match := _DOI_PATTERN.match(identifier):
-            identifier = _resolve_doi(match.group(1))
+        if isinstance(identifier, str):
+            identifier = identifier.strip()
 
-        if isinstance(identifier, int):
+        # Resolve DOI to record ID
+        if isinstance(identifier, str) and (match := _DOI_PATTERN.match(identifier)):
+            doi = match.group(1)
+            self.record_id = _resolve_doi(doi)
+        # Treat everything else as a record ID
+        elif isinstance(identifier, int):
             self.record_id = identifier
-        elif match := _URL_PATTERN.match(identifier):
+        elif isinstance(identifier, str) and (match := _URL_PATTERN.match(identifier)):
             self.record_id = int(match.group(1))
-        elif identifier.isnumeric():
+        elif isinstance(identifier, str) and identifier.isnumeric():
             self.record_id = int(identifier)
         else:
-            raise ValueError(f"unable to determine record ID from identifier {identifier}")
+            raise ValueError(f"unable to determine record ID from identifier: {identifier!r}")
 
-        # Obtain the list of files in the record and match against provided pattern
-        record_files = _get_file_list(self.record_id)
-        if file is None:
-            self.files = record_files
+        LOG.info(f"Zenodo record ID: {self.record_id}")
+
+        # Fetch file metadata from the Zenodo API
+        record_files = _get_record_files(self.record_id)
+
+        # No filenames specified -> select all
+        if filenames is None:
+            self._file_urls = record_files
+        # Match filenames with provided pattern
+        elif isinstance(filenames, str):
+            matched = fnmatch.filter(record_files.keys(), filenames)
+            if not matched:
+                raise FileNotFoundError(f"no files in record {self.record_id} matched the pattern: {filenames!r}")
+            self._file_urls = {name: record_files[name] for name in matched}
+        # Select filenames based on provided list
         else:
-            self.files = fnmatch.filter(record_files, file)
-            if not self.files:
-                raise FileNotFoundError(file)  # TODO
+            for name in filenames:
+                if name not in record_files:
+                    raise FileNotFoundError(f"file {name!r} not found in record {self.record_id}")
+            self._file_urls = {name: record_files[name] for name in filenames}
+
+        LOG.info(
+            f"Selected {len(self._file_urls)} file(s) from record {self.record_id}:, ".join(self._file_urls.keys())
+        )
 
     def mutate(self):
-        urls = [f"https://zenodo.org/records/{self.record_id}/files/{file}?download=1" for file in self.files]
-        return from_source_internal("url", urls, **self.kwargs)
+        urls = list(self._file_urls.values())
+        return from_source_internal("url", urls, **self._kwargs)
 
 
 source = Zenodo

--- a/src/earthkit/data/sources/zenodo.py
+++ b/src/earthkit/data/sources/zenodo.py
@@ -65,14 +65,14 @@ class Zenodo(Source):
     ----------
     identifier : int | str
         Record ID, Zenodo URL or DOI. A DOI may also be given as a doi.org URL.
-    filenames : str | Sequence[str] | None, optional
+    only : str | Sequence[str] | None, optional
         File selection with a glob string or an explicit list of file names.
         By default, all files are selected.
     **kwargs
         Additional keyword arguments forwarded to the URL source.
     """
 
-    def __init__(self, identifier, filenames=None, **kwargs):
+    def __init__(self, identifier, only=None, **kwargs):
         super().__init__()
         self._kwargs = kwargs
 
@@ -99,23 +99,23 @@ class Zenodo(Source):
         record_files = _get_record_files(self.record_id)
 
         # No filenames specified -> select all
-        if filenames is None:
+        if only is None:
             self._file_urls = record_files
         # Match filenames with provided pattern
-        elif isinstance(filenames, str):
-            matched = fnmatch.filter(record_files.keys(), filenames)
+        elif isinstance(only, str):
+            matched = fnmatch.filter(record_files.keys(), only)
             if not matched:
-                raise FileNotFoundError(f"no files in record {self.record_id} match the pattern: {filenames!r}")
+                raise ValueError(f"no files in record {self.record_id} match the pattern: {only!r}")
             self._file_urls = {name: record_files[name] for name in matched}
         # Select filenames based on provided list
         else:
-            filenames = list(dict.fromkeys(filenames))  # deduplicate while preserving order
-            if not filenames:
-                raise FileNotFoundError(f"no files selected from record {self.record_id}")
-            self._file_urls = {name: record_files[name] for name in filenames if name in record_files}
-            if len(self._file_urls) != len(filenames):
-                missing = ", ".join(repr(name) for name in filenames if name not in record_files)
-                raise FileNotFoundError(f"file(s) not found in record {self.record_id}: " + missing)
+            only = list(dict.fromkeys(only))  # deduplicate while preserving order
+            if not only:
+                raise ValueError(f"no files selected from record {self.record_id}")
+            self._file_urls = {name: record_files[name] for name in only if name in record_files}
+            if len(self._file_urls) != len(only):
+                missing = ", ".join(repr(name) for name in only if name not in record_files)
+                raise ValueError(f"file(s) not found in record {self.record_id}: " + missing)
 
         selected = ", ".join(self._file_urls.keys())
         LOG.info(f"Selected {len(self._file_urls)} file(s) from record {self.record_id}: {selected}")

--- a/src/earthkit/data/sources/zenodo.py
+++ b/src/earthkit/data/sources/zenodo.py
@@ -22,7 +22,7 @@ _DOI_PATTERN = re.compile(
     r"^(?:doi:\s*|(?:https?:\/\/)?(?:dx\.)?doi\.org\/)?10\.5281/zenodo\.(\d+)\/?$",
     flags=re.IGNORECASE,
 )
-_URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records?\/(\d+)\/?(?:\?.*)?$")
+_URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records?\/(\d+)\/?(?:\?.*)?$", flags=re.IGNORECASE)
 
 
 def _get_record_files(record_id):
@@ -45,7 +45,9 @@ def _get_record_files(record_id):
     except ValueError as e:
         raise RuntimeError("failed to parse Zenodo API response") from e
 
-    if "files" not in data or not data["files"]:
+    if not isinstance(data, dict) or "files" not in data:
+        raise RuntimeError(f"unexpected Zenodo API response for record {record_id}")
+    if not data["files"]:
         raise RuntimeError(f"Record {record_id} has no accessible files. The record may be restricted or embargoed.")
 
     try:

--- a/src/earthkit/data/sources/zenodo.py
+++ b/src/earthkit/data/sources/zenodo.py
@@ -13,35 +13,16 @@ import re
 import requests
 
 from earthkit.data.core.config import CONFIG
-from earthkit.data.sources import Source, from_source_internal
+from earthkit.data.sources import Source
+from earthkit.data.sources.multi_url import MultiUrl
 
 LOG = logging.getLogger(__name__)
 
-_DOI_PATTERN = re.compile(r"^(?:doi:\s*)?(10\.5281/zenodo\.\d+)$", flags=re.IGNORECASE)
+_DOI_PATTERN = re.compile(
+    r"^(?:doi:\s*|(?:https?:\/\/)?(?:dx\.)?doi\.org\/)?10\.5281/zenodo\.(\d+)\/?$",
+    flags=re.IGNORECASE,
+)
 _URL_PATTERN = re.compile(r"^(?:https?:\/\/)?zenodo\.org\/records?\/(\d+)\/?(?:\?.*)?$")
-
-
-def _resolve_doi(doi):
-    timeout = CONFIG.get("url-download-timeout")
-
-    LOG.debug("Resolving DOI %s", doi)
-    try:
-        r = requests.get(f"https://doi.org/{doi}", timeout=timeout)
-        r.raise_for_status()
-    except requests.ConnectionError as e:
-        raise RuntimeError("Could not connect to doi.org") from e
-    except requests.Timeout as e:
-        raise RuntimeError(f"request to doi.org timed out after {timeout}s") from e
-    except requests.HTTPError as e:
-        raise RuntimeError(f"doi.org returned HTTP {r.status_code}") from e
-
-    resolved_url = r.url
-    LOG.debug(f"DOI {doi} resolved to {resolved_url}")
-
-    match = _URL_PATTERN.match(resolved_url)
-    if not match:
-        raise ValueError(f"DOI '{doi}' resolved to an unexpected URL: {resolved_url}. Expected a Zenodo record URL.")
-    return int(match.group(1))
 
 
 def _get_record_files(record_id):
@@ -67,11 +48,14 @@ def _get_record_files(record_id):
     if "files" not in data or not data["files"]:
         raise RuntimeError(f"Record {record_id} has no accessible files. The record may be restricted or embargoed.")
 
-    files = [f["key"] for f in data["files"]]
-    LOG.debug(f"Record {record_id} contains {len(files)} file(s): {files!r}")
+    try:
+        # URLs from API response, works for record and concept IDs
+        file_urls = {f["key"]: f["links"]["self"] for f in data["files"]}
+    except (KeyError, TypeError) as e:
+        raise RuntimeError(f"unexpected file entry in the Zenodo API response for record {record_id}") from e
 
-    # Map of file name to its download URL, sorted by file name
-    return {name: f"https://zenodo.org/records/{record_id}/files/{name}?download=1" for name in sorted(files)}
+    LOG.debug(f"Record {record_id} contains {len(file_urls)} file(s): {list(file_urls)!r}")
+    return file_urls
 
 
 class Zenodo(Source):
@@ -80,12 +64,12 @@ class Zenodo(Source):
     Parameters
     ----------
     identifier : int | str
-        Record ID, Zenodo URL or DOI.
+        Record ID, Zenodo URL or DOI. A DOI may also be given as a doi.org URL.
     filenames : str | Sequence[str] | None, optional
         File selection with a glob string or an explicit list of file names.
         By default, all files are selected.
     **kwargs
-        Additional keyword arguments forwarded to the  URL source.
+        Additional keyword arguments forwarded to the URL source.
     """
 
     def __init__(self, identifier, filenames=None, **kwargs):
@@ -95,11 +79,11 @@ class Zenodo(Source):
         if isinstance(identifier, str):
             identifier = identifier.strip()
 
-        # Resolve DOI to record ID
+        # A Zenodo DOI is 10.5281/zenodo.<record ID>, so no lookup via doi.org is needed.
+        # For a concept DOI this is the concept record's ID, which the API redirects to the
+        # latest version, and the file URLs then refer to that version.
         if isinstance(identifier, str) and (match := _DOI_PATTERN.match(identifier)):
-            doi = match.group(1)
-            self.record_id = _resolve_doi(doi)
-        # Treat everything else as a record ID
+            self.record_id = int(match.group(1))
         elif isinstance(identifier, int):
             self.record_id = identifier
         elif isinstance(identifier, str) and (match := _URL_PATTERN.match(identifier)):
@@ -121,22 +105,24 @@ class Zenodo(Source):
         elif isinstance(filenames, str):
             matched = fnmatch.filter(record_files.keys(), filenames)
             if not matched:
-                raise FileNotFoundError(f"no files in record {self.record_id} matched the pattern: {filenames!r}")
+                raise FileNotFoundError(f"no files in record {self.record_id} match the pattern: {filenames!r}")
             self._file_urls = {name: record_files[name] for name in matched}
         # Select filenames based on provided list
         else:
-            for name in filenames:
-                if name not in record_files:
-                    raise FileNotFoundError(f"file {name!r} not found in record {self.record_id}")
-            self._file_urls = {name: record_files[name] for name in filenames}
+            filenames = list(dict.fromkeys(filenames))  # deduplicate while preserving order
+            if not filenames:
+                raise FileNotFoundError(f"no files selected from record {self.record_id}")
+            self._file_urls = {name: record_files[name] for name in filenames if name in record_files}
+            if len(self._file_urls) != len(filenames):
+                missing = ", ".join(repr(name) for name in filenames if name not in record_files)
+                raise FileNotFoundError(f"file(s) not found in record {self.record_id}: " + missing)
 
-        LOG.info(
-            f"Selected {len(self._file_urls)} file(s) from record {self.record_id}:, ".join(self._file_urls.keys())
-        )
+        selected = ", ".join(self._file_urls.keys())
+        LOG.info(f"Selected {len(self._file_urls)} file(s) from record {self.record_id}: {selected}")
 
     def mutate(self):
         urls = list(self._file_urls.values())
-        return from_source_internal("url", urls, **self._kwargs)
+        return MultiUrl(urls, **self._kwargs)
 
 
 source = Zenodo

--- a/tests/sources/test_zenodo.py
+++ b/tests/sources/test_zenodo.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2026 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import pytest
+import requests
+
+from earthkit.data import config, from_source
+from earthkit.data.sources import _from_source_internal, get_source
+from earthkit.data.sources import zenodo as zenodo_module
+
+# Test up to the point where the Zenodo source mutates into a MultiURL source.
+# Create a fake Zenodo API and verify the generated URLs.
+
+RECORD_ID = 123
+CONCEPT_ID = 678
+FILES = ["b.grib", "a.grib", "c.nc"]
+
+
+def DOI(id):
+    """The DOI for a given Zenodo record ID."""
+    return f"10.5281/zenodo.{id}"  # as per https://support.zenodo.org/help/en-gb/18-general/216-what-is-a-doi
+
+
+def download_url(name, record_id=RECORD_ID):
+    """The download URL as the Zenodo API reports it in files[*].links.self."""
+    return f"https://zenodo.org/api/records/{record_id}/files/{name}/content"
+
+
+def assert_selected(zenodo, names=FILES, record_id=RECORD_ID):
+    """Compare selections ignoring order, which is not part of the source's contract."""
+    assert set(zenodo.urls) == set(download_url(name, record_id) for name in names)
+
+
+BAD_JSON = object()
+UNSET = object()
+
+
+class FakeResponse:
+    def __init__(self, url, status_code=200, payload=None):
+        self.url = url
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code} for {self.url}", response=self)
+
+    def json(self):
+        if self._payload is BAD_JSON:
+            raise ValueError("not valid JSON")
+        return self._payload
+
+
+class FakeZenodo:
+    """Stand-in for the Zenodo REST API, and for the url source handover."""
+
+    def __init__(self):
+        self.records = {}
+        self.api_failure = None
+        self.api_payload = UNSET
+        # Observed behaviour
+        self.requested = []
+        self.urls = None
+        self.kwargs = None
+
+    # -- configuration ------------------------------------------------------
+
+    def record(self, record_id, files, resolves_to=None):
+        """Register a record. ``resolves_to`` mimics a concept record, which the API
+        redirects to the latest version, reporting that version's ID and file links.
+        """
+        self.records[int(record_id)] = (list(files), int(resolves_to or record_id))
+
+    def fail_api(self, failure):
+        """Make the Zenodo API fail, either with an exception instance or an HTTP status code."""
+        self.api_failure = failure
+
+    def api_returns(self, payload):
+        """Make the Zenodo API return an arbitrary payload (or ``BAD_JSON``)."""
+        self.api_payload = payload
+
+    # -- the fake requests.get ----------------------------------------------
+
+    def get(self, url, timeout=None):
+        self.requested.append(url)
+        if url.startswith("https://zenodo.org/api/records/"):
+            return self._api_response(url)
+        raise AssertionError(f"unexpected request to {url}")
+
+    def _api_response(self, url):
+        if self.api_failure is not None:
+            return self._failure(url, self.api_failure)
+        if self.api_payload is not UNSET:
+            return FakeResponse(url, payload=self.api_payload)
+        record_id = int(url.rsplit("/", 1)[-1])
+        if record_id not in self.records:
+            return FakeResponse(url, status_code=404)
+        names, resolved_id = self.records[record_id]
+        files = [{"key": name, "links": {"self": download_url(name, resolved_id)}} for name in names]
+        return FakeResponse(url, payload={"id": resolved_id, "files": files})
+
+    @staticmethod
+    def _failure(url, failure):
+        if isinstance(failure, int):
+            return FakeResponse(url, status_code=failure)
+        raise failure
+
+
+class FakeRequests:
+    """Minimal stand-in for the ``requests`` module as used by the zenodo source."""
+
+    ConnectionError = requests.ConnectionError
+    Timeout = requests.Timeout
+    HTTPError = requests.HTTPError
+
+    def __init__(self, api):
+        self.get = api.get
+
+
+class TestZenodoSourceOffline:
+    @pytest.fixture
+    def zenodo(self, monkeypatch):
+        api = FakeZenodo()
+        api.record(RECORD_ID, FILES)
+        api.record(CONCEPT_ID, FILES, resolves_to=RECORD_ID)
+
+        def capture(urls, **kwargs):
+            api.urls = list(urls)
+            api.kwargs = kwargs
+            return _from_source_internal("empty")
+
+        # Patch the names bound in the zenodo module only
+        monkeypatch.setattr(zenodo_module, "requests", FakeRequests(api))
+        monkeypatch.setattr(zenodo_module, "MultiUrl", capture)
+        return api
+
+    def test_zenodo_source_is_registered(self):
+        assert get_source._lookup("zenodo") is not None
+
+    @pytest.mark.parametrize("identifier", [RECORD_ID, CONCEPT_ID])
+    def test_int_identifier(self, zenodo, identifier):
+        from_source("zenodo", identifier)
+        assert_selected(zenodo)
+
+    @pytest.mark.parametrize("identifier", [RECORD_ID, CONCEPT_ID])
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "{id}",
+            " {id}",
+            "https://zenodo.org/record/{id}",
+            "https://zenodo.org/records/{id}",
+            "https://zenodo.org/records/{id}/",
+            "https://zenodo.org/records/{id}?download=1",
+            "  https://zenodo.org/records/{id}?download=1",
+            "https://zenodo.org/records/{id}?download=1  ",
+            "http://zenodo.org/record/{id}",
+            "http://zenodo.org/records/{id}",
+            "http://zenodo.org/records/{id}/",
+            "zenodo.org/record/{id}",
+            "zenodo.org/records/{id}",
+            "zenodo.org/records/{id}/",
+            "10.5281/zenodo.{id}",
+            "doi:10.5281/zenodo.{id}",
+            "https://doi.org/10.5281/zenodo.{id}",
+            "https://doi.org/10.5281/zenodo.{id}/",
+            "https://DOI.ORG/10.5281/zenodo.{id}",
+            "http://doi.org/10.5281/zenodo.{id}",
+            "http://doi.org/10.5281/zenodo.{id}/",
+            "doi.org/10.5281/zenodo.{id}",
+            "doi.org/10.5281/zenodo.{id}/",
+            "https://dx.doi.org/10.5281/zenodo.{id}",
+            "https://dx.doi.org/10.5281/zenodo.{id}/",
+            "dx.doi.org/10.5281/zenodo.{id}",
+        ],
+    )
+    def test_str_identifiers_valid(self, zenodo, identifier, url):
+        from_source("zenodo", url.format(id=identifier))
+        assert_selected(zenodo)
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            None,
+            "",
+            "   ",
+            "not-a-record",
+            "10.1234/foo.567",
+            "10.5281/foobar.12345",
+            "https://example.com/records/12345",
+            "https://zenodo.org/communities/abc",
+            "https://zenodo.org/records/abc",
+            "zenodo.org/records/12345/files/a.grib",
+            # Near misses of the accepted doi.org URL forms
+            "https://doi.org/10.1234/foo.567",
+            "https://doi.org/10.5281/foobar.12345",
+            "https://doi.org/",
+            "https://doi.org",
+            "https://example.com/10.5281/zenodo.12345",
+            # The host must be matched, not merely found at the end of another one
+            "https://mydoi.org/10.5281/zenodo.12345",
+            # The doi: prefix and the URL form are alternatives, not combinable
+            f"doi:https://doi.org/{DOI}",
+        ],
+    )
+    def test_identifiers_invalid(self, zenodo, identifier):
+        with pytest.raises(ValueError, match="unable to determine record ID"):
+            from_source("zenodo", identifier)
+
+    def test_zenodo_unknown_record(self, zenodo):
+        with pytest.raises(RuntimeError, match="Zenodo API returned HTTP 404"):
+            from_source("zenodo", 999)
+
+    @pytest.mark.parametrize(
+        "failure,message",
+        [
+            (requests.ConnectionError("no route to host"), "could not connect to zenodo.org"),
+            (requests.ReadTimeout("too slow"), "request to zenodo.org timed out after"),
+            (403, "Zenodo API returned HTTP 403"),
+            (404, "Zenodo API returned HTTP 404"),
+            (500, "Zenodo API returned HTTP 500"),
+            (503, "Zenodo API returned HTTP 503"),
+        ],
+    )
+    def test_zenodo_api_failure(self, zenodo, failure, message):
+        zenodo.fail_api(failure)
+        with pytest.raises(RuntimeError, match=message):
+            from_source("zenodo", RECORD_ID)
+
+    def test_zenodo_api_invalid_json(self, zenodo):
+        zenodo.api_returns(BAD_JSON)
+        with pytest.raises(RuntimeError, match="failed to parse Zenodo API response"):
+            from_source("zenodo", RECORD_ID)
+
+    @pytest.mark.parametrize("payload", [{}, {"files": []}, {"files": None}, {"metadata": {}}])
+    def test_zenodo_record_without_files(self, zenodo, payload):
+        zenodo.api_returns(payload)
+        with pytest.raises(RuntimeError, match="no accessible files"):
+            from_source("zenodo", RECORD_ID)
+
+    @pytest.mark.parametrize("timeout,expected", [(7, "7s"), ("20s", "20s")])
+    def test_zenodo_timeout_message_reports_configured_timeout(self, zenodo, timeout, expected):
+        zenodo.fail_api(requests.ReadTimeout("too slow"))
+        with config.temporary("url-download-timeout", timeout):
+            with pytest.raises(RuntimeError, match=f"timed out after {expected}"):
+                from_source("zenodo", RECORD_ID)
+
+    def test_zenodo_download_url_comes_from_the_api(self, zenodo):
+        # The URL is whatever the API reports, not something the source builds
+        zenodo.api_returns({"files": [{"key": "a.grib", "links": {"self": "https://example.com/elsewhere"}}]})
+        from_source("zenodo", RECORD_ID, filenames="a.grib")
+        assert zenodo.urls == ["https://example.com/elsewhere"]
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            [{"key": "a.grib"}],
+            [{"key": "a.grib", "links": {}}],
+            [{"links": {"self": "https://example.com/a.grib"}}],
+            ["a.grib"],
+        ],
+    )
+    def test_zenodo_malformed_file_entry(self, zenodo, files):
+        zenodo.api_returns({"files": files})
+        with pytest.raises(RuntimeError, match="unexpected file entry"):
+            from_source("zenodo", RECORD_ID)
+
+    def test_zenodo_all_files_selected(self, zenodo):
+        from_source("zenodo", RECORD_ID)
+        assert_selected(zenodo, FILES)
+
+    @pytest.mark.parametrize(
+        "pattern,expected",
+        [
+            ("*", ["a.grib", "b.grib", "c.nc"]),
+            ("*.grib", ["a.grib", "b.grib"]),
+            ("*.nc", ["c.nc"]),
+            ("?.grib", ["a.grib", "b.grib"]),
+            ("[ab].grib", ["a.grib", "b.grib"]),
+            ("a.grib", ["a.grib"]),
+        ],
+    )
+    def test_zenodo_filenames_pattern(self, zenodo, pattern, expected):
+        from_source("zenodo", RECORD_ID, filenames=pattern)
+        assert_selected(zenodo, expected)
+
+    @pytest.mark.parametrize("pattern", ["*.zip", "d.grib", "", "grib", "a.gri"])
+    def test_zenodo_filenames_pattern_no_match(self, zenodo, pattern):
+        with pytest.raises(FileNotFoundError, match="match the pattern"):
+            from_source("zenodo", RECORD_ID, filenames=pattern)
+
+    @pytest.mark.parametrize(
+        "filenames,expected",
+        [
+            (["a.grib"], ["a.grib"]),
+            (["a.grib", "c.nc"], ["a.grib", "c.nc"]),
+            # The caller's order must be honoured: unlike the all-files case, which has no
+            # defined order, an explicit list is used exactly as given.
+            (["c.nc", "a.grib"], ["c.nc", "a.grib"]),
+            (("b.grib", "a.grib"), ["b.grib", "a.grib"]),
+            (FILES, FILES),
+            # A repeated name is requested once, keeping its first position
+            (["a.grib", "c.nc", "a.grib"], ["a.grib", "c.nc"]),
+            (["c.nc", "c.nc"], ["c.nc"]),
+        ],
+    )
+    def test_zenodo_filenames_list(self, zenodo, filenames, expected):
+        from_source("zenodo", RECORD_ID, filenames=filenames)
+        assert zenodo.urls == [download_url(name) for name in expected]
+
+    @pytest.mark.parametrize(
+        "filenames,missing",
+        [
+            (["d.grib"], ["d.grib"]),
+            (["a.grib", "d.grib"], ["d.grib"]),
+            # Matching is case sensitive, and a list entry is a name rather than a pattern
+            (["A.GRIB"], ["A.GRIB"]),
+            (["*.grib"], ["*.grib"]),
+            # Every unknown name is reported at once, so a caller does not have to fix them
+            # one API request at a time
+            (["d.grib", "e.nc"], ["d.grib", "e.nc"]),
+            (["d.grib", "a.grib", "e.nc"], ["d.grib", "e.nc"]),
+            (["e.nc", "d.grib"], ["e.nc", "d.grib"]),
+            # A repeated unknown name is reported once
+            (["d.grib", "d.grib"], ["d.grib"]),
+        ],
+    )
+    def test_zenodo_filenames_list_unknown_file(self, zenodo, filenames, missing):
+        with pytest.raises(FileNotFoundError, match=f"not found in record {RECORD_ID}"):
+            from_source("zenodo", RECORD_ID, filenames=filenames)
+
+    @pytest.mark.parametrize("filenames", [[], ()])
+    def test_zenodo_filenames_empty(self, zenodo, filenames):
+        with pytest.raises(FileNotFoundError, match="no files selected"):
+            from_source("zenodo", RECORD_ID, filenames=filenames)
+
+    def test_zenodo_no_kwargs_forwarded(self, zenodo):
+        from_source("zenodo", RECORD_ID)
+        assert zenodo.kwargs == {}
+
+    def test_zenodo_kwargs_forwarded(self, zenodo):
+        from_source("zenodo", RECORD_ID, filenames="a.grib", parts=[(0, 4)], stream=False)
+        assert zenodo.kwargs == {"parts": [(0, 4)], "stream": False}
+
+
+# --------------------------------------------------------------------------------------------
+# Live test against the real Zenodo API.
+#
+# The offline tests above encode two assumptions about Zenodo that no Zenodo documentation
+# states: that files[*].links.self carries the download URL, and that the API redirects a
+# concept record to its latest version. Only a real request can confirm those still hold.
+#
+# Deliberately commented out. To enable it, replace the placeholders below with a small,
+# permanent record and uncomment. Adapt the assertion to what that record holds; to_fieldlist
+# assumes field data such as GRIB or NetCDF. The markers keep it out of the default -E short
+# profile, so it runs only with -E long or -E release.
+#
+# _LIVE_CONCEPT_DOI = "10.5281/zenodo.<concept record ID>"  # all versions, resolves to latest
+# _LIVE_VERSION_DOI = "10.5281/zenodo.<version record ID>"  # one specific version
+# _LIVE_RECORD_ID = <version record ID>
+# _LIVE_FILENAME = "<a file name in that record>"
+# _LIVE_FIELD_COUNT = <number of fields in that file>
+#
+#
+# @pytest.mark.long_test
+# @pytest.mark.download
+# @pytest.mark.parametrize("identifier", [_LIVE_CONCEPT_DOI, _LIVE_VERSION_DOI, _LIVE_RECORD_ID])
+# def test_zenodo_live(identifier):
+#     ds = from_source("zenodo", identifier, filenames=_LIVE_FILENAME)
+#     assert len(ds.to_fieldlist()) == _LIVE_FIELD_COUNT
+
+
+if __name__ == "__main__":
+    from earthkit.data.utils.testing import main
+
+    main(__file__)

--- a/tests/sources/test_zenodo.py
+++ b/tests/sources/test_zenodo.py
@@ -128,6 +128,7 @@ class TestZenodoSourceOffline:
             " {id}",
             "https://zenodo.org/record/{id}",
             "https://zenodo.org/records/{id}",
+            "https://ZENODO.ORG/records/{id}",
             "https://zenodo.org/records/{id}/",
             "https://zenodo.org/records/{id}?download=1",
             "  https://zenodo.org/records/{id}?download=1",
@@ -199,7 +200,7 @@ class TestZenodoSourceOffline:
             # The host must be matched, not merely found at the end of another one
             "https://mydoi.org/10.5281/zenodo.12345",
             # The doi: prefix and the URL form are alternatives, not combinable
-            f"doi:https://doi.org/{DOI}",
+            "doi:https://doi.org/10.5281/zenodo.12345",
         ],
     )
     def test_invalid_identifier(self, zenodo, identifier):
@@ -238,8 +239,8 @@ class TestZenodoSourceOffline:
             requests.ReadTimeout(),
             MockResponse(status_code=404),
             MockResponse(status_code=503),
-            # Invalid JSON
-            MockResponse(payload=None),
+            MockResponse(payload=None),  # invalid JSON
+            MockResponse(payload=5),  # not dict-typed
             # No files in records
             MockResponse(payload={}),
             MockResponse(payload={"files": []}),

--- a/tests/sources/test_zenodo.py
+++ b/tests/sources/test_zenodo.py
@@ -12,12 +12,9 @@
 import pytest
 import requests
 
-from earthkit.data import config, from_source
+from earthkit.data import from_source
 from earthkit.data.sources import _from_source_internal, get_source
 from earthkit.data.sources import zenodo as zenodo_module
-
-# Test up to the point where the Zenodo source mutates into a MultiURL source.
-# Create a fake Zenodo API and verify the generated URLs.
 
 RECORD_ID = 123
 CONCEPT_ID = 678
@@ -25,7 +22,6 @@ FILES = ["b.grib", "a.grib", "c.nc"]
 
 
 def DOI(id):
-    """The DOI for a given Zenodo record ID."""
     return f"10.5281/zenodo.{id}"  # as per https://support.zenodo.org/help/en-gb/18-general/216-what-is-a-doi
 
 
@@ -34,17 +30,16 @@ def download_url(name, record_id=RECORD_ID):
     return f"https://zenodo.org/api/records/{record_id}/files/{name}/content"
 
 
-def assert_selected(zenodo, names=FILES, record_id=RECORD_ID):
-    """Compare selections ignoring order, which is not part of the source's contract."""
-    assert set(zenodo.urls) == set(download_url(name, record_id) for name in names)
+def assert_selected(zenodo, files=set(FILES), record_id=RECORD_ID):
+    # Files ignores order of elements while list enforces it
+    expected = type(files)(download_url(file, record_id) for file in files)
+    assert type(files)(zenodo.urls) == expected
 
 
-BAD_JSON = object()
-UNSET = object()
+class MockResponse:
+    """Stand-in for requests.Response."""
 
-
-class FakeResponse:
-    def __init__(self, url, status_code=200, payload=None):
+    def __init__(self, url=None, status_code=200, payload=None):
         self.url = url
         self.status_code = status_code
         self._payload = payload
@@ -54,83 +49,58 @@ class FakeResponse:
             raise requests.HTTPError(f"HTTP {self.status_code} for {self.url}", response=self)
 
     def json(self):
-        if self._payload is BAD_JSON:
-            raise ValueError("not valid JSON")
+        if self._payload is None:
+            raise ValueError("invalid JSON")
         return self._payload
 
 
-class FakeZenodo:
-    """Stand-in for the Zenodo REST API, and for the url source handover."""
-
-    def __init__(self):
-        self.records = {}
-        self.api_failure = None
-        self.api_payload = UNSET
-        # Observed behaviour
-        self.requested = []
-        self.urls = None
-        self.kwargs = None
-
-    # -- configuration ------------------------------------------------------
-
-    def record(self, record_id, files, resolves_to=None):
-        """Register a record. ``resolves_to`` mimics a concept record, which the API
-        redirects to the latest version, reporting that version's ID and file links.
-        """
-        self.records[int(record_id)] = (list(files), int(resolves_to or record_id))
-
-    def fail_api(self, failure):
-        """Make the Zenodo API fail, either with an exception instance or an HTTP status code."""
-        self.api_failure = failure
-
-    def api_returns(self, payload):
-        """Make the Zenodo API return an arbitrary payload (or ``BAD_JSON``)."""
-        self.api_payload = payload
-
-    # -- the fake requests.get ----------------------------------------------
-
-    def get(self, url, timeout=None):
-        self.requested.append(url)
-        if url.startswith("https://zenodo.org/api/records/"):
-            return self._api_response(url)
-        raise AssertionError(f"unexpected request to {url}")
-
-    def _api_response(self, url):
-        if self.api_failure is not None:
-            return self._failure(url, self.api_failure)
-        if self.api_payload is not UNSET:
-            return FakeResponse(url, payload=self.api_payload)
-        record_id = int(url.rsplit("/", 1)[-1])
-        if record_id not in self.records:
-            return FakeResponse(url, status_code=404)
-        names, resolved_id = self.records[record_id]
-        files = [{"key": name, "links": {"self": download_url(name, resolved_id)}} for name in names]
-        return FakeResponse(url, payload={"id": resolved_id, "files": files})
-
-    @staticmethod
-    def _failure(url, failure):
-        if isinstance(failure, int):
-            return FakeResponse(url, status_code=failure)
-        raise failure
-
-
-class FakeRequests:
-    """Minimal stand-in for the ``requests`` module as used by the zenodo source."""
+class MockRequests:
+    """Stand-in for the requests module, pretending to be the Zenodo API."""
 
     ConnectionError = requests.ConnectionError
     Timeout = requests.Timeout
     HTTPError = requests.HTTPError
 
-    def __init__(self, api):
-        self.get = api.get
+    def __init__(self):
+        self.records = {}
+        self.response = None
+        # Observed behaviour
+        self.urls = None
+        self.kwargs = None
+
+    def register_record(self, record_id, files, resolves_to=None):
+        self.records[int(record_id)] = (list(files), int(resolves_to or record_id))
+
+    def respond_with(self, response):
+        self.response = response
+
+    def get(self, url, **kwargs):
+        assert url.startswith("https://zenodo.org/api/records/"), f"unexpected request to {url}"
+        if self.response is None:
+            record_id = int(url.rsplit("/", 1)[-1])
+            if record_id not in self.records:
+                return MockResponse(url, status_code=404)
+            # Minimal valid response from the Zenodo API
+            names, resolved_id = self.records[record_id]
+            files = [{"key": name, "links": {"self": download_url(name, resolved_id)}} for name in names]
+            return MockResponse(url, payload={"id": resolved_id, "files": files})
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
 
 
 class TestZenodoSourceOffline:
+    """Offline test for the Zenodo source.
+
+    Test up to the point where the Zenodo source mutates into a MultiURL source
+    with a fake Zenodo API.
+    """
+
     @pytest.fixture
     def zenodo(self, monkeypatch):
-        api = FakeZenodo()
-        api.record(RECORD_ID, FILES)
-        api.record(CONCEPT_ID, FILES, resolves_to=RECORD_ID)
+        api = MockRequests()
+        api.register_record(RECORD_ID, FILES)
+        api.register_record(CONCEPT_ID, FILES, resolves_to=RECORD_ID)
 
         def capture(urls, **kwargs):
             api.urls = list(urls)
@@ -138,7 +108,7 @@ class TestZenodoSourceOffline:
             return _from_source_internal("empty")
 
         # Patch the names bound in the zenodo module only
-        monkeypatch.setattr(zenodo_module, "requests", FakeRequests(api))
+        monkeypatch.setattr(zenodo_module, "requests", api)
         monkeypatch.setattr(zenodo_module, "MultiUrl", capture)
         return api
 
@@ -146,7 +116,7 @@ class TestZenodoSourceOffline:
         assert get_source._lookup("zenodo") is not None
 
     @pytest.mark.parametrize("identifier", [RECORD_ID, CONCEPT_ID])
-    def test_int_identifier(self, zenodo, identifier):
+    def test_valid_identifier_int(self, zenodo, identifier):
         from_source("zenodo", identifier)
         assert_selected(zenodo)
 
@@ -182,9 +152,30 @@ class TestZenodoSourceOffline:
             "dx.doi.org/10.5281/zenodo.{id}",
         ],
     )
-    def test_str_identifiers_valid(self, zenodo, identifier, url):
-        from_source("zenodo", url.format(id=identifier))
-        assert_selected(zenodo)
+    @pytest.mark.parametrize(
+        "only,expected",
+        [
+            (None, set(FILES)),
+            ("c.nc", {"c.nc"}),
+            ("*.grib", {"a.grib", "b.grib"}),
+            (FILES, FILES),
+            (FILES[::-1], FILES[::-1]),  # maintains order
+            (["a.grib", "a.grib", "b.grib"], ["a.grib", "b.grib"]),  # ignores duplicates
+        ],
+    )
+    def test_valid_identifier_str(self, zenodo, identifier, url, only, expected):
+        from_source("zenodo", url.format(id=identifier), only=only)
+        assert_selected(zenodo, files=expected)
+
+    def test_without_kwargs(self, zenodo):
+        from_source("zenodo", RECORD_ID)
+        assert zenodo.kwargs == {}
+
+    def test_kwargs_forwarded(self, zenodo):
+        from_source("zenodo", RECORD_ID, only="a.grib", foo="bar", bar=False)
+        assert zenodo.kwargs == {"foo": "bar", "bar": False}
+
+    # ValueErrors for input validation problems and invalid file selection
 
     @pytest.mark.parametrize(
         "identifier",
@@ -211,171 +202,60 @@ class TestZenodoSourceOffline:
             f"doi:https://doi.org/{DOI}",
         ],
     )
-    def test_identifiers_invalid(self, zenodo, identifier):
-        with pytest.raises(ValueError, match="unable to determine record ID"):
+    def test_invalid_identifier(self, zenodo, identifier):
+        with pytest.raises(ValueError):
             from_source("zenodo", identifier)
 
+    @pytest.mark.parametrize(
+        "only",
+        [
+            "",
+            "*.zip",
+            "d.grib",
+            "grib",
+            "a.gri",
+            ["d.grib"],
+            ["a.grib", "d.grib"],
+            ["A.GRIB"],  # case sensitive
+            ["*.grib"],  # list entry does not trigger pattern matching
+            [],
+        ],
+    )
+    def test_invalid_only(self, zenodo, only):
+        with pytest.raises(ValueError):
+            from_source("zenodo", RECORD_ID, only=only)
+
+    # RuntimeErrors raised for problems with Zenodo API and response
+
     def test_zenodo_unknown_record(self, zenodo):
-        with pytest.raises(RuntimeError, match="Zenodo API returned HTTP 404"):
+        with pytest.raises(RuntimeError):
             from_source("zenodo", 999)
 
     @pytest.mark.parametrize(
-        "failure,message",
+        "response",
         [
-            (requests.ConnectionError("no route to host"), "could not connect to zenodo.org"),
-            (requests.ReadTimeout("too slow"), "request to zenodo.org timed out after"),
-            (403, "Zenodo API returned HTTP 403"),
-            (404, "Zenodo API returned HTTP 404"),
-            (500, "Zenodo API returned HTTP 500"),
-            (503, "Zenodo API returned HTTP 503"),
+            requests.ConnectionError(),
+            requests.ReadTimeout(),
+            MockResponse(status_code=404),
+            MockResponse(status_code=503),
+            # Invalid JSON
+            MockResponse(payload=None),
+            # No files in records
+            MockResponse(payload={}),
+            MockResponse(payload={"files": []}),
+            MockResponse(payload={"files": None}),
+            MockResponse(payload={"metadata": {}}),
+            # Malformed file entry
+            MockResponse(payload={"files": [{"key": "a.grib"}]}),
+            MockResponse(payload={"files": [{"key": "a.grib", "links": {}}]}),
+            MockResponse(payload={"files": [{"links": {"self": "https://example.com/a.grib"}}]}),
+            MockResponse(payload={"files": ["a.grib"]}),
         ],
     )
-    def test_zenodo_api_failure(self, zenodo, failure, message):
-        zenodo.fail_api(failure)
-        with pytest.raises(RuntimeError, match=message):
+    def test_api_failure_runtime_errors(self, zenodo, response):
+        zenodo.respond_with(response)
+        with pytest.raises(RuntimeError):
             from_source("zenodo", RECORD_ID)
-
-    def test_zenodo_api_invalid_json(self, zenodo):
-        zenodo.api_returns(BAD_JSON)
-        with pytest.raises(RuntimeError, match="failed to parse Zenodo API response"):
-            from_source("zenodo", RECORD_ID)
-
-    @pytest.mark.parametrize("payload", [{}, {"files": []}, {"files": None}, {"metadata": {}}])
-    def test_zenodo_record_without_files(self, zenodo, payload):
-        zenodo.api_returns(payload)
-        with pytest.raises(RuntimeError, match="no accessible files"):
-            from_source("zenodo", RECORD_ID)
-
-    @pytest.mark.parametrize("timeout,expected", [(7, "7s"), ("20s", "20s")])
-    def test_zenodo_timeout_message_reports_configured_timeout(self, zenodo, timeout, expected):
-        zenodo.fail_api(requests.ReadTimeout("too slow"))
-        with config.temporary("url-download-timeout", timeout):
-            with pytest.raises(RuntimeError, match=f"timed out after {expected}"):
-                from_source("zenodo", RECORD_ID)
-
-    def test_zenodo_download_url_comes_from_the_api(self, zenodo):
-        # The URL is whatever the API reports, not something the source builds
-        zenodo.api_returns({"files": [{"key": "a.grib", "links": {"self": "https://example.com/elsewhere"}}]})
-        from_source("zenodo", RECORD_ID, filenames="a.grib")
-        assert zenodo.urls == ["https://example.com/elsewhere"]
-
-    @pytest.mark.parametrize(
-        "files",
-        [
-            [{"key": "a.grib"}],
-            [{"key": "a.grib", "links": {}}],
-            [{"links": {"self": "https://example.com/a.grib"}}],
-            ["a.grib"],
-        ],
-    )
-    def test_zenodo_malformed_file_entry(self, zenodo, files):
-        zenodo.api_returns({"files": files})
-        with pytest.raises(RuntimeError, match="unexpected file entry"):
-            from_source("zenodo", RECORD_ID)
-
-    def test_zenodo_all_files_selected(self, zenodo):
-        from_source("zenodo", RECORD_ID)
-        assert_selected(zenodo, FILES)
-
-    @pytest.mark.parametrize(
-        "pattern,expected",
-        [
-            ("*", ["a.grib", "b.grib", "c.nc"]),
-            ("*.grib", ["a.grib", "b.grib"]),
-            ("*.nc", ["c.nc"]),
-            ("?.grib", ["a.grib", "b.grib"]),
-            ("[ab].grib", ["a.grib", "b.grib"]),
-            ("a.grib", ["a.grib"]),
-        ],
-    )
-    def test_zenodo_filenames_pattern(self, zenodo, pattern, expected):
-        from_source("zenodo", RECORD_ID, filenames=pattern)
-        assert_selected(zenodo, expected)
-
-    @pytest.mark.parametrize("pattern", ["*.zip", "d.grib", "", "grib", "a.gri"])
-    def test_zenodo_filenames_pattern_no_match(self, zenodo, pattern):
-        with pytest.raises(FileNotFoundError, match="match the pattern"):
-            from_source("zenodo", RECORD_ID, filenames=pattern)
-
-    @pytest.mark.parametrize(
-        "filenames,expected",
-        [
-            (["a.grib"], ["a.grib"]),
-            (["a.grib", "c.nc"], ["a.grib", "c.nc"]),
-            # The caller's order must be honoured: unlike the all-files case, which has no
-            # defined order, an explicit list is used exactly as given.
-            (["c.nc", "a.grib"], ["c.nc", "a.grib"]),
-            (("b.grib", "a.grib"), ["b.grib", "a.grib"]),
-            (FILES, FILES),
-            # A repeated name is requested once, keeping its first position
-            (["a.grib", "c.nc", "a.grib"], ["a.grib", "c.nc"]),
-            (["c.nc", "c.nc"], ["c.nc"]),
-        ],
-    )
-    def test_zenodo_filenames_list(self, zenodo, filenames, expected):
-        from_source("zenodo", RECORD_ID, filenames=filenames)
-        assert zenodo.urls == [download_url(name) for name in expected]
-
-    @pytest.mark.parametrize(
-        "filenames,missing",
-        [
-            (["d.grib"], ["d.grib"]),
-            (["a.grib", "d.grib"], ["d.grib"]),
-            # Matching is case sensitive, and a list entry is a name rather than a pattern
-            (["A.GRIB"], ["A.GRIB"]),
-            (["*.grib"], ["*.grib"]),
-            # Every unknown name is reported at once, so a caller does not have to fix them
-            # one API request at a time
-            (["d.grib", "e.nc"], ["d.grib", "e.nc"]),
-            (["d.grib", "a.grib", "e.nc"], ["d.grib", "e.nc"]),
-            (["e.nc", "d.grib"], ["e.nc", "d.grib"]),
-            # A repeated unknown name is reported once
-            (["d.grib", "d.grib"], ["d.grib"]),
-        ],
-    )
-    def test_zenodo_filenames_list_unknown_file(self, zenodo, filenames, missing):
-        with pytest.raises(FileNotFoundError, match=f"not found in record {RECORD_ID}"):
-            from_source("zenodo", RECORD_ID, filenames=filenames)
-
-    @pytest.mark.parametrize("filenames", [[], ()])
-    def test_zenodo_filenames_empty(self, zenodo, filenames):
-        with pytest.raises(FileNotFoundError, match="no files selected"):
-            from_source("zenodo", RECORD_ID, filenames=filenames)
-
-    def test_zenodo_no_kwargs_forwarded(self, zenodo):
-        from_source("zenodo", RECORD_ID)
-        assert zenodo.kwargs == {}
-
-    def test_zenodo_kwargs_forwarded(self, zenodo):
-        from_source("zenodo", RECORD_ID, filenames="a.grib", parts=[(0, 4)], stream=False)
-        assert zenodo.kwargs == {"parts": [(0, 4)], "stream": False}
-
-
-# --------------------------------------------------------------------------------------------
-# Live test against the real Zenodo API.
-#
-# The offline tests above encode two assumptions about Zenodo that no Zenodo documentation
-# states: that files[*].links.self carries the download URL, and that the API redirects a
-# concept record to its latest version. Only a real request can confirm those still hold.
-#
-# Deliberately commented out. To enable it, replace the placeholders below with a small,
-# permanent record and uncomment. Adapt the assertion to what that record holds; to_fieldlist
-# assumes field data such as GRIB or NetCDF. The markers keep it out of the default -E short
-# profile, so it runs only with -E long or -E release.
-#
-# _LIVE_CONCEPT_DOI = "10.5281/zenodo.<concept record ID>"  # all versions, resolves to latest
-# _LIVE_VERSION_DOI = "10.5281/zenodo.<version record ID>"  # one specific version
-# _LIVE_RECORD_ID = <version record ID>
-# _LIVE_FILENAME = "<a file name in that record>"
-# _LIVE_FIELD_COUNT = <number of fields in that file>
-#
-#
-# @pytest.mark.long_test
-# @pytest.mark.download
-# @pytest.mark.parametrize("identifier", [_LIVE_CONCEPT_DOI, _LIVE_VERSION_DOI, _LIVE_RECORD_ID])
-# def test_zenodo_live(identifier):
-#     ds = from_source("zenodo", identifier, filenames=_LIVE_FILENAME)
-#     assert len(ds.to_fieldlist()) == _LIVE_FIELD_COUNT
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

- The Zenodo source translates record IDs and DOIs from the Zenodo namespace into URLs for individual files, then delegates to a `MultiUrl` source for accessing the files.
- The source offers file name matching based on Python's `fnmatch`, so users can select, e.g., all netcdf files of a record conveniently. Files can also be selected explicitly by providing a list of files.
- Adds `requests` as an explicit dependency. As far as I can tell, it was already pulled in by the `multiurl` dependency previously.

[docs preview](https://earthkit-data--933.org.readthedocs.build/en/933/concepts/inputs/from_source.html#data-sources-zenodo)

### Usage

```python
# Access with record id, select all files by default
ekd.from_source("zenodo", 10458186)

# Access with DOI, select only files with grib extension
ekd.from_source("zenodo", "10.5281/zenodo.10458186", only="*.grib")

# Concept DOI is resolved to latest version, DOI accepted as URL, select specific files
ekd.from_source("zenodo", "https://doi.org/10.5281/zenodo.10458185", only=["FWI_T0.0_P0.8_EU_1981_2010.grib", ...])
```

### Tests

The current test suite only checks that the Zenodo source produces correct URLs. It mocks the `requests` module and produces responses as expected from the Zenodo API to avoid spamming API requests to the actual Zenodo API.

### Questions

- Is `only` a good name for the file selection argument?
- Should the test suite have a test that verifies against the actual Zenodo API? If so, I could create a dedicated Zenodo test data record with a few example files.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 