### PR TITLE
fix doc quotes around parameter.variable

### DIFF
--- a/src/earthkit/data/core/fieldlist.py
+++ b/src/earthkit/data/core/fieldlist.py
@@ -654,11 +654,11 @@ class FieldList(Source, Encodable):
 
             - single value::
 
-                fl.sel({parameter.variable: "t"})
+                fl.sel({"parameter.variable": "t"})
 
             - list of values::
 
-                fl.sel({parameter.variable: ["u", "v"]})
+                fl.sel({"parameter.variable": ["u", "v"]})
 
             - slice of values (defines a closed interval, so treated as inclusive of both the start
             and stop values, unlike normal Python indexing). The following example filters the fields
@@ -718,7 +718,7 @@ class FieldList(Source, Encodable):
 
         Selecting by a single key ("parameter.variable") with a single value:
 
-        >>> fl1 = fl.sel({parameter.variable: "t"})
+        >>> fl1 = fl.sel({"parameter.variable": "t"})
         >>> for f in fl1:
         ...     print(f)
         ...
@@ -732,7 +732,7 @@ class FieldList(Source, Encodable):
         Selecting by multiple keys ("parameter.variable", "vertical.level") with a list and slice of values:
 
         >>> fl1 = fl.sel(
-        ...     {parameter.variable: ["u", "v"], vertical.level: slice(400, 700)}
+        ...     {"parameter.variable": ["u", "v"], "vertical.level": slice(400, 700)}
         ... )
         >>> for f in fl1:
         ...     print(f)


### PR DESCRIPTION
### Description
Hi dear earthkit-devs,

From the [Fieldlist doc](https://earthkit-data.readthedocs.io/en/latest/autoapi/earthkit/data/core/fieldlist/index.html#earthkit.data.core.fieldlist.FieldList.sel):
<img width="271" height="86" alt="image" src="https://github.com/user-attachments/assets/09ce2fed-a095-4f21-a87c-ae747fe9c066" />
I obtained `NameError: name "parameter" is not defined`: 
<img width="467" height="182" alt="image" src="https://github.com/user-attachments/assets/dbe80651-5d8e-46fa-930c-587ee380e87a" />

So I added the quotes around `parameter.variable` in the corresponding doc in this PR.

Feel free to ignore and close the PR if this is supposed to work.

Cheers

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
