### PR TITLE
date/time conversion handles null-like objects

### DIFF
--- a/src/earthkit/data/utils/dates.py
+++ b/src/earthkit/data/utils/dates.py
@@ -20,6 +20,27 @@ SUFFIX_STEP_PATTERN = re.compile(r"\d+[a-zA-Z]{1}")
 STEP_RANGE_PATTERN = re.compile(r"\d+-\d+")
 
 
+def _is_null_like(value):
+    """Return True if value is a null-like object (None, NaN, NaT, pd.NaT)."""
+    if value is None:
+        return True
+
+    try:
+        # covers nan, np.datetime64('NaT') and np.timedelta64('NaT')
+        if np.isnan(value):
+            return True
+    except Exception:
+        pass
+    try:
+        # covers pd.NaT
+        if np.isnan(value.second):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
 def _handle_complex_object_datetime(dt: np.ndarray) -> np.ndarray:
     """Attempt to handle complex object datetime arrays."""
     dt = dt.ravel()
@@ -45,6 +66,9 @@ def _handle_complex_object_datetime(dt: np.ndarray) -> np.ndarray:
 
 
 def to_datetime(dt):
+    if _is_null_like(dt):
+        return None
+
     if isinstance(dt, datetime.datetime):
         return dt
 
@@ -66,22 +90,6 @@ def to_datetime(dt):
 
     if hasattr(dt, "isoformat"):
         return datetime.datetime.fromisoformat(dt.isoformat())
-
-    # if dt is NaT-like, then return None
-    if dt is None:
-        return dt
-    try:
-        # covers nan, np.datetime64('NaT') and np.timedelta64('NaT')
-        if np.isnan(dt):
-            return None
-    except Exception:
-        pass
-    try:
-        # covers pd.NaT
-        if np.isnan(dt.second):
-            return None
-    except Exception:
-        pass
 
     dt = from_object(dt)
 
@@ -142,6 +150,9 @@ def to_date_list(obj):
 
 
 def to_time(dt):
+    if _is_null_like(dt):
+        return None
+
     if isinstance(dt, float):
         dt = int(dt)
 
@@ -194,6 +205,9 @@ def to_time_list(times):
 
 
 def to_timedelta(td):
+    if _is_null_like(td):
+        return None
+
     if isinstance(td, int):
         return datetime.timedelta(hours=td)
 
@@ -234,11 +248,15 @@ def to_timedelta_list(td):
 
 
 def numpy_timedelta_to_timedelta(td):
+    if np.isnat(td):
+        return None
     td = td.astype("timedelta64[s]").astype(int)
     return datetime.timedelta(seconds=int(td))
 
 
 def numpy_datetime_to_datetime(dt):
+    if np.isnat(dt):
+        return None
     dt = dt.astype("datetime64[s]").astype(int)
     return datetime.datetime.fromtimestamp(int(dt), datetime.timezone.utc).replace(tzinfo=None)
 

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -10,8 +10,10 @@
 #
 
 import datetime
+import math
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from earthkit.data.utils.dates import (
@@ -361,6 +363,70 @@ def test_time_to_grib(d, expected_value, error):
     else:
         with pytest.raises(error):
             time_to_grib(d)
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        None,
+        math.nan,
+        np.nan,
+        np.datetime64("NaT"),
+        np.timedelta64("NaT"),
+        pd.NaT,
+    ],
+)
+def test_to_datetime_null_like(d):
+    assert to_datetime(d) is None
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        None,
+        math.nan,
+        np.nan,
+        np.datetime64("NaT"),
+        np.timedelta64("NaT"),
+        pd.NaT,
+    ],
+)
+def test_to_time_null_like(d):
+    assert to_time(d) is None
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        None,
+        math.nan,
+        np.nan,
+        np.timedelta64("NaT"),
+        pd.NaT,
+    ],
+)
+def test_to_timedelta_null_like(d):
+    assert to_timedelta(d) is None
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        np.datetime64("NaT"),
+    ],
+)
+def test_numpy_datetime_to_datetime_null_like(d):
+    assert numpy_datetime_to_datetime(d) is None
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        np.timedelta64("NaT"),
+    ],
+)
+def test_numpy_timedelta_to_timedelta_null_like(d):
+    assert numpy_timedelta_to_timedelta(d) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

This is a follow-up of the PR #999. It provides more robust checks for null-like values in the context of convertion into a data/time object.

Null-like values are:
* `None`
* `NaN`
* `numpy NaT`, i.e. `numpy.datetime64('NaT')` and `numpy.timedelta64('NaT')`
* `pandas.NaT`

Now, the following to date/time conversion routines are checking for a null-like value and return `None` on a null-like input:
  * `to_datetime()`
  * `to_time()`
  * `to_timedelta()`

Additionally, the routines expecting numpy-type input, i.e.
* `numpy_timedelta_to_timedelta()`
* `numpy_datetime_to_datetime()`
check for `numpy NaT`. Note that without such check, the conversion `.astype(int)` would produce a meaningless `int`, out of range for `datetime.datetime.fromtimestamp()` (see https://github.com/ecmwf/earthkit-data/blob/c3e2c822265c6955fc443c3c99aa34b536197a14/src/earthkit/data/utils/dates.py#L241).

Tests covering all the above changes have been added.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
