### PR TITLE
Add regression test for MultiData.to_pandas via CDS multi-source

### DIFF
--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -105,7 +105,8 @@ class MultiData(SimpleData):
         :py:class:`pandas.DataFrame`
             A Pandas DataFrame containing data from all sources.
         """
-        pass
+        
+        return self.sources.to_pandas(*args, **kwargs)
 
     def to_geopandas(self, *args, **kwargs):
         """Convert into a GeoPandas GeoDataFrame.

--- a/src/earthkit/data/mergers/pandas.py
+++ b/src/earthkit/data/mergers/pandas.py
@@ -18,4 +18,4 @@ def merge(
 
     options = dict(ignore_index=True)  # Renumber all indices
     options.update(kwargs)
-    return pd.concat([s.to_pandas(**kwargs) for s in sources], **options)
+    return pd.concat([s.to_data_object().to_pandas(**kwargs) for s in sources], **options)

--- a/tests/sources/test_cds.py
+++ b/tests/sources/test_cds.py
@@ -466,6 +466,32 @@ def test_cds_netcdf_to_pandas_xarray():
     # assert data_cds.to_pandas().equals(data_file.to_pandas())
 
 
+@pytest.mark.long_test
+@pytest.mark.download
+@pytest.mark.skipif(NO_CDS, reason="No access to CDS")
+@pytest.mark.timeout(300)
+def test_cds_multi_source_to_pandas():
+    dataset = "sis-european-wind-storm-reanalysis"
+    request = {
+        "product": "windstorm_track",
+        "variable": "all",
+        "tracking_algorithm": ["hodges"],
+        "event_aggregation": "single_event",
+        "year": ["2020"],
+        "month": ["01"],
+        "day": [f"{day:02}" for day in range(1, 32)],
+    }
+
+    data = from_source("cds", dataset, request)
+
+    df = data.to_pandas()
+
+    assert not df.empty
+    assert "time" in df.columns
+    assert "latitude" in df.columns
+    assert "longitude" in df.columns
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 


### PR DESCRIPTION
## Description

MultiData.to_pandas was unimplemented (just pass), so calling .to_pandas() on data returned by multi-source CDS requests (e.g. `sis-european-wind-storm-reanalysis`) returned None instead of a Dataframe

While testing this against a real CDS request, found a second related bug: mergers/pandas.py::merge was calling .to_pandas() on raw Source objects, which don't implement that method, only the result of `.to_data_object()` does. Fixed by calling `.to_data_object().to_pandas()` for each source

- src/earthkit/data/data/multi.py: MultiData.to_pandas now delegates to self.sources.to_pandas(...)
- src/earthkit/data/mergers/pandas.py: merge each source via to_data_object().to_pandas() instead of to_pandas() directly

Added test_cds_multi_source_to_pandas:
- Fails against un-fixed branch with AttributeError: 'NoneType' object has no attribute empty
- Passes with this fix applied

Ran tests with pytest (no failures)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
