### PR TITLE
Release 0.20.0

### DIFF
--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -15,6 +15,7 @@ Version updates
 .. toctree::
     :maxdepth: 1
 
+    version_0.20_updates
     version_0.19_updates
     version_0.18_updates
     version_0.17_updates

--- a/docs/release_notes/version_0.20_update.rst
+++ b/docs/release_notes/version_0.20_update.rst
@@ -9,4 +9,3 @@ Changes
 ++++++++++++++++++++++++++++++
 
 Previously, when using the :ref:`data-sources-mars` source via the standalone MARS client the ``MARS_AUTO_SPLIT_BY_DATES="1"`` environment variable was set to enable splitting of MARS requests by date when needed. However, this approach has been removed and now users must set this environment variable themselves when needed. This change was made to give users more control over the behavior of MARS requests and to avoid potential issues with unintended splitting of requests. (:pr:`974`)
- 

--- a/docs/release_notes/version_0.20_update.rst
+++ b/docs/release_notes/version_0.20_update.rst
@@ -1,0 +1,12 @@
+Version 0.20 Updates
+/////////////////////////
+
+
+Version 0.20.0
+===============
+
+Changes
+++++++++++++++++++++++++++++++
+
+Previously, when using the :ref:`data-sources-mars` source via the standalone MARS client the ``MARS_AUTO_SPLIT_BY_DATES="1"`` environment variable was set to enable splitting of MARS requests by date when needed. However, this approach has been removed and now users must set this environment variable themselves when needed. This change was made to give users more control over the behavior of MARS requests and to avoid potential issues with unintended splitting of requests. (:pr:`974`)
+ 

--- a/src/earthkit/data/sources/mars.py
+++ b/src/earthkit/data/sources/mars.py
@@ -53,7 +53,6 @@ class StandaloneMarsClient:
 
             subprocess.run(
                 [self.command(), filename],
-                env=dict(os.environ, MARS_AUTO_SPLIT_BY_DATES="1"),
                 check=True,
                 **log,
             )


### PR DESCRIPTION
### Description

The only change is as follows:

Previously, the standalone MARS client was called by setting the following env var internally:

MARS_AUTO_SPLIT_BY_DATES="1"

This has been removed and and now users must set this env var themselves when needed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
