### PR TITLE
Avoid using ecCodes GRIB keys in Xarray engine unnecessarily

### DIFF
--- a/src/earthkit/data/xr_engine/builder.py
+++ b/src/earthkit/data/xr_engine/builder.py
@@ -676,7 +676,7 @@ class DatasetBuilder:
         return ds_xr, profile
 
     def grid(self, ds):
-        grids = ds.index("metadata.md5GridSection")
+        grids = ds.index("geography.unique_grid_id")
 
         if not grids:
             grid = "_custom_" + str(id(ds))

--- a/src/earthkit/data/xr_engine/coord.py
+++ b/src/earthkit/data/xr_engine/coord.py
@@ -191,7 +191,7 @@ class LevelCoord(Coord):
             # we only store the level type for the high-level level type key. For other
             # keys it will be looked up on demand from the stored field to avoid
             # accessing raw ecCodes keys unnecessarily, which can be expensive.
-            self._level_type = ds[0]._get_fast("vertical.level_type")
+            self._level_type = ds[0]._get_fast(self._LEVEL_TYPE_KEY)
 
             # store the field to be able to access raw ecCodes keys if needed
             self._field = ds[0]

--- a/src/earthkit/data/xr_engine/coord.py
+++ b/src/earthkit/data/xr_engine/coord.py
@@ -177,8 +177,10 @@ class MonthCoord(Coord):
 
 
 class LevelCoord(Coord):
+    _LEVEL_TYPE_KEY = "vertical.level_type"
+
     def __init__(self, name, vals, dims=None, ds=None, **kwargs):
-        self._level_types = {}
+        self._level_type = None
         self._default = None
         self._field = None
         if ds is not None:
@@ -189,10 +191,9 @@ class LevelCoord(Coord):
             # we only store the level type for the high-level level type key. For other
             # keys it will be looked up on demand from the stored field to avoid
             # accessing raw ecCodes keys unnecessarily, which can be expensive.
-            v = ds[0]._get_fast("vertical.level_type") if self._field else None
-            if v is not None:
-                self._level_types["vertical.level_type"] = v
+            self._level_type = ds[0]._get_fast("vertical.level_type")
 
+            # store the field to be able to access raw ecCodes keys if needed
             self._field = ds[0]
 
         super().__init__(name, vals, dims, **kwargs)
@@ -206,20 +207,22 @@ class LevelCoord(Coord):
             level_type_key = conf.get("dim_roles", {}).get("level_type")
 
             for key in keys:
+                level_type = None
+
                 if key == level_type_key or level_type_key is None:
                     # check the stored level type
-                    level_type = None
-                    if key in self._level_types:
-                        level_type = self._level_types[key]
+                    if key == self._LEVEL_TYPE_KEY:
+                        if self._level_type is not None:
+                            level_type = self._level_type
+                        else:
+                            continue
 
                     # check other level type keys.
                     # It involves getting raw ecCodes keys,
                     # which can be expensive, so this step is delayed
                     # until we actually need the level type information.
                     if level_type is None and self._field is not None:
-                        v = self._field._get_fast(key)
-                        if v is not None:
-                            level_type = v
+                        level_type = self._field._get_fast(key)
 
                     if level_type is None:
                         continue

--- a/src/earthkit/data/xr_engine/coord.py
+++ b/src/earthkit/data/xr_engine/coord.py
@@ -178,18 +178,22 @@ class MonthCoord(Coord):
 
 class LevelCoord(Coord):
     def __init__(self, name, vals, dims=None, ds=None, **kwargs):
-        self._level_type = {}
+        self._level_types = {}
         self._default = None
+        self._field = None
         if ds is not None:
             # TODO: this is a bit hacky, need to find a better way to get the level type information
             _cf_attrs = ds[0].vertical.cf()  # can be None
             self._default = dict(_cf_attrs) if _cf_attrs else {}
 
-            # TODO; try to avoid getting the metadata upfront
-            for k in ["vertical.level_type", "metadata.typeOfLevel", "metadata.levtype"]:
-                v = ds[0]._get_fast(k)
-                if v is not None:
-                    self._level_type[k] = v
+            # we only store the level type for the high-level level type key. For other
+            # keys it will be looked up on demand from the stored field to avoid
+            # accessing raw ecCodes keys unnecessarily, which can be expensive.
+            v = ds[0]._get_fast("vertical.level_type") if self._field else None
+            if v is not None:
+                self._level_types["vertical.level_type"] = v
+
+            self._field = ds[0]
 
         super().__init__(name, vals, dims, **kwargs)
 
@@ -203,9 +207,23 @@ class LevelCoord(Coord):
 
             for key in keys:
                 if key == level_type_key or level_type_key is None:
-                    level_type = self._level_type.get(key)
+                    # check the stored level type
+                    level_type = None
+                    if key in self._level_types:
+                        level_type = self._level_types[key]
+
+                    # check other level type keys.
+                    # It involves getting raw ecCodes keys,
+                    # which can be expensive, so this step is delayed
+                    # until we actually need the level type information.
+                    if level_type is None and self._field is not None:
+                        v = self._field._get_fast(key)
+                        if v is not None:
+                            level_type = v
+
                     if level_type is None:
                         continue
+
                     _attrs = conf.get(level_type)
                     if _attrs is not None:
                         return _attrs

--- a/src/earthkit/data/xr_engine/profile.py
+++ b/src/earthkit/data/xr_engine/profile.py
@@ -19,9 +19,9 @@ from earthkit.data.utils import ensure_dict, ensure_iterable
 LOG = logging.getLogger(__name__)
 
 
-GEO_KEYS = ["md5GridSection"]
+GEO_KEYS = ["geography.unique_grid_id"]
 MANDATORY_KEYS = GEO_KEYS
-IGNORE_ATTRS = ["md5GridSection"]
+IGNORE_ATTRS = ["geography.unique_grid_id"]
 
 
 class RemappingBuilder:


### PR DESCRIPTION
### Description

With this PR the Xarray engine uses high-level field metadata keys instead of ecCodes keys when possible in the following cases:

- describing the grid
- describing the the vertical coordinate attributes

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
