### PR TITLE
Constrain pyfdb to versions below 1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - hda>=2.22
 - pip:
   - multiurl>=0.3.3
-  - pyfdb>=0.1.0
+  - pyfdb>=0.1.0,<1.0
   - ecmwf-opendata>=0.1.2
   - polytope-client>=0.7.4
   - covjsonkit>=0.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,11 @@ optional-dependencies.docs = [
   "sphinx-tabs"
 ]
 optional-dependencies.ecmwf-opendata = ["ecmwf-opendata>=0.3.3"]
-optional-dependencies.fdb = ["pyfdb>=0.1"]
+optional-dependencies.fdb = ["pyfdb>=0.1,<1.0"]
 optional-dependencies.geo = ["earthkit-geo>=0.2"]
 optional-dependencies.geopandas = ["geopandas"]
 optional-dependencies.geotiff = ["pyproj", "rasterio", "rioxarray"]
-optional-dependencies.gribjump = ["pyfdb>=0.1", "pygribjump"]
+optional-dependencies.gribjump = ["pyfdb>=0.1,<1.0", "pygribjump"]
 optional-dependencies.iris = ["ncdata>=0.3.2", "scitools-iris"]
 optional-dependencies.mars = ["ecmwf-api-client>=1.6.1"]
 optional-dependencies.odb = ["pyodc"]

--- a/tests/environment-unit-tests.yml
+++ b/tests/environment-unit-tests.yml
@@ -25,7 +25,7 @@ dependencies:
 - jsonschema
 - pip:
   - multiurl>=0.3.3
-  - pyfdb>=0.1.0
+  - pyfdb>=0.1.0,<1.0
   - ecmwf-opendata>=0.3.3
   - polytope-client>=0.7.4
   - git+https://github.com/ecmwf/earthkit-data-demo-source


### PR DESCRIPTION
### Description

Because a major pyfdb release with breaking changes is coming soon, we are temporarily pinning pyfdb so that current earthkit-data usage continues to work without issues.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 