### PR TITLE
Improve using aliases for wekeo-cds source and update docs and tests

### DIFF
--- a/docs/source/concepts/inputs/from_source.rst
+++ b/docs/source/concepts/inputs/from_source.rst
@@ -71,8 +71,10 @@ from_source
       - retrieve data from Amazon S3 buckets
     * - :ref:`data-sources-wekeo`
       - retrieve data from `WEkEO`_ using the WEkEO grammar
-    * - :ref:`data-sources-wekeocds`
+    * - :ref:`data-sources-wekeo-cds`
       - retrieve `CDS <https://cds.climate.copernicus.eu/>`_ data stored on `WEkEO`_ using the `cdsapi`_ grammar
+    * - :ref:`data-sources-wekeocds-deprecated`
+      - deprecated, use :ref:`data-sources-wekeo-cds` instead
     * - :ref:`data-sources-zarr`
       - load data from a `Zarr <https://zarr.readthedocs.io/en/stable/>`_ store
 
@@ -1203,17 +1205,17 @@ wekeo
       - :ref:`/tutorials/source/wekeo.ipynb`
 
 
-.. _data-sources-wekeocds:
+.. _data-sources-wekeo-cds:
 
 wekeo-cds
 ---------
 
-*Added in version 1.2.0 replacing the deprecated ``wekeocds`` source.*
+*Added in version 1.2.0 replacing the deprecated* ``wekeocds`` *source.*
 
 .. py:function:: from_source("wekeo-cds", dataset, *args, request=None, prompt=True, **kwargs)
   :noindex:
 
-  `WEkEO`_ is the Copernicus DIAS reference service for environmental data and virtual processing environments. The ``wekeocds`` source provides access to `Copernicus Climate Data Store`_ (CDS) datasets served on `WEkEO`_ using the `cdsapi`_ grammar. The retrieval is based on the hda_ Python API.
+  `WEkEO`_ is the Copernicus DIAS reference service for environmental data and virtual processing environments. The ``wekeo-cds`` source provides access to `Copernicus Climate Data Store`_ (CDS) datasets served on `WEkEO`_ using the `cdsapi`_ grammar. The retrieval is based on the hda_ Python API.
 
   :param str dataset: the name of the WEkEO dataset
   :param tuple *args: positional arguments representing request dictionaries. Each item can be dictionary or
