### PR TITLE
Adapt to pytest 9.1.0 and  remove pytest-notebook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ optional-dependencies.test = [
   "pytest",
   "pytest-cov",
   "pytest-forked",
-  "pytest-notebook",
   "pytest-reraise",
   "pytest-timeout"
 ]

--- a/tests/documentation/test_notebooks.py
+++ b/tests/documentation/test_notebooks.py
@@ -11,15 +11,12 @@
 
 import os
 import re
+import sys
 
 import pytest
 from earthkit.utils.array.testing.testing import NO_TORCH
-from pytest_notebook.nb_regression import NBRegressionFixture
 
-from earthkit.data.utils.testing import earthkit_file
-
-fixture = NBRegressionFixture(exec_timeout=30)
-fixture.diff_color_words = False
+from earthkit.data.utils.testing import MISSING, earthkit_file
 
 # See https://www.blog.pythonlibrary.org/2018/10/16/testing-jupyter-notebooks/
 
@@ -65,45 +62,26 @@ def notebooks_list():
     return sorted(notebooks)
 
 
-# @pytest.mark.notebook
-# @pytest.mark.skipif(
-#     MISSING("nbformat", "nbconvert", "ipykernel"),
-#     reason="python package nbformat not installed",
-# )
-# # @pytest.mark.skipif(not IN_GITHUB, reason="Not on GITHUB")
-# @pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute notebooks on Windows")
-# @pytest.mark.parametrize("path", notebooks_list())
-# def test_notebook(path):
-#     import nbformat
-#     from nbconvert.preprocessors import ExecutePreprocessor
-
-#     if path in SKIP:
-#         pytest.skip("Notebook marked as 'skip'")
-
-#     with open(os.path.join(EXAMPLES, path)) as f:
-#         nb = nbformat.read(f, as_version=4)
-
-#     proc = ExecutePreprocessor(timeout=60 * 60 * 5, kernel_name="python3")
-#     proc.preprocess(nb, {"metadata": {"path": EXAMPLES}})
-
-
-@pytest.mark.skip(reason="Notebooks need to be adapted for new code")  # TODO: implement notebook testing
 @pytest.mark.notebook
-# @pytest.mark.skipif(
-#     MISSING("nbformat", "nbconvert", "ipykernel"),
-#     reason="python package nbformat not installed",
-# )
-# # @pytest.mark.skipif(not IN_GITHUB, reason="Not on GITHUB")
-# @pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute notebooks on Windows")
+@pytest.mark.skipif(
+    MISSING("nbformat", "nbconvert", "ipykernel"),
+    reason="python package nbformat not installed",
+)
+# @pytest.mark.skipif(not IN_GITHUB, reason="Not on GITHUB")
+@pytest.mark.skipif(sys.platform == "win32", reason="Cannot execute notebooks on Windows")
 @pytest.mark.parametrize("path", notebooks_list())
 def test_notebook(path):
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+
     if path in SKIP:
         pytest.skip("Notebook marked as 'skip'")
 
-    path = os.path.join(EXAMPLES, path)
-    fixture.check(path)
+    with open(os.path.join(EXAMPLES, path)) as f:
+        nb = nbformat.read(f, as_version=4)
 
-    # fixture.run_notebook(os.path.join(EXAMPLES, path))
+    proc = ExecutePreprocessor(timeout=60 * 60 * 5, kernel_name="python3")
+    proc.preprocess(nb, {"metadata": {"path": EXAMPLES}})
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/test_string_wrapper.py
+++ b/tests/wrappers/test_string_wrapper.py
@@ -41,7 +41,7 @@ def test_string_wrapper_datetime(date_format, expected_value):
     assert ds.to_datetime() == dt
 
 
-@pytest.mark.parametrize("date_format,", ["%Y-%m-%d"])
+@pytest.mark.parametrize("date_format", ["%Y-%m-%d"])
 def test_string_wrapper_datetime_list(date_format):
     dt = [datetime.datetime(2000, 1, i) for i in range(1, 30)]
 
@@ -56,7 +56,7 @@ def test_string_wrapper_datetime_list(date_format):
     assert ds.to_datetime_list() == dt
 
 
-@pytest.mark.parametrize("date_format,", ["%Y-%m-%d"])
+@pytest.mark.parametrize("date_format", ["%Y-%m-%d"])
 def test_string_wrapper_datetime_list_by(date_format):
     dt = [datetime.datetime(2000, 1, i) for i in range(1, 30, 2)]
 


### PR DESCRIPTION
### Description

Pytest 9.1.0 crashes when `pytest-notebook` (0.10.0 is the latest) is installed. 

This PR:

- removes `pytest-notebook` from the dependencies
- adjust the tests


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
