### PR TITLE
chore: use dark logo always

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,7 +170,7 @@ html_theme_options = {
         "color-sidebar-item-background--hover": "#001F3F",
         "color-sidebar-item-expander-background--hover": "#001F3F",
     },
-    "light_logo": "earthkit-data-light.svg",
+    "light_logo": "earthkit-data-dark.svg",
     "dark_logo": "earthkit-data-dark.svg",
     "source_repository": "https://github.com/ecmwf/earthkit-data/",
     "source_branch": source_branch,


### PR DESCRIPTION
### Description
The sidebar is always dark colour regardless of light/dark mode, so actually the logo for the sidebar should always be the dark mode one

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