@@ -1236,7 +1238,7 @@ wekeo-cds
       import earthkit.data as ekd
 
       d = ekd.from_source(
-          "wekeocds",
+          "wekeo-cds",
           "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS_MONTHLY_MEANS",
           request=dict(
               variable=["2m_temperature", "mean_sea_level_pressure"],
@@ -1263,7 +1265,7 @@ wekeo-cds
 wekeocds
 ---------
 
-This is a deprecated source since version 1.2.0 and will be removed in a future release. Please use the ``wekeo-cds`` source instead.
+This is a deprecated source since version 1.2.0 and will be removed in a future release. Please use the :ref:`data-sources-wekeo-cds` source instead.
 
 .. _data-sources-zarr:
 

--- a/docs/source/concepts/inputs/from_source.rst
+++ b/docs/source/concepts/inputs/from_source.rst
@@ -1205,10 +1205,12 @@ wekeo
 
 .. _data-sources-wekeocds:
 
-wekeocds
---------
+wekeo-cds
+---------
 
-.. py:function:: from_source("wekeocds", dataset, *args, request=None, prompt=True, **kwargs)
+*Added in version 1.2.0 replacing the deprecated ``wekeocds`` source.*
+
+.. py:function:: from_source("wekeo-cds", dataset, *args, request=None, prompt=True, **kwargs)
   :noindex:
 
   `WEkEO`_ is the Copernicus DIAS reference service for environmental data and virtual processing environments. The ``wekeocds`` source provides access to `Copernicus Climate Data Store`_ (CDS) datasets served on `WEkEO`_ using the `cdsapi`_ grammar. The retrieval is based on the hda_ Python API.
@@ -1236,7 +1238,7 @@ wekeocds
       d = ekd.from_source(
           "wekeocds",
           "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS_MONTHLY_MEANS",
-          requewst=dict(
+          request=dict(
               variable=["2m_temperature", "mean_sea_level_pressure"],
               product_type=["monthly_averaged_reanalysis_by_hour_of_day"],
               year=["2012"],
@@ -1256,6 +1258,12 @@ wekeocds
       - :ref:`/tutorials/source/wekeo.ipynb`
 
 
+.. _data-sources-wekeocds-deprecated:
+
+wekeocds
+---------
+
+This is a deprecated source since version 1.2.0 and will be removed in a future release. Please use the ``wekeo-cds`` source instead.
 
 .. _data-sources-zarr:
 

--- a/docs/source/concepts/misc/split_on.rst
+++ b/docs/source/concepts/misc/split_on.rst
@@ -11,7 +11,7 @@ The majority of the request-based retrieval **sources**  supports the ``split_on
 - :ref:`data-sources-mars`
 - :ref:`data-sources-polytope`
 - :ref:`data-sources-wekeo`
-- :ref:`data-sources-wekeocds`
+- :ref:`data-sources-wekeo-cds`
 
 When ``split_on`` is present in the request, it instructs the source to split the request into multiple parts, which are then executed independently and the resulting data will be stored in different files. However, the actual storage is hidden from the users and they can still work with the results as a single object.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,7 +50,7 @@ The following optional extras are available:
     - projection: adds projection support
     - polytope: provides access to the :ref:`data-sources-polytope` source
     - s3: provides access to non-public :ref:`s3 <data-sources-s3>` buckets (new in version *0.11.0*)
-    - wekeo: provides access to the :ref:`data-sources-wekeo` and :ref:`data-sources-wekeocds` sources
+    - wekeo: provides access to the :ref:`data-sources-wekeo` and :ref:`data-sources-wekeo-cds` sources
     - zarr: provides access to the :ref:`data-sources-zarr` source (new in version *0.15.0*). Please note that this is not included in the ``[all]`` option and has to be invoked separately.
 
 

--- a/docs/source/release-notes/version_0.13_updates.rst
+++ b/docs/source/release-notes/version_0.13_updates.rst
@@ -125,7 +125,7 @@ See the notebook examples:
 New features
 +++++++++++++++++
 
-- Refactored :ref:`data-sources-wekeo` and :ref:`data-sources-wekeocds` to use ``hda`` version 2 (:pr:`593`). The minimum ``hda`` version is now 2.22.
+- Refactored :ref:`data-sources-wekeo` and :ref:`data-sources-wekeo-cds` to use ``hda`` version 2 (:pr:`593`). The minimum ``hda`` version is now 2.22.
 - Added support for patterns with dates using timedelta as ``strftimedlta()`` for the :ref:`data-sources-file-pattern` source (:pr:`606`)
 - Enabled using string formatter for output file patterns in :ref:`new_grib_output <deprecated-new-grib-output>` and :ref:`GribOutput <deprecated-griboutput>` (:pr:`603`)
 - Enabled creating :ref:`data-sources-lod` fieldlists without latitudes/longitudes (:pr:`636`)

--- a/docs/source/release-notes/version_0.18_updates.rst
+++ b/docs/source/release-notes/version_0.18_updates.rst
@@ -81,7 +81,7 @@ with:
 
 The logic applied to build the requests is described :doc:`here </concepts/misc/request_args>`.
 
-This is implemented for the following sources: :ref:`data-sources-ads`, :ref:`data-sources-cds`, :ref:`data-sources-fdb`, :ref:`data-sources-mars`, :ref:`data-sources-eod`, :ref:`data-sources-polytope`, :ref:`data-sources-wekeo`, and :ref:`data-sources-wekeocds`.
+This is implemented for the following sources: :ref:`data-sources-ads`, :ref:`data-sources-cds`, :ref:`data-sources-fdb`, :ref:`data-sources-mars`, :ref:`data-sources-eod`, :ref:`data-sources-polytope`, :ref:`data-sources-wekeo`, and :ref:`data-sources-wekeo-cds`.
 
 The following exceptions apply:
 

--- a/docs/source/release-notes/version_0.4_updates.rst
+++ b/docs/source/release-notes/version_0.4_updates.rst
@@ -7,7 +7,7 @@ Version 0.4.0
 New features
 ++++++++++++++++
 
-- added new sources :ref:`data-sources-wekeo` and :ref:`data-sources-wekeocds` to retrieve data from `WEkEO <https://www.wekeo.eu/>`_. See the :ref:`/tutorials/source/wekeo.ipynb` notebook example.
+- added new sources :ref:`data-sources-wekeo` and :ref:`data-sources-wekeo-cds` to retrieve data from `WEkEO <https://www.wekeo.eu/>`_. See the :ref:`/tutorials/source/wekeo.ipynb` notebook example.
 - added new source :ref:`data-sources-polytope` to retrieve data from the `Polytope web services <https://polytope-client.readthedocs.io/en/latest/>`_. See the :ref:`/tutorials/source/polytope.ipynb` notebook example.
 - added the ``append`` option to :meth:`FieldList.save() <earthkit.data.core.fieldlist.FieldList.save>`.
 - added the ``dtype`` option to the ``to_data()``, ``to_latlon()`` and ``to_points()`` methods both on a :class:`~earthkit.data.core.field.Field` or :class:`~earthkit.data.core.fieldlist.FieldList`.

--- a/docs/source/release-notes/version_0.7_updates.rst
+++ b/docs/source/release-notes/version_0.7_updates.rst
@@ -21,7 +21,7 @@ New features
 - added support for Lambert Conformal projection when using :meth:`Field.projection() <earthkit.data.core.fieldlist.Field.projection>`
 - changed the default of the ``bits_per_value`` option to None in :meth:`NumpyFieldList.save() <data.sources.numpy_list.NumpyFieldList.save>`. None means the original ``bits_per_value`` in the GRIB header is kept when the data is written to disk.
 - added the ``model`` option to the :ref:`data-sources-eod` source
-- added the ``prompt`` optional argument to certain retrievals to control whether the prompt is to be used. When enabled (default), the prompt asks the user to provide credentials when none seems to be specified. See the :ref:`data-sources-cds`, :ref:`data-sources-mars`, :ref:`data-sources-wekeo`, :ref:`data-sources-wekeocds` sources for more information on how the prompt works.
+- added the ``prompt`` optional argument to certain retrievals to control whether the prompt is to be used. When enabled (default), the prompt asks the user to provide credentials when none seems to be specified. See the :ref:`data-sources-cds`, :ref:`data-sources-mars`, :ref:`data-sources-wekeo`, :ref:`data-sources-wekeo-cds` sources for more information on how the prompt works.
 - added the ``user_email`` and ``user_key`` options to the :ref:`data-sources-polytope` source. This source does not use the prompt any longer.
 - allowed using :func:`save` without specifying a file name. In this case an attempt is made to generate the filename automatically, when it fails an exception is thrown.
 - :func:`from_source` now fails when trying to load an empty file

--- a/docs/source/tutorials/source/wekeo.ipynb
+++ b/docs/source/tutorials/source/wekeo.ipynb
@@ -33,10 +33,13 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "raw"
+    }
    },
    "source": [
-    "The :ref:`wekeo <data-sources-wekeo>` and :ref:`wekeocds <data-sources-wekeocds>` sources provide access to `WEkEO <https://www.wekeo.eu/>`_."
+    "The :ref:`wekeo <data-sources-wekeo>` and :ref:`wekeo-cds <data-sources-wekeo-cds>` sources provide access to `WEkEO <https://www.wekeo.eu/>`_."
    ]
   },
   {
@@ -822,9 +825,9 @@
     }
    },
    "source": [
-    "We can use the :ref:`wekeocds <data-sources-wekeocds>` source to access datasets from the `Copernicus Climate Data Store (CDS) <https://cds.climate.copernicus.eu>`_ available through `WEkEO <https://www.wekeo.eu/>`_, using the standard `cdsapi <https://pypi.org/project/cdsapi>`_ request grammar.\n",
+    "We can use the :ref:`wekeo-cds <data-sources-wekeo-cds>` source to access datasets from the `Copernicus Climate Data Store (CDS) <https://cds.climate.copernicus.eu>`_ available through `WEkEO <https://www.wekeo.eu/>`_, using the standard `cdsapi <https://pypi.org/project/cdsapi>`_ request grammar.\n",
     "\n",
-    "Compared to the wekeo source, the wekeocds source accepts queries directly in cdsapi format, without requiring the dataset_id to be repeated in the request payload. This allows users to copy and paste requests directly from the dataset forms and examples provided in CDS-compatible interfaces.\n",
+    "Compared to the wekeo source, the wekeo-cds source accepts queries directly in cdsapi format, without requiring the dataset_id to be repeated in the request payload. This allows users to copy and paste requests directly from the dataset forms and examples provided in CDS-compatible interfaces.\n",
     "\n",
     "Dataset identifiers can be derived automatically by prepending ``\"EO:ECMWF:DAT:\"`` to the CDS dataset name and converting it to the WEkEO naming convention. For example, the CDS dataset name ``\"reanalysis-era5-single-levels\"`` becomes:\n",
     "\n",

--- a/docs/source/tutorials/source/wekeo.ipynb
+++ b/docs/source/tutorials/source/wekeo.ipynb
@@ -957,7 +957,7 @@
     "import earthkit.data as ekd\n",
     "\n",
     "d = ekd.from_source(\n",
-    "    \"wekeocds\",\n",
+    "    \"wekeo-cds\",\n",
     "    \"EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS\",\n",
     "    request=dict(\n",
     "        variable=[\"2m_temperature\", \"mean_sea_level_pressure\"],\n",

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -90,28 +90,71 @@ class SourceLoader:
 
 
 class SourceMaker:
+    """Create :class:`Source` objects by name.
+
+    A source is implemented either as a module in this package or as a plugin. Calling
+    the maker resolves the source class by name (:meth:`_lookup`) and instantiates it.
+    The lookup itself is performed by :func:`find_plugin` and its result is cached in
+    :attr:`SOURCES`, so each source is only looked up once per session.
+
+    The single instance created at module level is used by :func:`from_source`, which is
+    the public entry point. Direct use is not needed in user code.
+
+    Attributes
+    ----------
+    SOURCES : dict of str to class
+        Cache of the source classes already looked up, keyed by the resolved (i.e.
+        non-aliased) source name. Shared by all the instances of :class:`SourceMaker`
+        and populated on demand by :meth:`_lookup`.
+    ALIASES : dict of str to str
+        Maps alternative source names to the name the source is registered under. Used to
+        resolve the name before the lookup, so both the alias and the resolved name yield
+        the same source class.
+    DEPRECATED : set of str
+        The source names that are deprecated. Using one of them emits a ``FutureWarning``.
+        When the deprecated name is also a key in :attr:`ALIASES`, the warning names the
+        alias target as the preferred name to use instead.
+
+    """
+
     SOURCES = {}
 
     ALIASES = {
-        "wekeo-cds": "wekeocds",
+        "wekeocds": "wekeo-cds",
     }
 
+    DEPRECATED = {"wekeocds"}
+
     def __call__(self, name, *args, **kwargs):
-        loader = SourceLoader()
+        """Create the source called ``name``.
 
-        if name in self.ALIASES.values() and name not in self.ALIASES:
-            preferred = next(k for k, v in self.ALIASES.items() if v == name)
-            warnings.warn(
-                f"Source name '{name}' is deprecated, use '{preferred}' instead",
-                FutureWarning,
-            )
+        Parameters
+        ----------
+        name : str
+            The name of the source. Can be an alias, see :attr:`ALIASES`.
+        *args : tuple
+            Positional arguments passed to the source class.
+        **kwargs : dict, optional
+            Keyword arguments passed to the source class.
 
-        lookup_name = self.ALIASES.get(name, name)
-        if lookup_name in self.SOURCES:
-            klass = self.SOURCES[lookup_name]
-        else:
-            klass = find_plugin(os.path.dirname(__file__), lookup_name, loader)
-            self.SOURCES[lookup_name] = klass
+        Returns
+        -------
+        :class:`Source`
+            The new source. Its ``name`` is set to ``name`` (i.e. to the alias, when an
+            alias was used) unless the source class already defines one.
+
+        Raises
+        ------
+        NameError
+            If no source or plugin called ``name`` can be found.
+
+        Warns
+        -----
+        FutureWarning
+            If ``name`` is deprecated, see :attr:`DEPRECATED`.
+
+        """
+        klass = self._lookup(name)
 
         source = klass(*args, **kwargs)
 
@@ -120,7 +163,79 @@ class SourceMaker:
 
         return source
 
-    def __getattr__(self, name):
+    def _lookup(self, name):
+        """Resolve a source name to the source class implementing it.
+
+        The name is first mapped through :attr:`ALIASES`, then looked up in
+        :attr:`SOURCES`. On a cache miss the source is located by :func:`find_plugin`,
+        which searches the modules of this package as well as the registered plugins,
+        and the result is added to :attr:`SOURCES`.
+
+        Parameters
+        ----------
+        name : str
+            The name of the source. Can be an alias, see :attr:`ALIASES`.
+
+        Returns
+        -------
+        class
+            The source class registered under the resolved name. Not instantiated.
+
+        Raises
+        ------
+        NameError
+            If no source or plugin called ``name`` can be found.
+
+        Warns
+        -----
+        FutureWarning
+            If ``name`` is deprecated, see :attr:`DEPRECATED`.
+
+        """
+        loader = SourceLoader()
+
+        if name in self.DEPRECATED:
+            if name in self.ALIASES:
+                preferred = self.ALIASES.get(name)
+                warnings.warn(
+                    f"Source name '{name}' is deprecated, use '{preferred}' instead",
+                    FutureWarning,
+                )
+            else:
+                warnings.warn(f"Source name '{name}' is deprecated", FutureWarning)
+
+        lookup_name = self.ALIASES.get(name, name)
+        if lookup_name in self.SOURCES:
+            klass = self.SOURCES[lookup_name]
+        else:
+            klass = find_plugin(os.path.dirname(__file__), lookup_name, loader)
+            self.SOURCES[lookup_name] = klass
+
+        return klass
+
+    def __getattr__(self, name: str):
+        """Create a source using attribute access.
+
+        Allows ``get_source.file_pattern`` as a shorthand for ``get_source("file-pattern")``.
+        Underscores in ``name`` are replaced by dashes, since source names are dash-separated.
+        The source is created without any arguments.
+
+        Parameters
+        ----------
+        name : str
+            The name of the source, with dashes optionally written as underscores.
+
+        Returns
+        -------
+        :class:`Source`
+            The new source.
+
+        Raises
+        ------
+        NameError
+            If no source or plugin called ``name`` can be found.
+
+        """
         return self(name.replace("_", "-"))
 
 

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -95,35 +95,35 @@ class SourceMaker:
     A source is implemented either as a module in this package or as a plugin. Calling
     the maker resolves the source class by name (:meth:`_lookup`) and instantiates it.
     The lookup itself is performed by :func:`find_plugin` and its result is cached in
-    :attr:`SOURCES`, so each source is only looked up once per session.
+    :attr:`_SOURCES`, so each source is only looked up once per session.
 
     The single instance created at module level is used by :func:`from_source`, which is
     the public entry point. Direct use is not needed in user code.
 
     Attributes
     ----------
-    SOURCES : dict of str to class
+    _SOURCES : dict of str to class
         Cache of the source classes already looked up, keyed by the resolved (i.e.
         non-aliased) source name. Shared by all the instances of :class:`SourceMaker`
         and populated on demand by :meth:`_lookup`.
-    ALIASES : dict of str to str
+    _ALIASES : dict of str to str
         Maps alternative source names to the name the source is registered under. Used to
         resolve the name before the lookup, so both the alias and the resolved name yield
         the same source class.
-    DEPRECATED : set of str
+    _DEPRECATED : set of str
         The source names that are deprecated. Using one of them emits a ``FutureWarning``.
-        When the deprecated name is also a key in :attr:`ALIASES`, the warning names the
+        When the deprecated name is also a key in :attr:`_ALIASES`, the warning names the
         alias target as the preferred name to use instead.
 
     """
 
-    SOURCES = {}
+    _SOURCES = {}
 
-    ALIASES = {
+    _ALIASES = {
         "wekeocds": "wekeo-cds",
     }
 
-    DEPRECATED = {"wekeocds"}
+    _DEPRECATED = {"wekeocds"}
 
     def __call__(self, name, *args, **kwargs):
         """Create the source called ``name``.
@@ -131,7 +131,7 @@ class SourceMaker:
         Parameters
         ----------
         name : str
-            The name of the source. Can be an alias, see :attr:`ALIASES`.
+            The name of the source. Can be an alias, see :attr:`_ALIASES`.
         *args : tuple
             Positional arguments passed to the source class.
         **kwargs : dict, optional
@@ -151,7 +151,7 @@ class SourceMaker:
         Warns
         -----
         FutureWarning
-            If ``name`` is deprecated, see :attr:`DEPRECATED`.
+            If ``name`` is deprecated, see :attr:`_DEPRECATED`.
 
         """
         klass = self._lookup(name)
@@ -166,15 +166,15 @@ class SourceMaker:
     def _lookup(self, name):
         """Resolve a source name to the source class implementing it.
 
-        The name is first mapped through :attr:`ALIASES`, then looked up in
-        :attr:`SOURCES`. On a cache miss the source is located by :func:`find_plugin`,
+        The name is first mapped through :attr:`_ALIASES`, then looked up in
+        :attr:`_SOURCES`. On a cache miss the source is located by :func:`find_plugin`,
         which searches the modules of this package as well as the registered plugins,
-        and the result is added to :attr:`SOURCES`.
+        and the result is added to :attr:`_SOURCES`.
 
         Parameters
         ----------
         name : str
-            The name of the source. Can be an alias, see :attr:`ALIASES`.
+            The name of the source. Can be an alias, see :attr:`_ALIASES`.
 
         Returns
         -------
@@ -189,14 +189,14 @@ class SourceMaker:
         Warns
         -----
         FutureWarning
-            If ``name`` is deprecated, see :attr:`DEPRECATED`.
+            If ``name`` is deprecated, see :attr:`_DEPRECATED`.
 
         """
         loader = SourceLoader()
 
-        if name in self.DEPRECATED:
-            if name in self.ALIASES:
-                preferred = self.ALIASES.get(name)
+        if name in self._DEPRECATED:
+            if name in self._ALIASES:
+                preferred = self._ALIASES.get(name)
                 warnings.warn(
                     f"Source name '{name}' is deprecated, use '{preferred}' instead",
                     FutureWarning,
@@ -204,12 +204,12 @@ class SourceMaker:
             else:
                 warnings.warn(f"Source name '{name}' is deprecated", FutureWarning)
 
-        lookup_name = self.ALIASES.get(name, name)
-        if lookup_name in self.SOURCES:
-            klass = self.SOURCES[lookup_name]
+        lookup_name = self._ALIASES.get(name, name)
+        if lookup_name in self._SOURCES:
+            klass = self._SOURCES[lookup_name]
         else:
             klass = find_plugin(os.path.dirname(__file__), lookup_name, loader)
-            self.SOURCES[lookup_name] = klass
+            self._SOURCES[lookup_name] = klass
 
         return klass
 

--- a/src/earthkit/data/sources/wekeo_cds.py
+++ b/src/earthkit/data/sources/wekeo_cds.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 
 class APIClient(WekeoClient):
-    name = "wekeocds"
+    name = "wekeo-cds"
 
     def __int__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)

--- a/tests/sources/test_source_aliases.py
+++ b/tests/sources/test_source_aliases.py
@@ -25,16 +25,14 @@ class _DummySource:
 
 
 def test_wekeocds_alias_old_name_warns():
-    get_source.SOURCES["wekeocds"] = _DummySource
     with pytest.warns(FutureWarning, match="wekeocds"):
-        get_source("wekeocds")
+        get_source._lookup("wekeocds")
 
 
 def test_wekeocds_alias_new_name_no_warning():
-    get_source.SOURCES["wekeocds"] = _DummySource
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
-        get_source("wekeo-cds")
+        get_source._lookup("wekeo-cds")
 
 
 if __name__ == "__main__":

--- a/tests/sources/test_source_aliases.py
+++ b/tests/sources/test_source_aliases.py
@@ -16,14 +16,6 @@ import pytest
 from earthkit.data.sources import get_source
 
 
-class _DummySource:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def mutate(self):
-        return self
-
-
 def test_wekeocds_alias_old_name_warns():
     with pytest.warns(FutureWarning, match="wekeocds"):
         get_source._lookup("wekeocds")

--- a/tests/sources/test_wekeocds.py
+++ b/tests/sources/test_wekeocds.py
@@ -22,9 +22,9 @@ CDS_TIMEOUT = pytest.CDS_TIMEOUT
 @pytest.mark.skipif(NO_HDA, reason="No access to WEKEO")
 @pytest.mark.timeout(CDS_TIMEOUT)
 @pytest.mark.parametrize("prompt", [True, False])
-def test_wekeo_grib_1_prompt(prompt):
+def test_wekeo_cds_grib_1_prompt(prompt):
     s = from_source(
-        "wekeocds",
+        "wekeo-cds",
         "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
         variable=["2m_temperature", "mean_sea_level_pressure"],
         product_type=["monthly_averaged_reanalysis_by_hour_of_day"],
@@ -42,9 +42,9 @@ def test_wekeo_grib_1_prompt(prompt):
 @pytest.mark.download
 @pytest.mark.skipif(NO_HDA, reason="No access to CDS")
 @pytest.mark.timeout(CDS_TIMEOUT)
-def test_wekeo_grib_2():
+def test_wekeo_cds_grib_2():
     s = from_source(
-        "wekeocds",
+        "wekeo-cds",
         "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
         variable=["2m_temperature", "mean_sea_level_pressure"],
         product_type=["monthly_averaged_reanalysis_by_hour_of_day"],
@@ -62,9 +62,9 @@ def test_wekeo_grib_2():
 @pytest.mark.download
 @pytest.mark.skipif(NO_HDA, reason="No access to CDS")
 @pytest.mark.timeout(CDS_TIMEOUT)
-def test_wekeo_grib_3():
+def test_wekeo_cds_grib_3():
     s = from_source(
-        "wekeocds",
+        "wekeo-cds",
         "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
         variable=["2m_temperature", "mean_sea_level_pressure"],
         product_type=["monthly_averaged_reanalysis_by_hour_of_day"],
@@ -81,9 +81,9 @@ def test_wekeo_grib_3():
 @pytest.mark.download
 @pytest.mark.skipif(NO_HDA, reason="No access to CDS")
 @pytest.mark.timeout(CDS_TIMEOUT)
-def test_wekeo_netcdf():
+def test_wekeo_cds_netcdf():
     s = from_source(
-        "wekeocds",
+        "wekeo-cds",
         "EO:ECMWF:DAT:REANALYSIS_ERA5_SINGLE_LEVELS_MONTHLY_MEANS",
         variable=["2m_temperature", "mean_sea_level_pressure"],
         product_type=["monthly_averaged_reanalysis_by_hour_of_day"],


### PR DESCRIPTION
### Description

1. Made the `wekeocds` source deprecation explicit instead of inferred from the alias table.

    This involves the following changes in `ClassMaker`:
    
    - Made `SOURCES` and `ALIASES`  private class variables. E.g. `ClassMaker._SOURCES`
    - **Alias inverted**: `_ALIASES` was `{"wekeo-cds": "wekeocds"}`, now `{"wekeocds": "wekeo-cds"}` — the dashed name is canonical and `SOURCES` is keyed by it.
    - **New _DEPRECATED set**: deprecation. A source can now be deprecated without being an alias.

2. Improved source alias testing

-  These tests now rely the newly added `SourceMaker._lookup()` method to avoid using/modifying SourceMaker class variables (i.e. global resources) affecting other tests

3. Updated docs



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
