### PR TITLE
Improve sync field

### DIFF
--- a/src/earthkit/data/core/field.py
+++ b/src/earthkit/data/core/field.py
@@ -530,6 +530,29 @@ class Field(Base):
             components[_GEOGRAPHY] = _COMPONENT_MAKER.default_cls(_GEOGRAPHY).from_dict({}, shape_hint=shape_hint)
         return cls(**components)
 
+    @classmethod
+    def _tmp_field_from_metadata(cls, field):
+        """Create a new Field from an existing Field's metadata components.
+
+        Parameters
+        ----------
+        field : Field
+            The original field.
+
+        Returns
+        -------
+        Field
+            A new Field with the metadata components copied from the original field.
+        """
+        components = {}
+        for component_name in cls._COMPONENT_NAMES:
+            if component_name not in [_DATA, _LABELS]:
+                components[component_name] = field._components[component_name]
+
+        new_field = cls.from_components(**components)
+        new_field._private = field._private
+        return new_field
+
     @property
     def ensemble(self):
         """Ensemble: Return the ensemble component of the field."""
@@ -763,13 +786,13 @@ class Field(Base):
         --------
         How-to examples for the :meth:`data` method can be found in the following notebooks:
 
-        - :ref:`/how-tos/grib/grib_lat_lon_value_ll.ipynb`
-        - :ref:`/how-tos/grib/grib_lat_lon_value_rgg.ipynb`
+        - :ref:`/tutorials/grib/grib_lat_lon_value_ll.ipynb`
+        - :ref:`/tutorials/grib/grib_lat_lon_value_rgg.ipynb`
 
         Other examples:
 
         >>> import earthkit.data as ekd
-        >>> fl = ekd.from_source("file", "docs/how-tos/test6.grib").to_fieldlist()
+        >>> fl = ekd.from_source("file", "docs/tutorials/test6.grib").to_fieldlist()
         >>> d = fl[0].data()
         >>> d.shape
         (3, 7, 12)
@@ -1433,8 +1456,8 @@ class Field(Base):
         --------
         See the how-to examples for the :meth:`set` method in the following notebook:
 
-        - :ref:`/how-tos/grib/grib_modify_metadata.ipynb`
-        - :ref:`/how-tos/grib/grib_modify_values.ipynb`
+        - :ref:`/tutorials/grib/grib_modify_metadata.ipynb`
+        - :ref:`/tutorials/grib/grib_modify_values.ipynb`
 
         Further examples:
 
@@ -1578,8 +1601,8 @@ class Field(Base):
         --------
         How-to examples for the :meth:`to_target` method can be found in the following notebooks:
 
-        - :ref:`/how-tos/target/file_target.ipynb`
-        - :ref:`/how-tos/target/grib_to_file_target.ipynb`
+        - :ref:`/tutorials/target/file_target.ipynb`
+        - :ref:`/tutorials/target/grib_to_file_target.ipynb`
         """
         from earthkit.data.targets import to_target
 
@@ -1682,7 +1705,7 @@ class Field(Base):
 
         Examples
         --------
-        :ref:`/how-tos/grib/grib_contents.ipynb`
+        :ref:`/tutorials/grib/grib_contents.ipynb`
 
         """
         if component is None or component == "":
@@ -1740,7 +1763,7 @@ class Field(Base):
 
         Examples
         --------
-        :ref:`/how-tos/grib/grib_contents.ipynb`
+        :ref:`/tutorials/grib/grib_contents.ipynb`
 
         """
         from earthkit.data.utils.summary import format_namespace_dump
@@ -1910,6 +1933,10 @@ class Field(Base):
         #     m.check(self)
 
     def _get_grib_context(self, context):
+        """Helper method to get the GRIB context for the field and its components.
+
+        It is used by the encoders.
+        """
         grib = self._get_grib()
         if grib is not None:
             context["handle"] = grib.handle
@@ -1918,21 +1945,67 @@ class Field(Base):
             m.get_grib_context(context)
 
     def _set_metadata(self, md):
-        g = self._get_grib()
-        if g is not None:
-            from earthkit.data.encoders.grib import GribEncoder
+        """Helper method to set raw metadata in the field."""
+        grib = self._get_grib()
+        if grib is not None:
+            # when the data is not stored in the GRIB message but in the field's components (e.g.
+            # after calling set(values=...)) we need to ensure the values are not encoded into
+            # the new handle and also that the new field is created with the same data object
+            # as the original field. We use the encode_values flag to control this behaviour.
+            data = self._components[_DATA]
+            encode_values = "values" in md or (data is not None and hasattr(data, "handle"))
 
-            encoder = GribEncoder()
-            return encoder.encode(data=self, metadata=md).to_field()
+            # create a new field
+            return self._update_grib_handle(self, data, metadata=md, encode_values=encode_values)
+
         return self
 
     def _sync_metadata(self):
-        if self._get_grib() and self._private and "_metadata" in self._private:
-            from earthkit.data.encoders.grib import GribEncoder
+        """Helper method to synchronize the raw metadata in the field with the field's components."""
+        grib = self._get_grib()
+        if grib and self._private and "_metadata" in self._private:
+            # when the data is not stored in the GRIB message but in the field's components (e.g.
+            # after calling set(values=...)) we need to ensure the values are not encoded into
+            # the new handle and also that the new field is created with the same data object
+            # as the original field. We use the encode_values flag to control this behaviour.
+            data = self._components[_DATA]
+            encode_values = data is None or hasattr(data, "handle")
 
