### PR TITLE
Improve usage of earthkit-meteo related computations

### DIFF
--- a/src/earthkit/data/sources/forcings.py
+++ b/src/earthkit/data/sources/forcings.py
@@ -170,7 +170,7 @@ class ForcingMaker:
         return self.cos_solar_zenith_angle(date)
 
     def toa_incident_solar_radiation(self, date, copy=True):
-        from earthkit.data.utils.meteo import toa_incident_solar_radiation
+        from earthkit.data.utils.meteo.solar import toa_incident_solar_radiation
 
         date = to_datetime(date)
         result = toa_incident_solar_radiation(
@@ -183,7 +183,7 @@ class ForcingMaker:
         return result.flatten()
 
     def cos_solar_zenith_angle(self, date, copy=True):
-        from earthkit.data.utils.meteo import cos_solar_zenith_angle
+        from earthkit.data.utils.meteo.solar import cos_solar_zenith_angle
 
         date = to_datetime(date)
         result = cos_solar_zenith_angle(
@@ -194,7 +194,7 @@ class ForcingMaker:
         return result.flatten()
 
     def distance_to_moon(self, date, copy=True):
-        from earthkit.data.utils.lunar import distance_to_moon
+        from earthkit.data.utils.meteo.lunar import distance_to_moon
 
         date = to_datetime(date)
         result = distance_to_moon(
@@ -205,7 +205,7 @@ class ForcingMaker:
         return result.flatten()
 
     def delta_distance_to_moon(self, date, copy=True):
-        from earthkit.data.utils.lunar import delta_distance_to_moon
+        from earthkit.data.utils.meteo.lunar import delta_distance_to_moon
 
         date = to_datetime(date)
         result = delta_distance_to_moon(
@@ -216,7 +216,7 @@ class ForcingMaker:
         return result.flatten()
 
     def singular_distance_to_moon(self, date, copy=True):
-        from earthkit.data.utils.lunar import singular_distance_to_moon
+        from earthkit.data.utils.meteo.lunar import singular_distance_to_moon
 
         date = to_datetime(date)
         result = singular_distance_to_moon(

--- a/src/earthkit/data/utils/meteo/__init__.py
+++ b/src/earthkit/data/utils/meteo/__init__.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+
+# NOTE: The "forcings" source relies on array-based solar and lunar parameter computations that are
+# implemented in earthkit-meteo. However, earthkit-meteo cannot be a dependency of earthkit-data
+# (not even an optional one), so its presence cannot be assumed. To handle this, equivalent
+# implementations are provided in the local `solar` and `lunar` submodules as a fallback.
+#
+# Resolution order:
+#   1. Use earthkit-meteo if it is installed.
+#   2. Fall back to the local submodule implementation otherwise.
+#
+# Each local submodule explicitly declares the set of methods it exposes for use within earthkit-data.
+# Any method available only in a local submodule (and not yet in earthkit-meteo) will be served from
+# there on a temporary basis until it can be upstreamed to earthkit-meteo.
+#
+
+# TODO: Find a better way to handle the situation.

--- a/src/earthkit/data/utils/meteo/lunar/__init__.py
+++ b/src/earthkit/data/utils/meteo/lunar/__init__.py
@@ -1,0 +1,19 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import importlib
+
+from earthkit.data.utils.meteo.registry import _register
+
+_EKM_MODULE_NAME = "lunar"
+_METHOD_NAMES = ["distance_to_moon", "delta_distance_to_moon", "distance_from_earth_centre_to_moon"]
+_EKD_MODULE = importlib.import_module("earthkit.data.utils.meteo.lunar.local")
+
+for method in _register(_EKM_MODULE_NAME, _EKD_MODULE, _METHOD_NAMES):
+    globals()[method.__name__] = method

--- a/src/earthkit/data/utils/meteo/lunar/local.py
+++ b/src/earthkit/data/utils/meteo/lunar/local.py
@@ -8,25 +8,45 @@
 #
 # type: ignore[reportPossiblyUnboundVariable]
 
-from typing import Any
+
+# NOTE: These methods are identical to the ones in earthkit-meteo, but they are duplicated here
+# to provide a fallback when earthkit-meteo is not installed.
+# See the comments in src/earthkit/data/utils/meteo/__init__.py for more details.
+
+from __future__ import annotations
+
+import datetime
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeAlias,
+)
 
 from earthkit.utils.array import array_namespace
+from numpy.typing import NDArray
 
-ASTROPY_AVAILABLE = True
+NDArrayLike: TypeAlias = NDArray | float
+ArrayNamespace: TypeAlias = Any
+
+_ASTROPY_AVAILABLE = True
 try:
-    import astropy.units as u
+    import astropy.units as astropy_units
     from astropy.coordinates import ITRS, EarthLocation, get_body
     from astropy.time import Time
 except ImportError:
-    ASTROPY_AVAILABLE = False
+    _ASTROPY_AVAILABLE = False
 
 
-def _require_astropy():
-    if not ASTROPY_AVAILABLE:
-        raise ImportError("`astropy` is required for this function.")
+def _require_astropy(function_name: str):
+    if not _ASTROPY_AVAILABLE:
+        raise ImportError(f"`astropy` is required for the function `{function_name}`.")
 
 
-def _get_body_xyz(body_name: str, time: "Time", xp) -> Any:
+if TYPE_CHECKING:
+    import astropy  # type: ignore[import]
+
+
+def _get_body_xyz(body_name: str, time: "astropy.time.Time", xp: ArrayNamespace) -> Any:
     """Get the geocentric cartesian coordinates of a celestial body in km.
 
     Parameters
@@ -35,7 +55,7 @@ def _get_body_xyz(body_name: str, time: "Time", xp) -> Any:
         Name of the celestial body (e.g., 'moon', 'earth').
     time : astropy.time.Time
         The time at which to compute the position.
-    xp : module
+    xp : ArrayNamespace
         The array namespace (e.g., numpy, cupy).
 
     Returns
@@ -46,62 +66,64 @@ def _get_body_xyz(body_name: str, time: "Time", xp) -> Any:
     body = get_body(body_name, time)
     body_itrs = body.transform_to(ITRS(obstime=time))
 
-    xyz = xp.array([
-        body_itrs.cartesian.x.to(u.km).value,
-        body_itrs.cartesian.y.to(u.km).value,
-        body_itrs.cartesian.z.to(u.km).value,
+    xyz = xp.asarray([
+        body_itrs.cartesian.x.to(astropy_units.km).value,
+        body_itrs.cartesian.y.to(astropy_units.km).value,
+        body_itrs.cartesian.z.to(astropy_units.km).value,
     ])
 
     return xyz
 
 
-def _get_observer_xyz(time: "Time", latitudes, longitudes, xp) -> Any:
-    """Get the ITRS cartesian coordinates of surface observers on Earth at a given time.
+def _get_observer_xyz(
+    time: "astropy.time.Time", latitudes: NDArrayLike, longitudes: NDArrayLike, xp: ArrayNamespace
+) -> NDArray:
+    """Get the :term:`ITRS` cartesian coordinates of surface observers on Earth at a given time.
 
     Parameters
     ----------
     time : astropy.time.Time
-        The observation time (used to set the ITRS obstime).
-    latitudes : array-like
+        The observation time (used to set the :term:`ITRS` obstime).
+    latitudes : NDArrayLike
         Latitudes of the observer(s) in degrees.
-    longitudes : array-like
+    longitudes : NDArrayLike
         Longitudes of the observer(s) in degrees.
-    xp : module
+    xp : ArrayNamespace
         The array namespace (e.g., numpy, cupy).
 
     Returns
     -------
-    xyz : array-like (shape (3, N))
-        ITRS cartesian coordinates of the observer(s) in km.
+    xyz : NDArrayLike (shape (3, N))
+        :term:`ITRS` cartesian coordinates of the observer(s) in km.
+
     """
-    loc = EarthLocation.from_geodetic(lon=longitudes * u.deg, lat=latitudes * u.deg, height=0 * u.m)
+    loc = EarthLocation.from_geodetic(lon=longitudes, lat=latitudes)
+
     obs_itrs = loc.get_itrs(obstime=time)
-    obs_xyz = xp.array([
-        obs_itrs.cartesian.x.to(u.km).value,
-        obs_itrs.cartesian.y.to(u.km).value,
-        obs_itrs.cartesian.z.to(u.km).value,
+    obs_xyz = xp.asarray([
+        obs_itrs.cartesian.x.to(astropy_units.km).value,
+        obs_itrs.cartesian.y.to(astropy_units.km).value,
+        obs_itrs.cartesian.z.to(astropy_units.km).value,
     ])  # shape (3, N)
 
     return obs_xyz
 
 
-def _get_distance_between_bodies(observer_xyz, target_xyz, xp, device) -> Any:
+def _get_distance_between_bodies(observer_xyz: NDArray, target_xyz: NDArray, xp: ArrayNamespace) -> NDArray:
     """Compute the distance from observer(s) to a target body.
 
     Parameters
     ----------
-    observer_xyz : array-like (shape (3, N) or (3,))
+    observer_xyz : NDArray (shape (3, N) or (3,))
         Cartesian coordinates of the observer(s) in km.
-    target_xyz : array-like (shape (3,) or (3, N))
+    target_xyz : NDArray (shape (3,) or (3, N))
         Cartesian coordinates of the target body in km.
-    xp : module
+    xp : ArrayNamespace
         The array namespace (e.g., numpy, cupy).
-    device : device
-        The device on which to return the array.
 
     Returns
     -------
-    distances : array-like (shape (N,))
+    distances : NDArray (shape (N,))
         Distances from observer(s) to the target body in km.
     """
     if observer_xyz.ndim == 1:
@@ -109,12 +131,11 @@ def _get_distance_between_bodies(observer_xyz, target_xyz, xp, device) -> Any:
     if target_xyz.ndim == 1:
         target_xyz = target_xyz[:, xp.newaxis]  # shape (3, 1)
     diff = observer_xyz - target_xyz  # shape (3, N)
-    distances = xp.asarray(xp.linalg.norm(diff, axis=0), device=device)  # shape (N,)
-
+    distances = xp.linalg.norm(diff, axis=0)  # shape (N,)
     return distances
 
 
-def singular_distance_to_moon(date, latitudes, longitudes) -> Any:
+def distance_from_earth_centre_to_moon(date: datetime.datetime) -> float:
     """Distance to the Moon in km from the Earth centre,
     with no reference to the latitude and longitude of the observer.
 
@@ -122,78 +143,72 @@ def singular_distance_to_moon(date, latitudes, longitudes) -> Any:
     ----------
     date : datetime.datetime
         The date and time for which to compute the distance.
-    latitudes : array-like
-        Latitudes, used only for array namespace and device inference.
-    longitudes : array-like
-        Longitudes, used only for array namespace and device inference.
 
     Returns
     -------
     distance : float
         Distance to the Moon in km from the Earth centre at the given date and time.
     """
-    _require_astropy()
+    _require_astropy("distance_from_earth_centre_to_moon")
 
-    xp = array_namespace(latitudes, longitudes)
-    device = xp.device(latitudes)
+    xp = array_namespace("numpy")
 
     time = Time(date)  # Convert to astropy Time object
 
     moon_xyz = _get_body_xyz("moon", time, xp)
     earth_xyz = _get_body_xyz("earth", time, xp)
-    distance = _get_distance_between_bodies(earth_xyz, moon_xyz, xp, device)
+    distance = _get_distance_between_bodies(earth_xyz, moon_xyz, xp)
 
     return distance
 
 
-def distance_to_moon(date, latitudes, longitudes) -> Any:
+def distance_to_moon(date: datetime.datetime, latitudes: NDArrayLike, longitudes: NDArrayLike) -> NDArrayLike:
     """Distance to the Moon in km.
 
     Parameters
     ----------
     date : datetime.datetime
         The date and time for which to compute the distance.
-    latitudes : array-like
+    latitudes : NDArrayLike
         Latitudes of the observer(s) in degrees.
-    longitudes : array-like
+    longitudes : NDArrayLike
         Longitudes of the observer(s) in degrees.
 
     Returns
     -------
-    distances : array-like
+    distances : NDArrayLike
         Distances to the Moon in km.
     """
-    _require_astropy()
+    _require_astropy("distance_to_moon")
 
     xp = array_namespace(latitudes, longitudes)
     latitudes = xp.asarray(latitudes)
     longitudes = xp.asarray(longitudes)
-    device = xp.device(latitudes)
 
     time = Time(date)  # Convert to astropy Time object
 
     moon_xyz = _get_body_xyz("moon", time, xp)
     observer_xyz = _get_observer_xyz(time, latitudes, longitudes, xp)
-    distances = _get_distance_between_bodies(observer_xyz, moon_xyz, xp, device)
+    distances = _get_distance_between_bodies(observer_xyz, moon_xyz, xp)
     return distances
 
 
-def delta_distance_to_moon(date, latitudes, longitudes) -> Any:
-    """Delta distance to the Moon in km, relative to the min instantaneous distance.
+def delta_distance_to_moon(date: datetime.datetime, latitudes: NDArrayLike, longitudes: NDArrayLike) -> NDArrayLike:
+    """Delta distance to the Moon in km, relative to the minimum instantaneous distance.
 
     Parameters
     ----------
     date : datetime.datetime
         The date and time for which to compute the delta distance.
-    latitudes : array-like
+    latitudes : NDArrayLike
         Latitudes of the observer(s) in degrees.
-    longitudes : array-like
+    longitudes : NDArrayLike
         Longitudes of the observer(s) in degrees.
 
     Returns
     -------
-    delta_distances : array-like
-        Delta distances to the Moon in km, relative to the min instantaneous distance.
+    delta_distances : NDArrayLike
+        The difference between the distances and the minimum distance to the Moon of the specific observer(s).
     """
     distances = distance_to_moon(date, latitudes, longitudes)
     xp = array_namespace(distances)

--- a/src/earthkit/data/utils/meteo/registry.py
+++ b/src/earthkit/data/utils/meteo/registry.py
@@ -1,0 +1,33 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import importlib
+
+
+def _register(ekm_module_name, ekd_module, method_names):
+    """Register array computation methods from the earthkit-meteo module or the local module."""
+    res = []
+    found = set()
+    try:
+        module = importlib.import_module(f"earthkit.meteo.{ekm_module_name}.array")
+        for method_name in method_names:
+            if hasattr(module, method_name):
+                res.append(getattr(module, method_name))
+                found.add(method_name)
+    except ImportError:
+        pass
+
+    for method_name in method_names:
+        if method_name not in found:
+            try:
+                res.append(getattr(ekd_module, method_name))
+            except AttributeError:
+                pass
+
+    return res

--- a/src/earthkit/data/utils/meteo/solar/__init__.py
+++ b/src/earthkit/data/utils/meteo/solar/__init__.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import importlib
+
+from earthkit.data.utils.meteo.registry import _register
+
+_EKM_MODULE_NAME = "solar"
+_METHOD_NAMES = [
+    "cos_solar_zenith_angle",
+    "solar_declination_angle",
+    "julian_day",
+    "incoming_solar_radiation",
+    "toa_incident_solar_radiation",
+]
+
+_EKD_MODULE = importlib.import_module("earthkit.data.utils.meteo.solar.local")
+
+for method in _register(_EKM_MODULE_NAME, _EKD_MODULE, _METHOD_NAMES):
+    globals()[method.__name__] = method

--- a/src/earthkit/data/utils/meteo/solar/local.py
+++ b/src/earthkit/data/utils/meteo/solar/local.py
@@ -7,10 +7,9 @@
 # nor does it submit to any jurisdiction.
 #
 
-# TODO: This code was copied from earthkit.meteo.solar.array to avoid
-# dependency on earthkit.meteo and circular imports. It should be refactored
-# to avoid code duplication.
-
+# NOTE: These methods are identical to the ones in earthkit-meteo, but they are duplicated here
+# to provide a fallback when earthkit-meteo is not installed.
+# See the comments in src/earthkit/data/utils/meteo/__init__.py for more details.
 
 import datetime
 


### PR DESCRIPTION
### Description

This PR reorganised the earthkit-meteo related computations, which are now grouped into the `earthkit.data.utils.meteo` submodule.

The "forcings" source relies on array-based solar and lunar parameter computations that are  implemented in earthkit-meteo. However, earthkit-meteo cannot be a dependency of earthkit-data
(not even an optional one), so its presence cannot be assumed. To handle this, equivalent
implementations are provided in the local `solar` and `lunar` submodules as a fallback.

Resolution order:
   1. Use earthkit-meteo if it is installed.
   2. Fall back to the local submodule implementation otherwise.

Each local submodule explicitly declares the set of methods it exposes for use within earthkit-data.
Any method available only in a local submodule (and not yet in earthkit-meteo) will be served from
there on a temporary basis until it can be upstreamed to earthkit-meteo.

TODO:
- find a better solution for this situation

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
