### PR TITLE
Allow converting multiple csv files to pandas

### DIFF
--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -28,7 +28,16 @@ if TYPE_CHECKING:
 class MultiData(SimpleData):
     _TYPE_NAME = "Multi"
 
-    """Represent multiple sources that cannot be represented by a single Data object."""
+    """Represent multiple sources that cannot be represented by a single Data object.
+
+    When :py:func:`earthkit.data.from_source` is called with multiple input files, earthkit-data attempts to
+    return a single, type-specific Data object (e.g. ``GribData`` for a set of GRIB files). A ``MultiData``
+    object is returned instead in two situations:
+
+    - the source type does not support multiple input files (e.g. ``CSVData`` handles only one file at a time,
+      so multiple CSV files yield a ``MultiData``);
+    - the input files are of mixed types and cannot be merged into a single typed object.
+    """
 
     def __init__(self, sources):
         """Initialize a MultiData object.

--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -56,7 +56,7 @@ class MultiData(SimpleData):
 
     @property
     @experimental(msg="MultiData.sources is experimental and may change or be removed without notice. Do not use it.")
-    def _legacy_sources(self) -> Any:
+    def sources(self) -> Any:
         """Experimental property and may change or be removed in future versions."""
         return self._sources_legacy
 

--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -7,16 +7,31 @@
 # nor does it submit to any jurisdiction.
 #
 
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Any,  # noqa: F401
+)
+
 from earthkit.utils.decorators import experimental
 
 from . import Data, SimpleData
+
+if TYPE_CHECKING:
+    import pandas  # type: ignore[import]
+    import xarray  # type: ignore[import]
+
+    from earthkit.data.core.fieldlist import FieldList
 
 
 class MultiData(SimpleData):
     _TYPE_NAME = "Multi"
 
+    """Represent multiple sources that cannot be represented by a single Data object."""
+
     def __init__(self, sources):
-        """Initialize a MultiData object with multiple sources.
+        """Initialize a MultiData object.
 
         Parameters
         ----------
@@ -27,7 +42,7 @@ class MultiData(SimpleData):
         self._source = sources
 
     @property
-    def available_types(self):
+    def available_types(self) -> list[str]:
         """list[str]: Return the list of available types that this data object can be converted to."""
         types = set()
         try:
@@ -41,7 +56,7 @@ class MultiData(SimpleData):
 
     @property
     @experimental(msg="MultiData.sources is experimental and may change or be removed without notice. Do not use it.")
-    def sources(self):
+    def _legacy_sources(self) -> Any:
         """Experimental property and may change or be removed in future versions."""
         return self._sources_legacy
 
@@ -55,7 +70,7 @@ class MultiData(SimpleData):
 
         return res
 
-    def describe(self):
+    def describe(self) -> Any:
         """Provide a description of the MultiData.
 
         Returns
@@ -65,7 +80,7 @@ class MultiData(SimpleData):
         """
         pass
 
-    def to_fieldlist(self, *args, **kwargs):
+    def to_fieldlist(self, *args, **kwargs) -> FieldList:
         """Convert into a FieldList.
 
         Parameters
@@ -88,6 +103,7 @@ class MultiData(SimpleData):
         if "fieldlist" not in self.available_types:
             raise NotImplementedError("Cannot convert this MultiData object to a fieldlist")
 
+        # TODO: review this merger usage
         data = self._datas()
         fs = [d.to_fieldlist(*args, **kwargs) for d in data]
         from earthkit.data.mergers import merge_by_class
@@ -98,53 +114,77 @@ class MultiData(SimpleData):
 
         raise NotImplementedError("Cannot convert this MultiData object to a fieldlist")
 