-            encoder = GribEncoder()
-            return encoder.encode(data=self).to_field()
+            # create a new field
+            return self._update_grib_handle(self, data, metadata=None, encode_values=encode_values)
+
         return self
+
+    @staticmethod
+    def _update_grib_handle(field, data, metadata=None, encode_values=False):
+        from earthkit.data.encoders.grib import GribEncoder
+
+        encoder = GribEncoder()
+
+        # the data values are encoded into the new handle. A new field will be created
+        # from the new handle.
+        if encode_values:
+            return encoder.encode(data=field, metadata=metadata).to_field()
+        # the values will not be encoded into the new handle. A new field will be created from
+        # the new handle but with the data component object of the the original field.
+        else:
+            from earthkit.data.field.grib.create import create_grib_field
+            from earthkit.data.readers.grib.handle import MemoryGribHandle
+
+            #  create a temporary field with the same metadata as the original field
+            #  but with the no data component.
+            data = field._components[_DATA]
+            tmp_field = Field._tmp_field_from_metadata(field)
+
+            # encode the temporary field with the new metadata and create a new handle
+            # Since the temporary field has no data component, the encoder will not set
+            # any data values in the new handle. The new field will be created with the same data values
+            d = encoder.encode(data=tmp_field, metadata=metadata)
+            handle = MemoryGribHandle(d.handle)
+
+            # The new field will be created with the updated handle and
+            # data values from the original field.
+            return create_grib_field(handle, data=data, template_field=field)
 
     @normalise("time.valid_datetime", "date")
     @normalise("time.base_datetime", "date")

--- a/src/earthkit/data/field/grib/create.py
+++ b/src/earthkit/data/field/grib/create.py
@@ -47,7 +47,6 @@ def create_grib_field(handle, data=None, cache=False, extra_keys=None, template_
         proc=proc,
         labels=labels,
     )
-
     r._set_private_data("metadata", grib)
     return r
 
@@ -71,10 +70,16 @@ def new_array_grib_field(field, handle, array_namespace=None, device=None, flatt
     return new_field
 
 
-def create_grib_field_from_message(buf, template_field=None):
+def create_grib_field_from_message(buf, template_field=None, no_values=False):
     from earthkit.data.readers.grib.handle import MemoryGribHandle
 
-    return create_grib_field(MemoryGribHandle.from_message(buf), template_field=template_field, cache=False)
+    data = None
+    if no_values:
+        from earthkit.data.field.handler.data import DataFieldComponentHandler
+
+        data = DataFieldComponentHandler.create_empty()
+
+    return create_grib_field(MemoryGribHandle.from_message(buf), data=data, template_field=template_field, cache=False)
 
 
 create_grib_field_from_buffer = create_grib_field_from_message

--- a/src/earthkit/data/field/handler/data.py
+++ b/src/earthkit/data/field/handler/data.py
@@ -82,6 +82,11 @@ class BaseDataFieldComponentHandler(FieldComponentHandler):
                 "array_dtype": str(values.dtype),
             }
 
