### PR TITLE
Fix: xr_engine `strict` vs. `aux_coords`

### DIFF
--- a/src/earthkit/data/xr_engine/builder.py
+++ b/src/earthkit/data/xr_engine/builder.py
@@ -318,9 +318,18 @@ class BackendDataBuilder(metaclass=ABCMeta):
                 if d.name in dims_set:
                     dims_set.remove(d.name)
                     dim_objs.append(d)
-            assert len(dims_set) == 0, (
-                f"Auxiliary coordinate '{coord_label}' has unknown dimension(s): {tuple(dims_set)}"
-            )
+            if dims_set:
+                if strict:
+                    raise ValueError(
+                        f"Auxiliary coordinate '{coord_label}' references unknown dimension(s): {tuple(dims_set)}. "
+                        f"These dimensions are not defined in the dataset. "
+                        f"Update the coordinate's declared dimensions or use strict=False "
+                        f"to ignore invalid auxiliary coordinates."
+                    )
+                else:
+                    # ignore this invalid auxiliary coordinate
+                    continue
+
             coords = {d.key: self.tensor_coords[d.key].vals for d in dim_objs if d.key in self.tensor_coords}
 
             dim_keys = tuple(coords)

--- a/tests/xr_engine/test_xr_engine_aux_coords.py
+++ b/tests/xr_engine/test_xr_engine_aux_coords.py
@@ -12,7 +12,7 @@
 import numpy as np
 import pytest
 
-from earthkit.data import from_source
+from earthkit.data import concat, from_source
 from earthkit.data.utils.testing import earthkit_remote_test_data_file
 
 
@@ -100,13 +100,47 @@ def test_xr_engine_aux_coords_multiple_coords(lazy_load, allow_holes):
 @pytest.mark.cache
 @pytest.mark.parametrize("allow_holes", [False, True])
 def test_xr_engine_aux_coords_unknown_dim(allow_holes):
-    """aux_coords referencing a non-existent dimension should raise."""
+    """aux_coords referencing a non-existent dimension should raise when `strict=True` and ignore otherwise."""
     fl = from_source("url", earthkit_remote_test_data_file("xr_engine/level/pl_small.grib")).to_fieldlist()
-    with pytest.raises(AssertionError, match="unknown dimension"):
+
+    with pytest.raises(ValueError, match="unknown dimension"):
         fl.to_xarray(
-            aux_coords={"centre": ("metadata.centre", "nonexistent_dim")},
-            allow_holes=allow_holes,
+            aux_coords={"centre": ("metadata.centre", "nonexistent_dim")}, allow_holes=allow_holes, strict=True
         )
+
+    # strict=False is default
+    ds = fl.to_xarray(
+        aux_coords={"centre": ("metadata.centre", "nonexistent_dim")},
+        allow_holes=allow_holes,
+    )
+    assert "centre" not in ds.coords and "centre" not in ds
+
+
+@pytest.mark.cache
+@pytest.mark.parametrize("allow_holes", [False, True])
+def test_xr_engine_aux_coords_unknown_dim2(allow_holes):
+    """aux_coords referencing a non-existent dimension should raise when `strict=True` and ignore otherwise."""
+    fl1 = from_source("sample", "chem-cams.grib").to_fieldlist()
+    fl2 = from_source("sample", "optical-cams.grib").to_fieldlist()
+    fl = concat(fl1, fl2)
+
+    with pytest.raises(ValueError, match="unknown dimension"):
+        fl.to_xarray(
+            split_dims="parameter.variable",
+            aux_coords={"wavelength_units": ("parameter.wavelength_units", "wavelength")},
+            strict=True,
+        )
+
+    # strict=False is default
+    dss, d = fl.to_xarray(
+        split_dims="parameter.variable",
+        aux_coords={"wavelength_units": ("parameter.wavelength_units", "wavelength")},
+    )
+    for _ds, _d in zip(dss, d):
+        if _d["parameter.variable"] == "aod":
+            assert "wavelength_units" in _ds.coords
+        else:
+            assert "wavelength_units" not in _ds.coords and "wavelength_units" not in _ds
 
 
 def test_xr_engine_aux_coords_invalid_spec():


### PR DESCRIPTION
### Description

This PR fixes the `xr_engine` handling of the `aux_coords` and `strict` arguments.

#### Changes

* Invalid auxiliary coordinates are now handled consistently with the value of `strict`.
* When an entry in `aux_coords` references a dimension that is not present in the dataset (e.g. `aux_coords={"my_aux_coord": ("metadata_key", "unknown_dimension")}`):

  * If `strict=True`, a `ValueError` is raised.
  * If `strict=False`, the invalid auxiliary coordinate is silently ignored.

#### Motivation

Allowing invalid auxiliary coordinates to be ignored when `strict=False` is particularly useful when using `split_dims`. In that case, an auxiliary coordinate may only be applicable to a subset of the datasets produced by the split, while being invalid for the others.

#### Tests

Added test coverage for both `strict=True` and `strict=False` behaviors, including a `split_dims` use case demonstrating that dataset-specific auxiliary coordinates are handled correctly.



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