-    def to_xarray(self, *args, **kwargs):
+    def to_xarray(self, *args, xarray_open_mfdataset_kwargs=None, **kwargs) -> "xarray.Dataset":
         """Convert into an Xarray dataset.
+
+        The conversion is performed by using :py:func:`xarray.open_mfdataset`.
 
         Parameters
         ----------
         *args
-            Positional arguments to pass to the sources' to_xarray method.
+            Positional arguments to pass to the reader's to_xarray method.
+            Not used currently. It is there to allow for future extensions or
+            additional parameters that may be needed for specific use cases.
+        xarray_open_mfdataset_kwargs: dict, None, optional
+            Keyword arguments passed to :py:func:`xarray.open_mfdataset`.
+            When specified, this argument takes precedence over
+            any other keyword arguments passed to the method. It is used for safe
+            parsing of kwargs via intermediate methods.
         **kwargs
-            Keyword arguments to pass to the sources' to_xarray method.
+            Keyword arguments passed :py:func:`xarray.open_mfdataset`.
+            Ignored if `xarray_open_mfdataset_kwargs` is specified.
 
         Returns
         -------
         :py:class:`xarray.Dataset`
-            An Xarray dataset containing data from all sources.
+            An Xarray dataset containing data from all objects in the MultiData.
         """
+        if xarray_open_mfdataset_kwargs:
+            options = dict(xarray_open_mfdataset_kwargs=xarray_open_mfdataset_kwargs)
+        else:
+            options = dict()
+
         if "xarray" not in self.available_types:
-            raise NotImplementedError("Cannot convert this MultiData object to xarray")
+            raise NotImplementedError(
+                "Cannot convert this MultiData object to Xarray. Not all objects support Xarray conversion."
+            )
 
-        data = self._datas()
+        # TODO: review this merger usage
+        return self._source.to_xarray(*args, **options, **kwargs)
 
-        from earthkit.data.mergers import make_merger
-
-        return make_merger(None, data).to_xarray(*args, **kwargs)
-
-    def to_pandas(self, *args, **kwargs):
+    def to_pandas(self, comment="#", pandas_read_csv_kwargs=None) -> "pandas.DataFrame":
         """Convert into a Pandas DataFrame.
 
         Parameters
         ----------
-        *args
-            Positional arguments (unused).
-        **kwargs
-            Keyword arguments (unused).
+        comment: str
+            Character that represents a comment line in a CSV file. This value is ignored if the
+            comment character is defined in ``pandas_read_csv_kwargs``. Applied to all the CSV data
+            sources in the current object.
+        pandas_read_csv_kwargs: dict, None, optional
+            Keyword arguments passed to :func:`pandas.read_csv`. This is used for safe parsing of
+            kwargs via intermediate methods. Applied to all the CSV data sources in the current object.
 
         Returns
         -------
         :py:class:`pandas.DataFrame`
-            A Pandas DataFrame containing data from all sources.
+            A Pandas DataFrame containing the data from all objects in the MultiData.
         """
         if "pandas" not in self.available_types:
-            raise NotImplementedError("Cannot convert this MultiData object to pandas")
+            raise NotImplementedError(
+                "Cannot convert this MultiData object to pandas. Not all objects support pandas conversion."
+            )
 
+        # TODO: review this merger usage
         data = self._datas()
 
         from earthkit.data.mergers import make_merger
 
-        return make_merger(None, data).to_pandas(*args, **kwargs)
+        pandas_read_csv_kwargs = dict(pandas_read_csv_kwargs) if pandas_read_csv_kwargs is not None else {}
+        if "comment" not in pandas_read_csv_kwargs:
+            pandas_read_csv_kwargs["comment"] = comment
+
+        return make_merger(None, data).to_pandas(pandas_read_csv_kwargs=pandas_read_csv_kwargs)
 
     def to_geopandas(self, *args, **kwargs):
         """Convert into a GeoPandas GeoDataFrame.
@@ -163,7 +203,7 @@ class MultiData(SimpleData):
         """
         raise NotImplementedError("Conversion of MultiData to geopandas is not implemented")
 
-    def to_geojson(self, *args, **kwargs):
+    def to_geojson(self, *args, **kwargs) -> dict:
         """Convert into GeoJSON format.
 
         Parameters

--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -7,30 +7,46 @@
 # nor does it submit to any jurisdiction.
 #
 
-
-from . import SimpleData
+from . import Data, SimpleData
 
 
 class MultiData(SimpleData):
+    _TYPE_NAME = "Multi"
+
     def __init__(self, sources):
         """Initialize a MultiData object with multiple sources.
 
         Parameters
         ----------
