### PR TITLE
Use eckit-geo directly to handle GRIB on unstructured grid

### DIFF
--- a/src/earthkit/data/core/field.py
+++ b/src/earthkit/data/core/field.py
@@ -588,11 +588,12 @@ class Field(Base):
     @property
     def shape(self):
         """tuple: Return the shape of the field."""
-        v = self.geography.shape()
-        if v is not None:
-            return v
-        else:
-            return self.values.shape
+        try:
+            v = self.geography.shape()
+        except Exception:
+            v = None
+
+        return v if v is not None else self.values.shape
 
     def to_numpy(self, flatten=False, dtype=None, copy=True, index=None):
         r"""Return the values stored in the field as an ndarray.

--- a/src/earthkit/data/field/grib/ensemble.py
+++ b/src/earthkit/data/field/grib/ensemble.py
@@ -29,10 +29,8 @@ class GribEnsembleBuilder:
             return handle.get(key, default=default)
 
         v = _get("number")
-        print("number", v)
         if v is None:
             v = _get("perturbationNumber")
-            print
 
         return dict(
             member=v,

--- a/src/earthkit/data/field/grib/geography.py
+++ b/src/earthkit/data/field/grib/geography.py
@@ -191,13 +191,39 @@ class GribGeographyBuilder:
     def build(handle):
         from earthkit.data.field.handler.geography import GeographyFieldComponentHandler
 
+        grid_type = handle.get("gridType", None)
+
         # Spectral data is handled differently right now
-        if handle.get("gridType", None) == "sh":
+        if grid_type == "sh":
             from earthkit.data.field.component.geography import SpectralGeography
 
             shape = (handle.get("numberOfDataPoints", None),)
             component = SpectralGeography(shape=shape)
-        # Gridded data
+        # "unstructured" grids are handled differently.
+        # Currently, ecCodes cannot generate lat-lon for these grids, so we need to
+        # rely on the gridSpec to reconstruct the grid with the eckit-geo Grid object.
+        # If the gridSpec is not available, we cannot handle these grids.
+        elif grid_type == "unstructured_grid":
+            if not ECKIT_GRID_SUPPORT.has_ecc_grid_spec or not ECKIT_GRID_SUPPORT.has_grid:
+                raise ValueError(
+                    (
+                        "GribGeographyBuilder: cannot use unstructured grid because eckit-geo"
+                        " grid support is not available in ecCodes"
+                    )
+                )
+            from earthkit.data.field.component.geography import GridsSpecBasedGeography
+
+            grid_spec = handle.get("gridSpec", default=None)
+            if isinstance(grid_spec, str) and grid_spec != "":
+                component = GridsSpecBasedGeography(grid_spec)
+            else:
+                raise ValueError(
+                    (
+                        "GribGeographyBuilder: cannot use unstructured grid because gridSpec"
+                        "  is not available in the handle"
+                    )
+                )
+        # Other gridded data is handled with ecCodes
         else:
             component = GribGeography(handle)
         return GeographyFieldComponentHandler.from_component(component)

--- a/tests/data/xr_engine/xr_grid.yaml
+++ b/tests/data/xr_engine/xr_grid.yaml
@@ -205,3 +205,30 @@
     values: 1122
   coords: {}
   distinct_ll: false
+- file: eORCA025_T.grib
+  dims:
+    y: 1442
+    x: 1207
+  coords:
+    latitude:
+    - - y
+      - x
+    - - 1442
+      - 1207
+    longitude:
+    - - y
+      - x
+    - - 1442
+      - 1207
+  distinct_ll: false
+- file: icon_ch1.grib2
+  dims:
+    values: 1147980
+  coords:
+    latitude:
+    - values
+    - 1147980
+    longitude:
+    - values
+    - 1147980
+  distinct_ll: false

--- a/tests/grib/test_grib_convert.py
+++ b/tests/grib/test_grib_convert.py
@@ -26,6 +26,7 @@ def test_icon_to_xarray(fl_type):
     g, _ = load_grib_data("test_icon.grib", fl_type, folder="data")
 
     ds = g.to_xarray(engine="cfgrib")
+
     assert len(ds.data_vars) == 1
     # Dataset contains 9 levels and 9 grid points per level
     ref_levs = g.get("vertical.level")

--- a/tests/grib/test_grib_geography.py
+++ b/tests/grib/test_grib_geography.py
@@ -362,9 +362,9 @@ def test_grib_latlon_various_grids_1(fl_type, filename, expected_shape, expected
     assert np.allclose(np.asarray(ds[0].geography.area()), np.asarray(expected_area))
 
 
-@pytest.mark.skip(
-    "This test is currently failing because the GRIB field geography is not correctly handled in ecCodes."
-)
+# @pytest.mark.skip(
+#     "This test is currently failing because the GRIB field geography is not correctly handled in ecCodes."
+# )
 @pytest.mark.parametrize(
     "filename,expected_shape, expected_lat, expected_lon, expected_area",
     [

--- a/tests/xr_engine/test_xr_engine_grid.py
+++ b/tests/xr_engine/test_xr_engine_grid.py
@@ -41,7 +41,7 @@ def grid_list(files=None):
 @pytest.mark.parametrize("lazy_load", [True])
 @pytest.mark.parametrize(
     "file,dims,coords,distinct_ll",
-    # grid_list(files=["regular_gg_F16.grib1"]),
+    # grid_list(files=["eORCA025_T.grib"]),
     grid_list(),
 )
 def test_xr_engine_grid_core(allow_holes, lazy_load, file, dims, coords, distinct_ll):
@@ -57,7 +57,9 @@ def test_xr_engine_grid_core(allow_holes, lazy_load, file, dims, coords, distinc
         assert a.coords[k].dims == to_tuple(v[0])
         assert a.coords[k].shape == to_tuple(v[1])
 
-    assert a.t.dims[-(len(dims)) :] == tuple(dims.keys())
+    first_da = next(iter(a.data_vars.values()))
+
+    assert first_da.dims[-(len(dims)) :] == tuple(dims.keys())
 
     if "latitude" in a.coords and "longitude" in a.coords:
         if distinct_ll:


### PR DESCRIPTION
### Description

When `gridType` == "unstructured_grid" instantiate an eckit.geo.Grid from the `gridSpec` to handle the field geography. For other grids still uses ecCodes for this. This was necessary to overcome the problems related to ORCA and ICON grids. See: https://jira.ecmwf.int/browse/ECC-2257


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 