### PR TITLE
Allow null values in conversion to datetime object

### DIFF
--- a/src/earthkit/data/utils/dates.py
+++ b/src/earthkit/data/utils/dates.py
@@ -67,6 +67,22 @@ def to_datetime(dt):
     if hasattr(dt, "isoformat"):
         return datetime.datetime.fromisoformat(dt.isoformat())
 
+    # if dt is NaT-like, then return None
+    if dt is None:
+        return dt
+    try:
+        # covers nan, np.datetime64('NaT') and np.timedelta64('NaT')
+        if np.isnan(dt):
+            return None
+    except Exception:
+        pass
+    try:
+        # covers pd.NaT
+        if np.isnan(dt.second):
+            return None
+    except Exception:
+        pass
+
     dt = from_object(dt)
 
     return to_datetime(dt.to_datetime())

--- a/tests/xr_engine/test_xr_engine_add_valid_time_coord.py
+++ b/tests/xr_engine/test_xr_engine_add_valid_time_coord.py
@@ -244,6 +244,34 @@ def test_fixed_dims_different_order(pl_fl, lazy_load, allow_holes):
 
 
 # -------------------------------------------------------------------------
+# valid_time aux coord should work even if there is no field for a given
+# (forecast_reference_time, step) pair (i.e. holes in the data) and thus
+# the corresponding valid_time value is NaT
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lazy_load", [True, False])
+@pytest.mark.parametrize("dim_name_from_role_name", [True, False])
+def test_NaT(pl_fl, lazy_load, dim_name_from_role_name):
+    fl_with_holes = pl_fl.to_fieldlist().sel({"vertical.level": 500})[2:]
+    ds = fl_with_holes.to_xarray(
+        profile="earthkit",
+        add_valid_time_coord=True,
+        dim_name_from_role_name=dim_name_from_role_name,
+        lazy_load=lazy_load,
+        allow_holes=True,
+    )
+
+    assert "valid_time" in ds.coords
+    assert "valid_time" not in ds.sizes
+    assert ds.coords["valid_time"].dims == ("forecast_reference_time", "step")
+    assert ds.coords["valid_time"].shape == (4, 2)
+    _valid_time = np.array(VALID_TIME_FRT_STEP)
+    _valid_time[0, 0] = np.datetime64("NaT")
+    np.testing.assert_array_equal(ds.coords["valid_time"].values, _valid_time)
+
+
+# -------------------------------------------------------------------------
 # Edge case: add_valid_time_coord=False should not add it
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

This PR addresses the following issue:

```python
import earthkit.data as ekd

fl = ekd.from_source("sample", "pl.grib").to_fieldlist()
fl2 = fl.sel({"parameter.variable": "t", "vertical.level": 500})[:3]

# len(fl2) == 3
# fl2.unique(["time.base_datetime", "time.step"]) == {
#     'time.base_datetime': (datetime.datetime(2024, 6, 3, 0, 0), datetime.datetime(2024, 6, 3, 12, 0)),
#     'time.step': (datetime.timedelta(0), datetime.timedelta(seconds=21600))
# }
# so a field for base_datetime=2024-6-3T12 and step=6h is missing

ds = fl2.to_xarray(allow_holes=True, add_valid_time_coord=True)
```

The above script crashes in https://github.com/ecmwf/earthkit-data/blob/03ca2adefbdfe1806a848567799f05a9da8bcf3e/src/earthkit/data/utils/dates.py#L72 with
`AttributeError: 'FloatData' object has no attribute 'to_datetime'`. The expected behaviour is to have an xarray Dataset in `ds` with `valid_time` auxiliary coordinate variable having 3 values + one 'NaT'.

To this end, the current PR extends the conversion to `datetime` object implemented in https://github.com/ecmwf/earthkit-data/blob/03ca2adefbdfe1806a848567799f05a9da8bcf3e/src/earthkit/data/utils/dates.py#L47 allowing for null values.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
