### PR TITLE
feat: Add lunar distance calculations as forcings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ optional-dependencies.polytope = ["polytope-client>=0.7.6"]
 optional-dependencies.projection = ["cartopy"]
 optional-dependencies.s3 = ["aws-requests-auth", "botocore"]
 optional-dependencies.test = [
+  "astropy",
   "earthkit-data-demo-source",
   "nbconvert",
   "nbformat",

--- a/src/earthkit/data/sources/forcings.py
+++ b/src/earthkit/data/sources/forcings.py
@@ -193,6 +193,39 @@ class ForcingMaker:
         )
         return result.flatten()
 
+    def distance_to_moon(self, date, copy=True):
+        from earthkit.data.utils.lunar import distance_to_moon
+
+        date = to_datetime(date)
+        result = distance_to_moon(
+            date,
+            self._latitude(),
+            self._longitude(),
+        )
+        return result.flatten()
+
+    def delta_distance_to_moon(self, date, copy=True):
+        from earthkit.data.utils.lunar import delta_distance_to_moon
+
+        date = to_datetime(date)
+        result = delta_distance_to_moon(
+            date,
+            self._latitude(),
+            self._longitude(),
+        )
+        return result.flatten()
+
+    def singular_distance_to_moon(self, date, copy=True):
+        from earthkit.data.utils.lunar import singular_distance_to_moon
+
+        date = to_datetime(date)
+        result = singular_distance_to_moon(
+            date,
+            self._latitude(),
+            self._longitude(),
+        )
+        return result.flatten()
+
     def __getattr__(self, name):
         if "+" not in name and "-" not in name:
             # If we are here, we are looking for a method that does not exist,

--- a/src/earthkit/data/utils/lunar.py
+++ b/src/earthkit/data/utils/lunar.py
@@ -26,7 +26,7 @@ def _require_astropy():
         raise ImportError("`astropy` is required for this function.")
 
 
-def _get_body_xyz(body_name: str, time: Time, xp) -> Any:
+def _get_body_xyz(body_name: str, time: "Time", xp) -> Any:
     """Get the geocentric cartesian coordinates of a celestial body in km.
 
     Parameters
@@ -55,7 +55,7 @@ def _get_body_xyz(body_name: str, time: Time, xp) -> Any:
     return xyz
 
 
-def _get_observer_xyz(time: Time, latitudes, longitudes, xp) -> Any:
+def _get_observer_xyz(time: "Time", latitudes, longitudes, xp) -> Any:
     """Get the ITRS cartesian coordinates of surface observers on Earth at a given time.
 
     Parameters

