### PR TITLE
Deprecate MultiData.sources

### DIFF
--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -64,9 +64,16 @@ class MultiData(SimpleData):
         return list()
 
     @property
-    @deprecation.deprecated(deprecated_in="1.1.0", removed_in=None)
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in=None,
+        details=(
+            "The 'sources' property is deprecated and will be removed in a future release. "
+            "Access to the underlying sources in MultiData is no longer part of the public API."
+        ),
+    )
     def sources(self) -> Any:
-        """Deprecated property and will be removed in future versions."""
+        """Deprecated. Access to the underlying sources is no longer part of the public API."""
         return self._sources_legacy
 
     def _datas(self):

--- a/src/earthkit/data/data/multi.py
+++ b/src/earthkit/data/data/multi.py
@@ -14,7 +14,7 @@ from typing import (
     Any,  # noqa: F401
 )
 
-from earthkit.utils.decorators import experimental
+import deprecation
 
 from . import Data, SimpleData
 
@@ -64,9 +64,9 @@ class MultiData(SimpleData):
         return list()
 
     @property
-    @experimental(msg="MultiData.sources is experimental and may change or be removed without notice. Do not use it.")
+    @deprecation.deprecated(deprecated_in="1.1.0", removed_in=None)
     def sources(self) -> Any:
-        """Experimental property and may change or be removed in future versions."""
+        """Deprecated property and will be removed in future versions."""
         return self._sources_legacy
 
     def _datas(self):


### PR DESCRIPTION
### Description

Previously `MultiData.sources` was marked as experimental. Now it is marked as deprecated. Access to the underlying sources in `MultiData` is no longer part of the public API.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
