### PR TITLE
Do not enforce request splitting in standalone mars client

### DIFF
--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -52,7 +52,6 @@ class StandaloneMarsClient:
 
             subprocess.run(
                 [self.command(), filename],
-                env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"),
                 check=True,
                 **log,
             )


### PR DESCRIPTION
### Description

Previously, the standalone MARS client was called by setting the following env var internally:

MARS_AUTO_SPLIT_BY_DATES="1"

This has been removed and and now users must set this env var themselves when needed.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
