### PR TITLE
Adapt fdb interface to new pyfdb

### DIFF
--- a/src/earthkit/data/sources/fdb.py
+++ b/src/earthkit/data/sources/fdb.py
@@ -76,6 +76,8 @@ class FDBSource(Source):
             fdb = pyfdb.FDB(**self._fdb_kwargs)
             if self.stream:
                 stream = fdb.retrieve(self.request)
+                if hasattr(stream, "open") and callable(stream.open):
+                    stream.open()
                 return StreamSource(stream, **self._stream_kwargs)
             else:
                 return FDBFileSource(fdb, self.request)
@@ -136,10 +138,18 @@ class FDBRequestMapper(RequestMapper):
 
     def _build(self):
         r = []
+        # check for pyfdb >=5
+        has_new_api = hasattr(pyfdb, "ListElement")
         fdb = pyfdb.FDB(**self.fdb_kwargs)
-        for el in fdb.list(self.request, True, True):
-            data = el["keys"]
-            r.append(self._convert(data))
+        if has_new_api:
+            for el in fdb.list(self.request, level=3):
+                data = el.combined_key()
+                r.append(self._convert(data))
+        else:
+            for el in fdb.list(self.request, True, True):
+                data = el["keys"]
+                r.append(self._convert(data))
+
         return r
 
     @staticmethod

--- a/tests/lazy/test_lazy_fdb.py
+++ b/tests/lazy/test_lazy_fdb.py
@@ -96,6 +96,16 @@ def test_lazy_fdb():
         # fl_in is the original fieldlist from the sample grib file, fl is the fieldlist retrieved from FDB
         fl_in, config = make_fdb(os.path.join(tmpdir, "_fdb"))
 
+        # import pyfdb
+        # fdb = pyfdb.FDB(config=config)
+        # stream = fdb.retrieve(TEST_GRIB_REQUEST)
+
+        # from eccodes.highlevel.reader import codes_new_from_stream
+        # h = codes_new_from_stream(stream)
+
+        # print(h)
+        # return
+
         # fl is the virtual fieldlist retrieved from FDB
         fl = from_source("fdb", TEST_GRIB_REQUEST, config=config, stream=False, lazy=True).to_fieldlist()
         assert len(fl) == 32


### PR DESCRIPTION
### Description

This PR allows to use both pyfdb <=1.0 and pyfdb >= 5.21.4.20

The required dependencies not yet changed but the code was adapted.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
