### PR TITLE
Fix GRIB field when typeOfLevel key missing

### DIFF
--- a/src/earthkit/data/field/grib/vertical.py
+++ b/src/earthkit/data/field/grib/vertical.py
@@ -213,7 +213,7 @@ class GribVerticalBuilder:
 
     @staticmethod
     def _build_dict(handle):
-        level_type = handle.get("typeOfLevel", None)
+        level_type = handle.get("typeOfLevel", default=None)
         t = _GRIB_TYPES.get(level_type)
         if t is None:
             from earthkit.data.field.component.level_type import get_level_type


### PR DESCRIPTION
### Description

Fixed issue when could not load GRIB data into a fieldlist when the  `typeOfLevel` GRIB  key was missing.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