--- a/src/earthkit/data/utils/lunar.py
+++ b/src/earthkit/data/utils/lunar.py
@@ -1,0 +1,203 @@
+# (C) Copyright 2026 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+# type: ignore[reportPossiblyUnboundVariable]
+
+from typing import Any
+
+from earthkit.utils.array import array_namespace
+
+ASTROPY_AVAILABLE = True
+try:
+    import astropy.units as u
+    from astropy.coordinates import ITRS, EarthLocation, get_body
+    from astropy.time import Time
+except ImportError:
+    ASTROPY_AVAILABLE = False
+
+
+def _require_astropy():
+    if not ASTROPY_AVAILABLE:
+        raise ImportError("`astropy` is required for this function.")
+
+
+def _get_body_xyz(body_name: str, time: Time, xp) -> Any:
+    """Get the geocentric cartesian coordinates of a celestial body in km.
+
+    Parameters
+    ----------
+    body_name : str
+        Name of the celestial body (e.g., 'moon', 'earth').
+    time : astropy.time.Time
+        The time at which to compute the position.
+    xp : module
+        The array namespace (e.g., numpy, cupy).
+
+    Returns
+    -------
+    xyz : array-like (shape (3,))
+        Geocentric cartesian coordinates of the body in km.
+    """
+    body = get_body(body_name, time)
+    body_itrs = body.transform_to(ITRS(obstime=time))
+
+    xyz = xp.array([
+        body_itrs.cartesian.x.to(u.km).value,
+        body_itrs.cartesian.y.to(u.km).value,
+        body_itrs.cartesian.z.to(u.km).value,
+    ])
+
+    return xyz
+
+
+def _get_observer_xyz(time: Time, latitudes, longitudes, xp) -> Any:
+    """Get the ITRS cartesian coordinates of surface observers on Earth at a given time.
+
+    Parameters
+    ----------
+    time : astropy.time.Time
+        The observation time (used to set the ITRS obstime).
+    latitudes : array-like
+        Latitudes of the observer(s) in degrees.
+    longitudes : array-like
+        Longitudes of the observer(s) in degrees.
+    xp : module
+        The array namespace (e.g., numpy, cupy).
+
+    Returns
+    -------
+    xyz : array-like (shape (3, N))
+        ITRS cartesian coordinates of the observer(s) in km.
+    """
+    loc = EarthLocation.from_geodetic(lon=longitudes * u.deg, lat=latitudes * u.deg, height=0 * u.m)
+    obs_itrs = loc.get_itrs(obstime=time)
+    obs_xyz = xp.array([
+        obs_itrs.cartesian.x.to(u.km).value,
+        obs_itrs.cartesian.y.to(u.km).value,
+        obs_itrs.cartesian.z.to(u.km).value,
+    ])  # shape (3, N)
+
+    return obs_xyz
+
+
+def _get_distance_between_bodies(observer_xyz, target_xyz, xp, device) -> Any:
+    """Compute the distance from observer(s) to a target body.
+
+    Parameters
+    ----------
+    observer_xyz : array-like (shape (3, N) or (3,))
+        Cartesian coordinates of the observer(s) in km.
+    target_xyz : array-like (shape (3,) or (3, N))
+        Cartesian coordinates of the target body in km.
+    xp : module
+        The array namespace (e.g., numpy, cupy).
+    device : device
+        The device on which to return the array.
+
+    Returns
+    -------
+    distances : array-like (shape (N,))
+        Distances from observer(s) to the target body in km.
+    """
+    if observer_xyz.ndim == 1:
+        observer_xyz = observer_xyz[:, xp.newaxis]  # shape (3, 1)
+    if target_xyz.ndim == 1:
+        target_xyz = target_xyz[:, xp.newaxis]  # shape (3, 1)
+    diff = observer_xyz - target_xyz  # shape (3, N)
+    distances = xp.asarray(xp.linalg.norm(diff, axis=0), device=device)  # shape (N,)
+
+    return distances
+
+
+def singular_distance_to_moon(date, latitudes, longitudes) -> Any:
+    """Distance to the Moon in km from the Earth centre,
+    with no reference to the latitude and longitude of the observer.
+
+    Parameters
+    ----------
+    date : datetime.datetime
+        The date and time for which to compute the distance.
+    latitudes : array-like
+        Latitudes, used only for array namespace and device inference.
+    longitudes : array-like
+        Longitudes, used only for array namespace and device inference.
+
+    Returns
+    -------
+    distance : float
+        Distance to the Moon in km from the Earth centre at the given date and time.
+    """
+    _require_astropy()
+
+    xp = array_namespace(latitudes, longitudes)
+    device = xp.device(latitudes)
+
+    time = Time(date)  # Convert to astropy Time object
+
+    moon_xyz = _get_body_xyz("moon", time, xp)
+    earth_xyz = _get_body_xyz("earth", time, xp)
+    distance = _get_distance_between_bodies(earth_xyz, moon_xyz, xp, device)
+
+    return distance
+
+
+def distance_to_moon(date, latitudes, longitudes) -> Any:
+    """Distance to the Moon in km.
+
+    Parameters
+    ----------
+    date : datetime.datetime
+        The date and time for which to compute the distance.
+    latitudes : array-like
+        Latitudes of the observer(s) in degrees.
+    longitudes : array-like
+        Longitudes of the observer(s) in degrees.
+
+    Returns
+    -------
+    distances : array-like
+        Distances to the Moon in km.
+    """
+    _require_astropy()
+
+    xp = array_namespace(latitudes, longitudes)
+    latitudes = xp.asarray(latitudes)
+    longitudes = xp.asarray(longitudes)
+    device = xp.device(latitudes)
+
+    time = Time(date)  # Convert to astropy Time object
+
+    moon_xyz = _get_body_xyz("moon", time, xp)
+    observer_xyz = _get_observer_xyz(time, latitudes, longitudes, xp)
+    distances = _get_distance_between_bodies(observer_xyz, moon_xyz, xp, device)
+    return distances
+
+
+def delta_distance_to_moon(date, latitudes, longitudes) -> Any:
+    """Delta distance to the Moon in km, relative to the min instantaneous distance.
+
+    Parameters
+    ----------
+    date : datetime.datetime
+        The date and time for which to compute the delta distance.
+    latitudes : array-like
+        Latitudes of the observer(s) in degrees.
+    longitudes : array-like
+        Longitudes of the observer(s) in degrees.
+
+    Returns
+    -------
+    delta_distances : array-like
+        Delta distances to the Moon in km, relative to the min instantaneous distance.
+    """
+    distances = distance_to_moon(date, latitudes, longitudes)
+    xp = array_namespace(distances)
+    min_distance = xp.min(distances)
+    delta_distances = distances - min_distance
+
+    return delta_distances

--- a/tests/data/forcings/proc.yaml
+++ b/tests/data/forcings/proc.yaml
@@ -66,3 +66,11 @@ toa_incident_solar_radiation:
   first: 2118960.0772719923
   last: 0.0
   mean: 1114965.3289838354
+distance_to_moon:
+  first: 397708.0
+  last: 398423.0
+  mean: 398647.0
+delta_distance_to_moon:
+  first: 508.20
+  last: 1223.54
+  mean: 1446.716

--- a/tests/forcings/forcings_fixtures.py
+++ b/tests/forcings/forcings_fixtures.py
@@ -33,6 +33,8 @@ all_params = [
     "ecef_z",
     "toa_incident_solar_radiation",
     "cos_solar_zenith_angle",
+    "distance_to_moon",
+    "delta_distance_to_moon",
 ]
 
 


### PR DESCRIPTION
### Description
Add lunar distance calculations backed by Astropy as available forcings.

- distance_to_moon: Absolute distance from any place on Earth
- delta_distance_to_moon: Min normalised distance, so that procession is not overwhelming
- singular_distance_to_moon: Global singular distance to moon for procession awareness

```python
distance = ekd.from_source(
	"forcings", 
	source_or_dataset=sample, 
	date = ['2020-01-01T00:00:00'], 
	param = "distance_to_moon"
)
```

> [!NOTE]
> This adds a dependency on Astropy not yet added to the pyproject.toml
> Possibly revert the addition to the tests such that it is entirely on the user to install?

<details>
<summary>GIF of Delta Forcing</summary>
<img width="512" height="651" alt="moon_distance" src="https://github.com/user-attachments/assets/6e4ff14a-b016-44a1-bfbf-e71168e63553" />
</details>



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
