### PR TITLE
raise supported python to match zarr>=3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 name = "earthkit-data"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 entry-points."xarray.backends".earthkit = "earthkit.data.xr_engine.engine:EarthkitBackendEntrypoint"
 optional-dependencies.all = [
   "earthkit-data[cds,covjsonkit,ecmwf-opendata,fdb,geopandas,gribjump,iris,mars,odb,polytope,projection,s3,wekeo]"

--- a/src/earthkit/data/utils/testing.py
+++ b/src/earthkit/data/utils/testing.py
@@ -134,6 +134,7 @@ if not NO_PROD_FDB:
     fdb_home = os.environ.get("FDB_HOME", None)
     NO_PROD_FDB = fdb_home is None
 
+NO_ODC = not modules_installed("pyodc")
 NO_GRIBJUMP = NO_FDB or not modules_installed("pygribjump")
 NO_POLYTOPE = not os.path.exists(os.path.expanduser("~/.polytopeapirc"))
 NO_COVJSONKIT = not modules_installed("covjsonkit")
@@ -141,6 +142,8 @@ NO_RIOXARRAY = not modules_installed("rioxarray")
 
 NO_S3_AUTH = not modules_installed("aws_requests_auth")
 NO_GEO = not modules_installed("earthkit-geo")
+NO_GEOPANDAS = not modules_installed("geopandas")
+
 try:
     NO_ECFS = not os.path.exists(shutil.which("ecp"))
 except Exception:

--- a/tests/high_level_object/test_hl_geojson_core.py
+++ b/tests/high_level_object/test_hl_geojson_core.py
@@ -9,10 +9,13 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pytest
+
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_test_data_file
+from earthkit.data.utils.testing import NO_GEOPANDAS, earthkit_test_data_file
 
 
+@pytest.mark.skipif(NO_GEOPANDAS, reason="geopandas is not installed")
 def test_hl_geojson_single_core():
     ds = from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.geojson"))
 

--- a/tests/high_level_object/test_hl_geopandas_core.py
+++ b/tests/high_level_object/test_hl_geopandas_core.py
@@ -9,6 +9,10 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pytest
+
+pytest.importorskip("geopandas")
+
 from earthkit.data import from_object
 from earthkit.data.utils.testing import earthkit_test_data_file
 

--- a/tests/high_level_object/test_hl_odb_core.py
+++ b/tests/high_level_object/test_hl_odb_core.py
@@ -9,8 +9,13 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pytest
+
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_examples_file
+from earthkit.data.utils.testing import NO_ODC, earthkit_examples_file
+
+if NO_ODC:
+    pytest.skip("pyodc is not installed", allow_module_level=True)
 
 
 def test_hl_odb_single_core():

--- a/tests/high_level_object/test_hl_shapefile_core.py
+++ b/tests/high_level_object/test_hl_shapefile_core.py
@@ -9,10 +9,13 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pytest
+
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_test_data_file
+from earthkit.data.utils.testing import NO_GEOPANDAS, earthkit_test_data_file
 
 
+@pytest.mark.skipif(NO_GEOPANDAS, reason="geopandas is not installed")
 def test_hl_shapefile_single_core():
     d = from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.shp.zip"))
 

--- a/tests/high_level_object/test_hl_target_file.py
+++ b/tests/high_level_object/test_hl_target_file.py
@@ -17,7 +17,7 @@ from earthkit.data import from_source
 from earthkit.data.core.temporary import temp_file
 from earthkit.data.encoders.grib import GribEncoder
 from earthkit.data.targets import to_target
-from earthkit.data.utils.testing import NO_RIOXARRAY, NO_ODC, earthkit_examples_file, earthkit_test_data_file
+from earthkit.data.utils.testing import NO_ODC, NO_RIOXARRAY, earthkit_examples_file, earthkit_test_data_file
 
 
 @pytest.mark.parametrize(

--- a/tests/high_level_object/test_hl_target_file.py
+++ b/tests/high_level_object/test_hl_target_file.py
@@ -17,7 +17,7 @@ from earthkit.data import from_source
 from earthkit.data.core.temporary import temp_file
 from earthkit.data.encoders.grib import GribEncoder
 from earthkit.data.targets import to_target
-from earthkit.data.utils.testing import NO_RIOXARRAY, earthkit_examples_file, earthkit_test_data_file
+from earthkit.data.utils.testing import NO_RIOXARRAY, NO_ODC, earthkit_examples_file, earthkit_test_data_file
 
 
 @pytest.mark.parametrize(
@@ -133,6 +133,7 @@ def test_hl_target_file_csv():
         assert list(df1.columns) == ["h1", "h2", "h3", "name"]
 
 
+@pytest.mark.skipif(NO_ODC, reason="pyodc is not installed")
 def test_hl_target_file_odb():
     ds = from_source("file", earthkit_examples_file("test.odb"))
     assert ds._TYPE_NAME == "ODB"

--- a/tests/odb/test_odb_pandas.py
+++ b/tests/odb/test_odb_pandas.py
@@ -10,9 +10,13 @@
 #
 
 import numpy as np
+import pytest
 
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_examples_file
+from earthkit.data.utils.testing import NO_ODC, earthkit_examples_file
+
+if NO_ODC:
+    pytest.skip("pyodc is not installed", allow_module_level=True)
 
 
 def test_odb_to_pandas():

--- a/tests/odb/test_odb_url.py
+++ b/tests/odb/test_odb_url.py
@@ -9,8 +9,13 @@
 # nor does it submit to any jurisdiction.
 #
 
+import pytest
+
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_remote_examples_file
+from earthkit.data.utils.testing import NO_ODC, earthkit_remote_examples_file
+
+if NO_ODC:
+    pytest.skip("pyodc is not installed", allow_module_level=True)
 
 
 def test_odb_url():

--- a/tests/readers/test_geojson_reader.py
+++ b/tests/readers/test_geojson_reader.py
@@ -11,7 +11,10 @@
 import pytest
 
 from earthkit.data import from_source
-from earthkit.data.utils.testing import earthkit_test_data_file
+from earthkit.data.utils.testing import NO_GEOPANDAS, earthkit_test_data_file
+
+if NO_GEOPANDAS:
+    pytest.skip("geopandas is not installed", allow_module_level=True)
 
 
 def test_geojson():

--- a/tests/readers/test_shapefile_reader.py
+++ b/tests/readers/test_shapefile_reader.py
@@ -9,10 +9,14 @@
 # nor does it submit to any jurisdiction.
 #
 import numpy as np
+import pytest
 
 from earthkit.data import from_source
 from earthkit.data.utils.bbox import BoundingBox
-from earthkit.data.utils.testing import earthkit_test_data_file
+from earthkit.data.utils.testing import NO_GEOPANDAS, earthkit_test_data_file
+
+if NO_GEOPANDAS:
+    pytest.skip("geopandas is not installed", allow_module_level=True)
 
 
 def test_shapefile():

--- a/tests/translators/test_pandas_translator.py
+++ b/tests/translators/test_pandas_translator.py
@@ -46,6 +46,7 @@ def test_pd_dataframe_translator():
 @pytest.mark.skipif(NO_GEOPANDAS, reason="geopandas is not installed")
 def test_gpd_dataframe_translator():
     import geopandas as gpd
+
     val = gpd.GeoDataFrame()
     ds = from_object(val)
 

--- a/tests/translators/test_pandas_translator.py
+++ b/tests/translators/test_pandas_translator.py
@@ -12,10 +12,11 @@
 
 import logging
 
-import geopandas as gpd
 import pandas as pd
+import pytest
 
 from earthkit.data import from_object, transform
+from earthkit.data.utils.testing import NO_GEOPANDAS
 
 LOG = logging.getLogger(__name__)
 
@@ -42,7 +43,9 @@ def test_pd_dataframe_translator():
     assert isinstance(transform(ds, pd.DataFrame), pd.DataFrame)
 
 
+@pytest.mark.skipif(NO_GEOPANDAS, reason="geopandas is not installed")
 def test_gpd_dataframe_translator():
+    import geopandas as gpd
     val = gpd.GeoDataFrame()
     ds = from_object(val)
 


### PR DESCRIPTION
### Description

When installing locally using `uv` dependencies cannot be solved because `zarr>=3` requires `python>=3.11`. This raises because ek-data is claiming to support `python>=3.10, python<3.11` which is not true for the zarr dependency. This raises by using `uv run` because it installs the `dev` dependency group which points to mostly all of the dependencies. On the other hand, It is true that:
- zarr is an optional dependency
- uv is not the officially supported build system

but
-  pip may be already solving for python 3.11, unless one installs optional dependencies partially or in multiple steps. This may result in a broken environment
- the required python definition is actually misleading.
- python 3.10 is reaching end-of-life in October 2026

## optional dependency -based tests

- `geopandas` is an optional dependency but there is no guardrails in the testing suite for the case it is missing.
Created a `NO_GEOPANDAS` global variable at `earthkit.data.utils.testing` following what's done with other optional dependencies.
- As above but for `pyodc`

## Local tests

the following two local tests are failing. Both are marked to be skipped on GITHUB runs. Maybe it is expected that they fail then!? Posting the error report for reference

```shell
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /Users/mojp/.cache/uv/builds-v0/.tmpm1b6Xi/bin/python
cachedir: .pytest_cache
rootdir: /Users/mojp/github/earthkit-data
configfile: pytest.ini
testpaths: tests
plugins: cov-7.1.0, timeout-2.4.0, pyfakefs-6.2.0, reraise-2.1.2, forked-1.6.0
collected 2 items / 6 skipped                                                                                                                                                                          
run-last-failure: rerun previous 2 failures (skipped 218 files)

Exception: eckit::codec::InvalidRecord: version not found in record /Users/mojp/.local/share/eckit/geo/grid/icon/17643da2574959b644d254a3cd6e2bc0-b0699f374c63d05028c18c12f80a48f4.ek                  
Request for file:/Users/mojp/.local/share/eckit/geo/grid/icon/17643da2574959b644d254a3cd6e2bc0-b0699f374c63d05028c18c12f80a48f4.ek?key=version&offset=0 was not completed.
ECCODES ERROR   :  GridSpec: Exception thrown (eckit::codec::InvalidRecord: version not found in record /Users/mojp/.local/share/eckit/geo/grid/icon/17643da2574959b644d254a3cd6e2bc0-b0699f374c63d05028c18c12f80a48f4.ek)
FAILED
tests/xr_engine/test_xr_engine_grid.py::test_xr_engine_grid_core[icon_ch1.grib2-dims19-coords19-False-True-False] FAILED

=============================================================================================== FAILURES ===============================================================================================
_____________________________________________ test_grib_latlon_various_grids_2[icon_ch1.grib2-expected_shape0-expected_lat0-expected_lon0-expected_area0] ______________________________________________

filename = 'icon_ch1.grib2', expected_shape = (1147980,), expected_lat = [50.24130630493164, 50.23910903930664, 50.23666763305664, 50.22787857055664]
expected_lon = [17.710683465003967, 17.689199090003967, 17.702382683753967, 17.704824090003967], expected_area = [50.6, -0.9, 41.9, 17.8]

    @pytest.mark.skipif(IN_GITHUB, reason="Skipping test on GitHub CI")
    @pytest.mark.parametrize(
        "filename,expected_shape, expected_lat, expected_lon, expected_area",
        [
            (
                "icon_ch1.grib2",
                (1147980,),
                [50.24130630493164, 50.23910903930664, 50.23666763305664, 50.22787857055664],
                [17.710683465003967, 17.689199090003967, 17.702382683753967, 17.704824090003967],
                [50.6, -0.9, 41.9, 17.8],
            ),
            (
                "eORCA025_T.grib",
                (
                    1442,
                    1207,
                ),
                [-89.5, -89.5, -89.5, -89.5],
                [72.75, 73.0, 73.25, 73.5],
                [90.0, 0.0, -90.0, 360.0],
            ),
        ],
    )
    def test_grib_latlon_various_grids_2(filename, expected_shape, expected_lat, expected_lon, expected_area):
        fl = earthkit.data.from_source("url", earthkit_remote_test_data_file("xr_engine/grid", filename)).to_fieldlist()
    
>       lat, lon = fl[0].geography.latlons()
                   ^^^^^^^^^^^^^^^

tests/grib/test_grib_geography.py:411: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/earthkit/data/core/field.py:580: in geography
    return self._components[_GEOGRAPHY].component
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/field/handler/core.py:187: in __getattr__
    return getattr(self._handler, name)
                   ^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/earthkit/utils/decorators/_thread_handlers.py:54: in __get__
    value = self.method(instance)
            ^^^^^^^^^^^^^^^^^^^^^
src/earthkit/data/field/grib/core.py:34: in _handler
    return self.BUILDER.build(self.handle)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

handle = <earthkit.data.readers.grib.handle.ManagedGribHandle object at 0x116ba3a10>

    @staticmethod
    def build(handle):
        from earthkit.data.field.handler.geography import GeographyFieldComponentHandler
    
        grid_type = handle.get("gridType", None)
    
        # Spectral data is handled differently right now
        if grid_type == "sh":
            from earthkit.data.field.component.geography import SpectralGeography
    
            shape = (handle.get("numberOfDataPoints", None),)
            component = SpectralGeography(shape=shape)
        # "unstructured" grids are handled differently.
        # Currently, ecCodes cannot generate lat-lon for these grids, so we need to
        # rely on the gridSpec to reconstruct the grid with the eckit-geo Grid object.
        # If the gridSpec is not available, we cannot handle these grids.
        elif grid_type == "unstructured_grid":
            if not ECKIT_GRID_SUPPORT.has_ecc_grid_spec or not ECKIT_GRID_SUPPORT.has_grid:
                raise ValueError(
                    (
                        "GribGeographyBuilder: cannot use unstructured grid because eckit-geo"
                        " grid support is not available in ecCodes"
                    )
                )
            from earthkit.data.field.component.geography import GridsSpecBasedGeography
    
            grid_spec = handle.get("gridSpec", default=None)
            if isinstance(grid_spec, str) and grid_spec != "":
                component = GridsSpecBasedGeography(grid_spec)
            else:
>               raise ValueError(
                    (
                        "GribGeographyBuilder: cannot use unstructured grid because gridSpec"
                        "  is not available in the handle"
                    )
                )
E               ValueError: GribGeographyBuilder: cannot use unstructured grid because gridSpec  is not available in the handle

src/earthkit/data/field/grib/geography.py:233: ValueError
------------------------------------------------------------------------------------------ Captured log call -------------------------------------------------------------------------------------------
ERROR    earthkit.data.field.grib.core:core.py:36 GribGeographyBuilder: cannot use unstructured grid because gridSpec  is not available in the handle
Traceback (most recent call last):
  File "/Users/mojp/github/earthkit-data/src/earthkit/data/field/grib/core.py", line 34, in _handler
    return self.BUILDER.build(self.handle)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/mojp/github/earthkit-data/src/earthkit/data/field/grib/geography.py", line 233, in build
    raise ValueError(
    ...<4 lines>...
    )
ValueError: GribGeographyBuilder: cannot use unstructured grid because gridSpec  is not available in the handle
______________________________________________________________ test_xr_engine_grid_core[icon_ch1.grib2-dims19-coords19-False-True-False] _______________________________________________________________

allow_holes = False, lazy_load = True, file = 'icon_ch1.grib2', dims = {'values': 1147980}, coords = {'latitude': ['values', 1147980], 'longitude': ['values', 1147980]}, distinct_ll = False

    @pytest.mark.cache
    @pytest.mark.skipif(IN_GITHUB, reason="Skipping test on GitHub CI")
    # @pytest.mark.parametrize("allow_holes", [False, True])
    # @pytest.mark.parametrize("lazy_load", [True, False])
    @pytest.mark.parametrize("allow_holes", [False])
    @pytest.mark.parametrize("lazy_load", [True])
    @pytest.mark.parametrize(
        "file,dims,coords,distinct_ll",
        # grid_list(files=["eORCA025_T.grib"]),
        grid_list(),
    )
    def test_xr_engine_grid_core(allow_holes, lazy_load, file, dims, coords, distinct_ll):
        ds = from_source("url", earthkit_remote_test_data_file("xr_engine", "grid", file)).to_fieldlist()
    
        a = ds.to_xarray(profile="mars", allow_holes=allow_holes, lazy_load=lazy_load)
        assert a is not None
    
        for k, v in dims.items():
>           assert a.dims[k] == v
E           assert 0 == 1147980

tests/xr_engine/test_xr_engine_grid.py:55: AssertionError
=========================================================================================== warnings summary ===========================================================================================
.venv/lib/python3.13/site-packages/_pytest/python.py:124
  /Users/mojp/github/earthkit-data/.venv/lib/python3.13/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/xr_engine/test_xr_engine_grid.py::test_xr_engine_grid_core, argvalues type: generator
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

tests/xr_engine/test_xr_engine_grid.py::test_xr_engine_grid_core[icon_ch1.grib2-dims19-coords19-False-True-False]
  /Users/mojp/github/earthkit-data/src/earthkit/data/core/caching.py:475: DeprecationWarning: The default datetime adapter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes
    db.execute(

tests/xr_engine/test_xr_engine_grid.py::test_xr_engine_grid_core[icon_ch1.grib2-dims19-coords19-False-True-False]
  /Users/mojp/github/earthkit-data/tests/xr_engine/test_xr_engine_grid.py:55: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    assert a.dims[k] == v

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= short test summary info ========================================================================================
FAILED tests/grib/test_grib_geography.py::test_grib_latlon_various_grids_2[icon_ch1.grib2-expected_shape0-expected_lat0-expected_lon0-expected_area0] - ValueError: GribGeographyBuilder: cannot use unstructured grid because gridSpec  is not available in the handle
FAILED tests/xr_engine/test_xr_engine_grid.py::test_xr_engine_grid_core[icon_ch1.grib2-dims19-coords19-False-True-False] - assert 0 == 1147980
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
