### PR TITLE
Fix unresolved GRIB standard names in xarray output

### DIFF
--- a/src/earthkit/data/field/grib/parameter.py
+++ b/src/earthkit/data/field/grib/parameter.py
@@ -46,6 +46,8 @@ class GribParameterBuilder:
             v = _get("param", None)
         variable = v
         standard_name = _get("cfName", None)
+        if standard_name == "unknown":
+            standard_name = None
         long_name = _get("name", None)
 
         units = _get("units", None)

--- a/tests/grib/test_grib_parameter.py
+++ b/tests/grib/test_grib_parameter.py
@@ -22,13 +22,17 @@ from grib_fixtures import (
 @pytest.mark.parametrize("fl_type", FL_TYPES)
 def test_grib_parameter_1(fl_type):
     ds, _ = load_grib_data("test_single.grib", fl_type, folder="data")
+    assert ds is not None
     f = ds[0]
 
     assert f.parameter.variable() == "2t"
-    assert f.parameter.standard_name() == "unknown"
+    assert f.parameter.standard_name() is None
     assert f.parameter.long_name() == "2 metre temperature"
     assert f.parameter.param() == "2t"
     assert f.parameter.units() == "K"
+
+    xr_ds = ds.to_xarray()
+    assert "standard_name" not in xr_ds["2t"].attrs
 
 
 @pytest.mark.parametrize("fl_type", FL_TYPES)
@@ -53,7 +57,7 @@ def test_grib_parameter_tilde_shortname(fl_type):
     assert f.parameter.variable() == "106"
     assert f.parameter.param() == "106"
     assert f.parameter.units() == "~"
-    assert f.parameter.standard_name() == "unknown"
+    assert f.parameter.standard_name() is None
     assert f.parameter.long_name() == "Experimental product"
 
 


### PR DESCRIPTION
Fixes #1082

### Description

Treat ecCodes' unresolved `cfName="unknown"` sentinel as missing metadata, so `to_xarray()` omits the invalid CF `standard_name` attribute. The existing GRIB fixture now covers both parameter metadata and xarray output.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I ran the focused GRIB parameter tests and confirmed they pass.