-        sources : list
+        sources : list, MultiSource
             List of data sources to combine.
         """
         self.sources = sources
         self._source = sources
-        # self.datas = [s._reader._to_data_object() for s in self.sources.sources]
 
     @property
     def available_types(self):
         """list[str]: Return the list of available types that this data object can be converted to."""
         types = set()
-        for d in self.sources:
-            types.update(d.available_types)
-        return sorted(types)
+        try:
+            for d in self._datas():
+                types.update(d.available_types)
+            return sorted(types)
+        except Exception:
+            pass
+
+        return list()
+
+    def _datas(self):
+        res = []
+        for s in self._source.sources:
+            if isinstance(s, Data):
+                res.append(s)
+            else:
+                res.append(s.to_data_object())
+
+        print(f"MultiData<{id(self)}>: _datas() -> {res}")
+        return res
 
     def describe(self):
         """Provide a description of the MultiData.
@@ -62,8 +78,10 @@ class MultiData(SimpleData):
         NotImplementedError
             If conversion to FieldList is not implemented for this combination of sources.
         """
-        # return self.sources.to_fieldlist(*args, **kwargs)
-        data = [s.to_data_object() for s in self.sources.sources]
+        if "fieldlist" not in self.available_types:
+            raise NotImplementedError("Cannot convert this MultiData object to a fieldlist")
+
+        data = self._datas()
         fs = [d.to_fieldlist(*args, **kwargs) for d in data]
         from earthkit.data.mergers import merge_by_class
 
@@ -71,7 +89,7 @@ class MultiData(SimpleData):
         if merged is not None:
             return merged.mutate()
 
-        raise NotImplementedError("Conversion of MultiData to fieldlist is not implemented")
+        raise NotImplementedError("Cannot convert this MultiData object to a fieldlist")
 
     def to_xarray(self, *args, **kwargs):
         """Convert into an Xarray dataset.
@@ -88,7 +106,14 @@ class MultiData(SimpleData):
         :py:class:`xarray.Dataset`
             An Xarray dataset containing data from all sources.
         """
-        return self.sources.to_xarray(*args, **kwargs)
+        if "xarray" not in self.available_types:
+            raise NotImplementedError("Cannot convert this MultiData object to xarray")
+
+        data = self._datas()
+
+        from earthkit.data.mergers import make_merger
+
+        return make_merger(None, data).to_xarray(*args, **kwargs)
 
     def to_pandas(self, *args, **kwargs):
         """Convert into a Pandas DataFrame.
@@ -105,7 +130,14 @@ class MultiData(SimpleData):
         :py:class:`pandas.DataFrame`
             A Pandas DataFrame containing data from all sources.
         """
-        pass
+        if "pandas" not in self.available_types:
+            raise NotImplementedError("Cannot convert this MultiData object to pandas")
+
+        data = self._datas()
+
+        from earthkit.data.mergers import make_merger
+
+        return make_merger(None, data).to_pandas(*args, **kwargs)
 
     def to_geopandas(self, *args, **kwargs):
         """Convert into a GeoPandas GeoDataFrame.

--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -7,6 +7,8 @@
 # nor does it submit to any jurisdiction.
 #
 
+from earthkit.utils.decorators import experimental
+
 from . import Data, SimpleData
 
 
@@ -18,10 +20,10 @@ class MultiData(SimpleData):
 
         Parameters
         ----------
