### PR TITLE
Clean up within xr_engine profiles and docs

### DIFF
--- a/src/earthkit/data/indexing/xarray.py
+++ b/src/earthkit/data/indexing/xarray.py
@@ -286,15 +286,35 @@ class XarrayMixIn:
                 The following attributes are supported:
 
                 - str: Name of the attribute used as a metadata key to generate the value of
-                  the attribute. Can also be specified by prefixing with "key=" (e.g. "key=level").
+                  the attribute. Can also be specified by prefixing with "key=" (e.g. "key=vertical.level").
                   When prefixed with "namespace=" it specifies a metadata namespace
                   (e.g. "namespace=parameter"), which will be added as a dict to the attribute.
-                - callable: A callable that takes a Metadata object and returns a dict of attributes
+                - callable: A callable that takes a Field object and returns a dict of attributes, e.g.:
+
+                  .. code-block:: python
+
+                    def rounded_wavelength(field):
+                        wl = field.get("metadata.wavelength")
+                        if wl is not None:
+                            return {"wavelength": round(wl)}
+                        else:
+                            return {}
+
                 - dict: A dictionary of attributes with the keys as the attribute names.
-                  If the value is a callable it takes the attribute name and a Metadata object and
-                  returns the value of the attribute. A str value prefixed with "key=" or
-                  "namespace=" is interpreted as explained above. Any other values are used as the
-                  pre-defined value for the attribute.
+                  If the value is a callable it takes the attribute name and a Field object and
+                  returns the value of the attribute, e.g.:
+
+                  .. code-block:: python
+
+                    def ensure_rounded(key, field):
+                        val = field.get(key)
+                        try:
+                            return round(val)
+                        except Exception:
+                            return val
+
+                  A str value prefixed with "key=" or "namespace=" is interpreted as explained above.
+                  Any other values are used as the pre-defined value for the attribute.
             * variable_attrs: str, number, callable, dict or list of these, None
                 Variable attribute or attributes. For the allowed values see ``attrs``. Its
                 default value (None) expands to [] unless the ``profile`` overwrites it.

--- a/src/earthkit/data/xr_engine/engine.py
+++ b/src/earthkit/data/xr_engine/engine.py
@@ -290,15 +290,35 @@ class EarthkitBackendEntrypoint(BackendEntrypoint):
             The following attributes are supported:
 
             - str: Name of the attribute used as a metadata key to generate the value of
-              the attribute. Can also be specified by prefixing with "key=" (e.g. "key=level").
+              the attribute. Can also be specified by prefixing with "key=" (e.g. "key=vertical.level").
               When prefixed with "namespace=" it specifies a metadata namespace
               (e.g. "namespace=parameter"), which will be added as a dict to the attribute.
-            - callable: A callable that takes a Metadata object and returns a dict of attributes
+            - callable: A callable that takes a Field object and returns a dict of attributes, e.g.:
+
+              .. code-block:: python
+
+                def rounded_wavelength(field):
+                    wl = field.get("metadata.wavelength")
+                    if wl is not None:
+                        return {"wavelength": round(wl)}
+                    else:
+                        return {}
+
             - dict: A dictionary of attributes with the keys as the attribute names.
-              If the value is a callable it takes the attribute name and a Metadata object and
-              returns the value of the attribute. A str value prefixed with "key=" or
-              "namespace=" is interpreted as explained above. Any other values are used as the
-              pre-defined value for the attribute.
+              If the value is a callable it takes the attribute name and a Field object and
+              returns the value of the attribute, e.g.:
+
+              .. code-block:: python
+
+                def ensure_rounded(key, field):
+                    val = field.get(key)
+                    try:
+                        return round(val)
+                    except Exception:
+                        return val
+
+              A str value prefixed with "key=" or "namespace=" is interpreted as explained above.
+              Any other values are used as the pre-defined value for the attribute.
         variable_attrs: str, number, callable, dict or list of these, None
             Variable attribute or attributes. For the allowed values see ``attrs``. Its
             default value (None) expands to [] unless the ``profile`` overwrites it.

--- a/src/earthkit/data/xr_engine/profiles/defaults.yaml
+++ b/src/earthkit/data/xr_engine/profiles/defaults.yaml
@@ -22,9 +22,7 @@ attrs: []
 variable_attrs: []
 global_attrs: []
 add_earthkit_attrs: true
-rename_attrs:
-  cfName: standard_name
-  name: long_name
+rename_attrs: {}
 add_valid_time_coord: false
 add_geo_coords: true
 decode_times: true

--- a/src/earthkit/data/xr_engine/profiles/earthkit.yaml
+++ b/src/earthkit/data/xr_engine/profiles/earthkit.yaml
@@ -10,8 +10,8 @@ dim_roles:
 variable_key: parameter.variable
 attrs_mode: fixed
 variable_attrs:
-- metadata.cfName
-- metadata.name
+- parameter.standard_name
+- parameter.long_name
 - parameter.units
 - vertical.level_type
 global_attrs:

--- a/src/earthkit/data/xr_engine/profiles/grib.yaml
+++ b/src/earthkit/data/xr_engine/profiles/grib.yaml
@@ -10,8 +10,8 @@ dim_roles:
 variable_key: metadata.param
 attrs_mode: fixed
 variable_attrs:
-- metadata.cfName
-- metadata.name
+- parameter.standard_name
+- parameter.long_name
 - parameter.units
 - metadata.typeOfLevel
 global_attrs:

--- a/src/earthkit/data/xr_engine/profiles/mars.yaml
+++ b/src/earthkit/data/xr_engine/profiles/mars.yaml
@@ -37,8 +37,8 @@ attrs:
 - metadata.levelist
 variable_attrs:
 - metadata.param
-- metadata.cfName
-- metadata.name
+- parameter.standard_name
+- parameter.long_name
 - metadata.paramId
 - parameter.units
 global_attrs:

--- a/tests/xr_engine/test_xr_engine_attrs.py
+++ b/tests/xr_engine/test_xr_engine_attrs.py
@@ -422,8 +422,9 @@ def test_xr_engine_attrs_types(lazy_load, kwargs, coords, dims, attrs):
     compare_dims(ds, dims, sizes=True)
 
     for k, v in attrs.items():
-        if k not in ["_earthkit"]:
-            assert ds["t"].attrs[k] == v, f"{k}"
+        assert ds["t"].attrs[k] == v, f"{k}"
+
+    assert set(ds["t"].attrs).difference(attrs).difference(["_earthkit"]) == set()
 
 
 @pytest.mark.cache


### PR DESCRIPTION
### Description

This PR fixes the following issues:
* Docstring on `to_xarray()` and `open_dataset()` concerning `attrs` corrected and expanded
* The profile-defined xr_engine keyword `attrs` uses format-agnostic metadata instead of GRIB keys. A related test was improved.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