+    @classmethod
+    def create_empty(cls) -> "BaseDataFieldComponentHandler":
+        """Create an empty DataFieldComponentHandler."""
+        return EMPTY_DATA_HANDLER
+
 
 class DataFieldComponentHandler(BaseDataFieldComponentHandler):
     """Data component handler for Field that provides implementation
@@ -125,6 +130,8 @@ class DataFieldComponentHandler(BaseDataFieldComponentHandler):
         elif isinstance(data, dict):
             dict_kwargs = dict_kwargs or {}
             return cls.from_dict(data, **dict_kwargs)
+        elif isinstance(data, BaseDataFieldComponentHandler):
+            return data
 
         raise TypeError(f"Cannot create {cls.__name__} from {type(data)}")
 
@@ -186,9 +193,9 @@ class DataFieldComponentHandler(BaseDataFieldComponentHandler):
 
         COLLECTOR.collect(self, context)
 
-    @classmethod
-    def create_empty(cls) -> "DataFieldComponentHandler":
-        return EMPTY_DATA_HANDLER
+    # @classmethod
+    # def create_empty(cls) -> "DataFieldComponentHandler":
+    #     return EMPTY_DATA_HANDLER
 
 
 class ArrayCache:

--- a/src/earthkit/data/xr_engine/engine.py
+++ b/src/earthkit/data/xr_engine/engine.py
@@ -512,7 +512,7 @@ class XarrayEarthkitDataArray(XarrayEarthkit):
             if message:
                 from earthkit.data.field.grib.create import create_grib_field_from_message
 
-                return create_grib_field_from_message(message)
+                return create_grib_field_from_message(message, no_values=True)
         except Exception as e:
             raise ValueError(
                 (

--- a/tests/encoders/test_grib_encoder.py
+++ b/tests/encoders/test_grib_encoder.py
@@ -127,7 +127,7 @@ def test_grib_encoder_field_data_and_template(init_encoder, template_arg):
     assert f_r.message() is not None
     assert f.message() != f_r.message()
     assert f_r.message() == r.to_bytes()
-    assert np.allclose(f.values, f_r.values)
+    np.testing.assert_allclose(f.values, f_r.values)
     assert f.get("parameter.variable") == "2t"
     assert f_r.get("parameter.variable") == "msl"
     if template_arg == "field_labels":

--- a/tests/grib/test_grib_set.py
+++ b/tests/grib/test_grib_set.py
@@ -708,3 +708,57 @@ def test_grib_set_field_mixed_metadata(fl_type):
         assert f_saved.get("metadata.levelist") == 600
         assert f_saved.get("vertical.level_type") == "pressure"
         assert f_saved.get("metadata.typeOfLevel") == "isobaricInhPa"
+
+
+@pytest.mark.parametrize("fl_type", ["file", "array", "memory"])
+def test_grib_set_field_raw_data_storage_1(fl_type):
+    ds_ori, _ = load_grib_data("test4.grib", fl_type)
+
+    f = ds_ori[0].set({
+        "metadata.shortName": "q",
+        "metadata.level": 600,
+    })
+
+    # TODO: avoid using private attributes in the following test
+    if fl_type == "array":
+        # After setting the raw keys an array field should stay an array field
+        assert hasattr(f._components["data"], "_values")
+        assert not hasattr(f._components["data"], "handle")
+    else:
+        # After setting the raw keys a file/memory GRIB field should not become an array field,
+        # but should have a handle to the original data
+        assert not hasattr(f._components["data"], "_values")
+        assert hasattr(f._components["data"], "handle")
+
+
+@pytest.mark.parametrize("fl_type", ["file", "array", "memory"])
+def test_grib_set_field_raw_data_storage_2(fl_type):
+    ds_ori, _ = load_grib_data("test4.grib", fl_type)
+
+    f = ds_ori[0].set({
+        "parameter.variable": "q",
+    })
+
+    # TODO: avoid using private attributes in the following test
+
+    if fl_type == "array":
+        # After setting high-level keys an array field should stay an array field
+        assert hasattr(f._components["data"], "_values")
+        assert not hasattr(f._components["data"], "handle")
+    else:
+        # After setting high-level keys a file/memory GRIB field should not become an array field,
+        # but should have a handle to the original data
+        assert not hasattr(f._components["data"], "_values")
+        assert hasattr(f._components["data"], "handle")
+
+    f1 = f.sync()
+
+    if fl_type == "array":
+        # After sync an array field should stay an array field
+        assert hasattr(f1._components["data"], "_values")
+        assert not hasattr(f1._components["data"], "handle")
+    else:
+        # After sync a file/memory GRIB  field should not become an array field,
+        # but should have a handle to the original data
+        assert not hasattr(f1._components["data"], "_values")
+        assert hasattr(f1._components["data"], "handle")


### PR DESCRIPTION
### Description

This PR:

- improves the syncing of the field and the GRIB handle after setting the high-level metadata and `sync()` is called
- improves the setting of the raw ecCodes metadata on a Field

In both cases the original data representation of the field is kept. I.e. if the field stores the values in array the updated field will also store the values as an array.

Also improved the way the `reference_field` of the Xarray accessor is updated when changing it with `set()`. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