-        sources : list, MultiSource
-            List of data sources to combine.
+        sources : MultiSource
+            A MultiSource object containing multiple data sources.
         """
-        self.sources = sources
+        self._sources_legacy = sources
         self._source = sources
 
     @property
@@ -37,6 +39,12 @@ class MultiData(SimpleData):
 
         return list()
 
+    @property
+    @experimental(msg="MultiData.sources is experimental and may change or be removed without notice. Do not use it.")
+    def sources(self):
+        """Experimental property and may change or be removed in future versions."""
+        return self._sources_legacy
+
     def _datas(self):
         res = []
         for s in self._source.sources:
@@ -45,7 +53,6 @@ class MultiData(SimpleData):
             else:
                 res.append(s.to_data_object())
 
-        print(f"MultiData<{id(self)}>: _datas() -> {res}")
         return res
 
     def describe(self):

--- a/src/earthkit/data/data/netcdf.py
+++ b/src/earthkit/data/data/netcdf.py
@@ -55,7 +55,7 @@ class NetCDFData(SourceData):
     def to_xarray(self, *args, xarray_open_mfdataset_kwargs=None, **kwargs):
         """Convert into an Xarray dataset.
 
-        The conversion is performed by using :py:func:`xarray.open_mfdataset` for a
+        The conversion is performed by using :py:func:`xarray.open_dataset` for a
         single file and :py:func:`xarray.open_mfdataset` for multiple files.
 
         Parameters

--- a/src/earthkit/data/mergers/__init__.py
+++ b/src/earthkit/data/mergers/__init__.py
@@ -85,8 +85,6 @@ class Merger:
                 self.reader_class = _nearest_common_class(readers)
                 self.paths = paths
 
-        print("reader_class", self.reader_class, "paths", self.paths, "common", self.common)
-
     @property
     def paths_or_sources(self):
         if self.paths is not None:

--- a/src/earthkit/data/mergers/__init__.py
+++ b/src/earthkit/data/mergers/__init__.py
@@ -85,6 +85,8 @@ class Merger:
                 self.reader_class = _nearest_common_class(readers)
                 self.paths = paths
 
+        print("reader_class", self.reader_class, "paths", self.paths, "common", self.common)
+
     @property
     def paths_or_sources(self):
         if self.paths is not None:

