### PR TITLE
Normalized ecCodes from unknown to None

### DIFF
--- a/src/earthkit/data/field/grib/parameter.py
+++ b/src/earthkit/data/field/grib/parameter.py
@@ -46,6 +46,11 @@ class GribParameterBuilder:
             v = _get("param", None)
         variable = v
         standard_name = _get("cfName", None)
+
+        if standard_name == "unknown":
+            # ecCodes may return "unknown" for unresolved cfName. None is safer downstream
+            standard_name = None
+
         long_name = _get("name", None)
 
         units = _get("units", None)

--- a/tests/grib/test_grib_parameter.py
+++ b/tests/grib/test_grib_parameter.py
@@ -25,7 +25,7 @@ def test_grib_parameter_1(fl_type):
     f = ds[0]
 
     assert f.parameter.variable() == "2t"
-    assert f.parameter.standard_name() == "unknown"
+    assert f.parameter.standard_name() is None
     assert f.parameter.long_name() == "2 metre temperature"
     assert f.parameter.param() == "2t"
     assert f.parameter.units() == "K"
@@ -53,7 +53,7 @@ def test_grib_parameter_tilde_shortname(fl_type):
     assert f.parameter.variable() == "106"
     assert f.parameter.param() == "106"
     assert f.parameter.units() == "~"
-    assert f.parameter.standard_name() == "unknown"
+    assert f.parameter.standard_name() is None
     assert f.parameter.long_name() == "Experimental product"
 
 

--- a/tests/xr_engine/test_xr_engine_dims.py
+++ b/tests/xr_engine/test_xr_engine_dims.py
@@ -560,7 +560,6 @@ def test_xr_ensure_dims(
             },
             {
                 "2dfd": {
-                    "standard_name": "unknown",
                     "long_name": "2D wave spectra (single)",
                     "units": "meter ** 2 * second / radian",
                     "typeOfLevel": "meanSea",
@@ -619,7 +618,6 @@ def test_xr_extra_dims(source, allow_holes, lazy_load, sel, kwargs, coords, dims
             },
             {
                 "2dfd": {
-                    "standard_name": "unknown",
                     "long_name": "2D wave spectra (single)",
                     "units": "meter ** 2 * second / radian",
                     "typeOfLevel": "meanSea",
@@ -722,7 +720,6 @@ def test_xr_wave_dims(source, allow_holes, lazy_load, sel, kwargs, coords, dims,
             },
             {
                 "aod": {
-                    "standard_name": "unknown",
                     "long_name": "Aerosol optical depth",
                     "units": "Numeric",
                     "level_type": "surface",


### PR DESCRIPTION
### Description
Problem

When converting GRIB fields to xarray via to_xarray(), several common ERA5 variables (2t, 10u, 10v, tp) end up with standard_name="unknown" in their attrs. This happens because ecCodes returns the literal string "unknown" for cfName when no CF mapping is resolved, and this value was passed through unfiltered into the field's standard_name. Since "unknown" is not a valid CF standard name, this misleadingly implies a resolved CF mapping exists when it doesn't.

Fix

In GribParameterBuilder._build_dict (src/earthkit/data/field/grib/parameter.py), cfName == "unknown" is now normalized to None. Downstream, the xr_engine attrs pipeline already drops None values before writing final attrs, so standard_name is now correctly omitted for these fields rather than containing an invalid literal.

Scope

This is a minimal, source-level fix. The issue also raised the possibility of falling back to a cfVarName-derived CF standard_name mapping, but I've scoped that out of this PR since it's a separate design decision. Happy to open a follow-up issue for that if maintainers want to pursue it.

Testing

Reproduced the exact scenario from the issue (CDS ERA5 fetch of 2t, 10u, 10v, msl, sp, tp) and confirmed all 4 affected variables now correctly omit standard_name, while msl/sp (already correctly resolved) are unaffected.
Updated tests/grib/test_grib_parameter.py (2 assertions) and tests/xr_engine/test_xr_engine_dims.py (3 expected-attrs dicts) that had encoded the old buggy "unknown" value as expected behavior.

Full test suite passes

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