--- a/src/earthkit/data/mergers/pandas.py
+++ b/src/earthkit/data/mergers/pandas.py
@@ -18,4 +18,8 @@ def merge(
 
     options = dict(ignore_index=True)  # Renumber all indices
     options.update(kwargs)
-    return pd.concat([s.to_pandas(**kwargs) for s in sources], **options)
+    if "pandas_read_csv_kwargs" in options:
+        pandas_read_csv_kwargs = options.pop("pandas_read_csv_kwargs")
+    else:
+        pandas_read_csv_kwargs = kwargs
+    return pd.concat([s.to_pandas(pandas_read_csv_kwargs=pandas_read_csv_kwargs) for s in sources], **options)

--- a/src/earthkit/data/readers/csv/reader.py
+++ b/src/earthkit/data/readers/csv/reader.py
@@ -31,8 +31,6 @@ class CSVReader(Reader):
     def to_pandas(self, comment="#", pandas_read_csv_kwargs=None):
         """Convert CSV data into a :py:class:`pandas.DataFrame` using :py:func:`pandas.read_csv`.
 
-        Please note that Earthkit should be able to handle compressed file objects.
-
         Parameters
         ----------
         comment: str
@@ -42,9 +40,16 @@ class CSVReader(Reader):
             kwargs passed to :func:`pandas.read_csv`, this is used for safe parsing of kwargs via intermediate
             methods
 
+
         Returns
         -------
         :py:class:`pandas.DataFrame`
+
+
+        Notes
+        -----
+        Compressed file objects are supported.
+
 
         Examples
         --------

--- a/src/earthkit/data/readers/grib/file.py
+++ b/src/earthkit/data/readers/grib/file.py
@@ -205,6 +205,9 @@ class GRIBReader(Source, GRIBReaderBase):
     def to_array(self, *args, **kwargs):
         return self.to_fieldlist().to_array(*args, **kwargs)
 
+    def to_pandas(self, *args, **kwargs):
+        return self.to_fieldlist().to_pandas(*args, **kwargs)
+
     def peek(self):
         return first_field_from_grib_file(self.path, parts=self._kwargs.get("parts", None))
 
@@ -255,6 +258,9 @@ class MultiGRIBReader(Source, GRIBReaderBase):
 
     def to_xarray(self, *args, **kwargs):
         return self.to_fieldlist().to_xarray(*args, **kwargs)
+
+    def to_pandas(self, *args, **kwargs):
+        return self.to_fieldlist().to_pandas(*args, **kwargs)
 
     def __repr__(self):
         return f"MultiGRIBReader({self.sources})"

--- a/tests/high_level_object/test_hl_csv_core.py
+++ b/tests/high_level_object/test_hl_csv_core.py
@@ -23,3 +23,19 @@ def test_hl_csv_single_core():
     df = ds.to_pandas()
     assert len(df) == 6
     assert list(df.columns) == ["h1", "h2", "h3", "name"]
+
+
+def test_hl_csv_multi_core():
+    paths = [earthkit_test_data_file("test.csv")] * 2
+    ds = from_source("file", paths)
+
+    assert ds._TYPE_NAME == "Multi"
+    assert ds.is_stream() is False
+    assert "pandas" in ds.available_types
+    assert "xarray" in ds.available_types
+    assert "fieldlist" not in ds.available_types
+
+    df = ds.to_pandas()
+    assert len(df) == 12
+    assert set(df.columns) == set(["h1", "h2", "h3", "name"])
+    assert df["name"].tolist() == ["A", "B", "C", "a", "b", "c"] * 2

--- a/tests/high_level_object/test_hl_grib_core.py
+++ b/tests/high_level_object/test_hl_grib_core.py
@@ -38,6 +38,10 @@ def test_hl_grib_single_core():
     assert a["2t"].shape == (8, 13)
     assert a["msl"].shape == (8, 13)
 
+    df = ds.to_pandas()
+    assert len(df) == 208
+    assert set(df.columns) == {"lat", "lon", "value", "datetime"}
+
     v = ds.to_numpy()
     assert v.shape == (2, 8, 13)
 

--- a/tests/netcdf/test_netcdf_concat.py
+++ b/tests/netcdf/test_netcdf_concat.py
@@ -229,7 +229,6 @@ def _concat_var_different_coords_1(kind1, kind2):
     target = xr.concat([ds1, ds2], dim="time")
 
     ds = from_source("multi", [s1, s2], merger="concat(concat_dim=time)")
-    # ds.graph()
     merged = ds.to_xarray()
 
     assert target.identical(merged), f"Concat failed for {kind1}, {kind2}"

--- a/tests/readers/test_csv_reader.py
+++ b/tests/readers/test_csv_reader.py
@@ -184,6 +184,51 @@ def test_csv_multi_1():
     assert df["name"].tolist() == ["A", "B", "C", "a", "b", "c"] * 2
 
 
+def test_csv_multi_2_comment_and_separator():
+    s1 = from_source(
+        "dummy-source",
+        "csv",
+        headers=["a", "b", "c"],
+        quote_strings=True,
+        lines=[
+            [1, "x", 3],
+            [4, "y", 6],
+            [7, "z", 9],
+        ],
+        separator="|",
+        comment_line="This is a comment",
+        comment="?",
+    )
+
+    s2 = from_source(
+        "dummy-source",
+        "csv",
+        headers=["a", "b", "c"],
+        quote_strings=True,
+        lines=[
+            [8, "x", 15],
+            [9, "y", 16],
+            [10, "z", 17],
+        ],
+        separator="|",
+        comment_line="This is a comment",
+        comment="?",
+    )
+
+    filename1 = s1._reader.path
+    filename2 = s2._reader.path
+
+    d = from_source("file", [filename1, filename2])
+
+    df = d.to_pandas(comment="?", pandas_read_csv_kwargs={"sep": "|"})
+    assert len(df) == 6
+    assert set(df.columns) == set(["a", "b", "c"])
+
+    df = d.to_pandas(pandas_read_csv_kwargs={"sep": "|", "comment": "?"})
+    assert len(df) == 6
+    assert set(df.columns) == set(["a", "b", "c"])
+
+
 # TODO test compression
 
 if __name__ == "__main__":

--- a/tests/readers/test_csv_reader.py
+++ b/tests/readers/test_csv_reader.py
@@ -14,6 +14,7 @@ import mimetypes
 import pytest
 
 from earthkit.data import from_source
+from earthkit.data.utils.testing import earthkit_test_data_file
 
 
 def test_csv_1():
@@ -171,6 +172,16 @@ def test_csv_mimetypes():
     assert mimetypes.guess_type("x.csv") == ("text/csv", None)
     assert mimetypes.guess_type("x.csv.gz") == ("text/csv", "gzip")
     assert mimetypes.guess_type("x.csv.bz2") == ("text/csv", "bzip2")
+
+
+def test_csv_multi_1():
+    paths = [earthkit_test_data_file("test.csv")] * 2
+    d = from_source("file", paths)
+
+    df = d.to_pandas()
+    assert len(df) == 12
+    assert set(df.columns) == set(["h1", "h2", "h3", "name"])
+    assert df["name"].tolist() == ["A", "B", "C", "a", "b", "c"] * 2
 
 
 # TODO test compression

--- a/tests/readers/test_netcdf_reader.py
+++ b/tests/readers/test_netcdf_reader.py
@@ -120,11 +120,12 @@ def test_netcdf_multi_cds():
     s2.to_xarray()
 
     source = from_source("multi", s1, s2)
-    for s in source:
-        print(s)
 
-    # TODO: this is crashing with new CDS
-    # source.to_xarray()
+    ds = source.to_xarray()
+
+    assert "t2m" in ds.data_vars
+    assert ds.t2m.shape == (2, 9, 18)
+    assert ds.valid_time.shape == (2,)
 
 
 @pytest.mark.no_eccodes

--- a/tests/sources/test_cds.py
+++ b/tests/sources/test_cds.py
@@ -14,7 +14,7 @@ import os
 import pytest
 
 from earthkit.data import from_source
-from earthkit.data.core.temporary import temp_directory
+from earthkit.data.core.temporary import temp_directory, temp_file
 from earthkit.data.utils.testing import NO_CDS, preserve_cwd
 
 CDS_TIMEOUT = pytest.CDS_TIMEOUT
@@ -420,18 +420,21 @@ def test_cds_grib_to_pandas_xarray():
     )
     data_cds = from_source("cds", collection_id, **request)
 
-    # Assert a consistent behaviour for local and remote versions
-    data_file = from_source("file", data_cds.path)
-    assert data_cds.to_pandas().equals(data_file.to_pandas())
-    assert data_cds.to_xarray().equals(data_file.to_xarray())
+    with temp_file() as filename:
+        data_cds.to_target("file", filename)
 
-    df = data_file.to_pandas()
-    assert len(df) == 388168
-    assert list(df.columns)[:3] == ["lat", "lon", "value"]
+        # Assert a consistent behaviour for local and remote versions
+        data_file = from_source("file", filename)
+        assert data_cds.to_pandas().equals(data_file.to_pandas())
+        assert data_cds.to_xarray().equals(data_file.to_xarray())
 
-    ds = data_file.to_xarray()
-    assert len(ds) == 2
-    assert len(ds.data_vars) == 2
+        df = data_file.to_pandas()
+        assert len(df) == 388168
+        assert list(df.columns)[:3] == ["lat", "lon", "value"]
+
+        ds = data_file.to_xarray()
+        assert len(ds) == 2
+        assert len(ds.data_vars) == 2
 
 
 @pytest.mark.long_test


### PR DESCRIPTION
### Description

This PR:

- Improves the `MultiData` implementation for `to_pandas()` and `to_xarray()`
- Makes `MultiData.available_types` work
- Adds tests for converting multiple CSV input files to pandas
- Add test for `MultiData.available_types`
- `MultiData.sources` was mistakenly implemented as a public attribute. Now it is turned into a property and marked as experimental. It will be removed in a future release. 
- Improved the MultiData docstrings

Fixes #1068 

Relates to #1070 


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
