### PR TITLE
Feat/raise invalid kwarg from source

### DIFF
--- a/src/earthkit/data/readers/bufr/__init__.py
+++ b/src/earthkit/data/readers/bufr/__init__.py
@@ -21,12 +21,12 @@ def _match_magic(magic, deeper_check):
     return False
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if _match_magic(magic, deeper_check):
         from .file import BUFRReader
 
         parts = source.parts if hasattr(source, "parts") else None
-        return BUFRReader(source, path, parts=parts)
+        return BUFRReader(source, path, parts=parts, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/bufr/file.py
+++ b/src/earthkit/data/readers/bufr/file.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
 from collections import defaultdict
 
 from earthkit.data.core.index import MaskIndex, MultiIndex
@@ -521,7 +522,14 @@ class BUFRListInFile(BUFRList, BUFRReaderBase):
 
 
 class BUFRReader(Source, BUFRReaderBase):
-    def __init__(self, source, path, parts=None, positions=None):
+    def __init__(self, source, path, parts=None, positions=None, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the BUFR reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ori_source = source
         self._kwargs = {"parts": parts, "positions": positions}
 

--- a/src/earthkit/data/readers/covjson/__init__.py
+++ b/src/earthkit/data/readers/covjson/__init__.py
@@ -29,7 +29,7 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     def _reader():
         from .reader import CovJSONReader
 
-        return CovJSONReader(source, path)
+        return CovJSONReader(source, path, **kwargs)
 
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
         return _reader()

--- a/src/earthkit/data/readers/covjson/__init__.py
+++ b/src/earthkit/data/readers/covjson/__init__.py
@@ -35,7 +35,7 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
         return _reader()
 
     extension = pathlib.Path(path).suffix
-    if extension in [".covjson"]:
+    if extension == ".covjson":
         return _reader()
 
     kind, _ = mimetypes.guess_type(path)

--- a/src/earthkit/data/readers/covjson/__init__.py
+++ b/src/earthkit/data/readers/covjson/__init__.py
@@ -61,10 +61,6 @@ def stream_reader(
     **kwargs,
 ):
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
-        # if memory:
-        #     from .reader import CovjsonMemoryReader
-
-        #     return CovjsonMemoryReader._from_stream(stream)
         from .reader import CovJSONStreamReader
 
         return CovJSONStreamReader(stream)

--- a/src/earthkit/data/readers/covjson/__init__.py
+++ b/src/earthkit/data/readers/covjson/__init__.py
@@ -29,11 +29,7 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     def _reader():
         from .reader import CovJSONReader
 
-<<<<<<< HEAD
         return CovJSONReader(source, path, **kwargs)
-=======
-        return CovJSONReader(source, path)
->>>>>>> e9d871db (chore: renaming)
 
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
         return _reader()
@@ -67,12 +63,6 @@ def stream_reader(
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
         from .reader import CovJSONStreamReader
 
-<<<<<<< HEAD
-=======
-        #     return CovjsonMemoryReader._from_stream(stream)
-        from .reader import CovJSONStreamReader
-
->>>>>>> e9d871db (chore: renaming)
         return CovJSONStreamReader(stream)
 
 

--- a/src/earthkit/data/readers/covjson/__init__.py
+++ b/src/earthkit/data/readers/covjson/__init__.py
@@ -29,7 +29,11 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     def _reader():
         from .reader import CovJSONReader
 
+<<<<<<< HEAD
         return CovJSONReader(source, path, **kwargs)
+=======
+        return CovJSONReader(source, path)
+>>>>>>> e9d871db (chore: renaming)
 
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
         return _reader()
@@ -63,6 +67,12 @@ def stream_reader(
     if _match_content_type(content_type) or _match_magic(magic, deeper_check):
         from .reader import CovJSONStreamReader
 
+<<<<<<< HEAD
+=======
+        #     return CovjsonMemoryReader._from_stream(stream)
+        from .reader import CovJSONStreamReader
+
+>>>>>>> e9d871db (chore: renaming)
         return CovJSONStreamReader(stream)
 
 

--- a/src/earthkit/data/readers/covjson/file.py
+++ b/src/earthkit/data/readers/covjson/file.py
@@ -75,6 +75,12 @@ class CovJSONList(IndexFeatureListBase):
         pass
 
     def to_data_object(self):
+<<<<<<< HEAD
         from earthkit.data.data.covjson import CovJSONData
 
         return CovJSONData(self)
+=======
+        from earthkit.data.data.geojson import GeoJSONData
+
+        return CovJSONList(self)
+>>>>>>> 1b673843 (chore: standardise naming)

--- a/src/earthkit/data/readers/covjson/file.py
+++ b/src/earthkit/data/readers/covjson/file.py
@@ -75,12 +75,6 @@ class CovJSONList(IndexFeatureListBase):
         pass
 
     def to_data_object(self):
-<<<<<<< HEAD
         from earthkit.data.data.covjson import CovJSONData
 
         return CovJSONData(self)
-=======
-        from earthkit.data.data.geojson import GeoJSONData
-
-        return CovJSONList(self)
->>>>>>> 1b673843 (chore: standardise naming)

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -7,6 +7,8 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
+
 from earthkit.data.core import Encodable
 from earthkit.data.sources import Source
 
@@ -44,7 +46,14 @@ class FieldlistMixIn:
 
 
 class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the CovJSON reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         CovJSONReaderBase.__init__(self, source, path)
 
     def __repr__(self):

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -44,10 +44,14 @@ class FieldlistMixIn:
         return ds.to_fieldlist(**kwargs)
 
 
+<<<<<<< HEAD
 class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
 =======
 class CovJSONReader(XarrayMixIn, GeojsonMixIn, CovJSONReaderBase):
 >>>>>>> 1b673843 (chore: standardise naming)
+=======
+class CovJSONReader(XarrayMixIn, GeojsonMixIn, FieldlistMixIn, CovJSONReaderBase):
+>>>>>>> e9d871db (chore: renaming)
     def __init__(self, source, path):
         CovJSONReaderBase.__init__(self, source, path)
 
@@ -140,10 +144,14 @@ class CovJSONMemoryReader(Source):
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
 =======
 class CovJSONInMemory(Source, XarrayMixIn, Encodable):
 >>>>>>> 1b673843 (chore: standardise naming)
+=======
+class CovJSONInMemory(Source, XarrayMixIn, GeojsonMixIn, FieldlistMixIn, Encodable):
+>>>>>>> e9d871db (chore: renaming)
     def __init__(self, data):
         self.data = data
 

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -35,7 +35,6 @@ class GeoJSONMixIn:
         return decoder.to_geojson()
 
 
-<<<<<<< HEAD
 class FieldlistMixIn:
     def to_fieldlist(self, **kwargs):
         from earthkit.data.data.wrappers import from_object
@@ -44,27 +43,12 @@ class FieldlistMixIn:
         return ds.to_fieldlist(**kwargs)
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
-=======
-class CovJSONReader(XarrayMixIn, GeojsonMixIn, CovJSONReaderBase):
->>>>>>> 1b673843 (chore: standardise naming)
-=======
-class CovJSONReader(XarrayMixIn, GeojsonMixIn, FieldlistMixIn, CovJSONReaderBase):
->>>>>>> e9d871db (chore: renaming)
-=======
-class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
->>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, source, path):
         CovJSONReaderBase.__init__(self, source, path)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.path})"
-
-    # def mutate_source(self):
-    #     # A Covjson is a source itself
-    #     return self
 
     def _json(self):
         import json
@@ -143,23 +127,8 @@ class CovJSONMemoryReader(Source):
 
         return CovJSONData(self)
 
-    # def _encode_default(self, encoder, **kwargs):
-    #     return encoder._encode_xarray(self.to_xarray(), **kwargs)
 
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
-=======
-class CovJSONInMemory(Source, XarrayMixIn, Encodable):
->>>>>>> 1b673843 (chore: standardise naming)
-=======
-class CovJSONInMemory(Source, XarrayMixIn, GeojsonMixIn, FieldlistMixIn, Encodable):
->>>>>>> e9d871db (chore: renaming)
-=======
-class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
->>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, data):
         self.data = data
 

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -45,6 +45,7 @@ class FieldlistMixIn:
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
 =======
 class CovJSONReader(XarrayMixIn, GeojsonMixIn, CovJSONReaderBase):
@@ -52,6 +53,9 @@ class CovJSONReader(XarrayMixIn, GeojsonMixIn, CovJSONReaderBase):
 =======
 class CovJSONReader(XarrayMixIn, GeojsonMixIn, FieldlistMixIn, CovJSONReaderBase):
 >>>>>>> e9d871db (chore: renaming)
+=======
+class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
+>>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, source, path):
         CovJSONReaderBase.__init__(self, source, path)
 
@@ -145,6 +149,7 @@ class CovJSONMemoryReader(Source):
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
 =======
 class CovJSONInMemory(Source, XarrayMixIn, Encodable):
@@ -152,6 +157,9 @@ class CovJSONInMemory(Source, XarrayMixIn, Encodable):
 =======
 class CovJSONInMemory(Source, XarrayMixIn, GeojsonMixIn, FieldlistMixIn, Encodable):
 >>>>>>> e9d871db (chore: renaming)
+=======
+class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
+>>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, data):
         self.data = data
 

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -35,6 +35,7 @@ class GeoJSONMixIn:
         return decoder.to_geojson()
 
 
+<<<<<<< HEAD
 class FieldlistMixIn:
     def to_fieldlist(self, **kwargs):
         from earthkit.data.data.wrappers import from_object
@@ -44,6 +45,9 @@ class FieldlistMixIn:
 
 
 class CovJSONReader(XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, CovJSONReaderBase):
+=======
+class CovJSONReader(XarrayMixIn, GeojsonMixIn, CovJSONReaderBase):
+>>>>>>> 1b673843 (chore: standardise naming)
     def __init__(self, source, path):
         CovJSONReaderBase.__init__(self, source, path)
 
@@ -135,7 +139,11 @@ class CovJSONMemoryReader(Source):
     #     return encoder._encode_xarray(self.to_xarray(), **kwargs)
 
 
+<<<<<<< HEAD
 class CovJSONInMemory(Source, XarrayMixIn, GeoJSONMixIn, FieldlistMixIn, Encodable):
+=======
+class CovJSONInMemory(Source, XarrayMixIn, Encodable):
+>>>>>>> 1b673843 (chore: standardise naming)
     def __init__(self, data):
         self.data = data
 

--- a/src/earthkit/data/readers/csv/__init__.py
+++ b/src/earthkit/data/readers/csv/__init__.py
@@ -124,12 +124,12 @@ def is_csv(path, probe_size=4096, compression=None):
     return dialect is not None
 
 
-def reader(source, path, *, magic=None, deeper_check=False, fwf=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     kind, compression = mimetypes.guess_type(path)
 
     if kind == "text/csv":
         from .reader import CSVReader
 
-        return CSVReader(source, path, compression=compression)
+        return CSVReader(source, path, compression=compression, **kwargs)
 
 READER = reader

--- a/src/earthkit/data/readers/csv/__init__.py
+++ b/src/earthkit/data/readers/csv/__init__.py
@@ -132,4 +132,5 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
 
         return CSVReader(source, path, compression=compression, **kwargs)
 
+
 READER = reader

--- a/src/earthkit/data/readers/csv/__init__.py
+++ b/src/earthkit/data/readers/csv/__init__.py
@@ -130,11 +130,7 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     if kind == "text/csv":
         from .reader import CSVReader
 
-<<<<<<< HEAD
         return CSVReader(source, path, compression=compression, **kwargs)
-=======
-        return CSVReader(source, path, compression=compression)
->>>>>>> 4a255edd (chore: kill dead code)
 
 
 READER = reader

--- a/src/earthkit/data/readers/csv/__init__.py
+++ b/src/earthkit/data/readers/csv/__init__.py
@@ -130,7 +130,11 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     if kind == "text/csv":
         from .reader import CSVReader
 
+<<<<<<< HEAD
         return CSVReader(source, path, compression=compression, **kwargs)
+=======
+        return CSVReader(source, path, compression=compression)
+>>>>>>> 4a255edd (chore: kill dead code)
 
 
 READER = reader

--- a/src/earthkit/data/readers/csv/__init__.py
+++ b/src/earthkit/data/readers/csv/__init__.py
@@ -132,5 +132,4 @@ def reader(source, path, *, magic=None, deeper_check=False, fwf=False, **kwargs)
 
         return CSVReader(source, path, compression=compression)
 
-
 READER = reader

--- a/src/earthkit/data/readers/csv/reader.py
+++ b/src/earthkit/data/readers/csv/reader.py
@@ -8,6 +8,7 @@
 #
 
 import logging
+import warnings
 
 from .. import Reader
 
@@ -21,7 +22,14 @@ class CSVReader(Reader):
 
     r"""Class representing CSV data"""
 
-    def __init__(self, source, path, compression=None):
+    def __init__(self, source, path, compression=None, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the CSV reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         from . import probe_csv
 
         super().__init__(source, path)

--- a/src/earthkit/data/readers/directory.py
+++ b/src/earthkit/data/readers/directory.py
@@ -44,10 +44,10 @@ def make_file_filter(filter, top):
 
 
 class DirectoryReader(Reader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
         super().__init__(source, path)
         self._content = []
-        self._source_kwargs = source._kwargs
+        self._source_kwargs = kwargs
 
         filter = make_file_filter(self.filter, self.path)
 
@@ -111,7 +111,7 @@ class DirectoryReader(Reader):
         return None
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs): 
     if (
         magic is None
         and os.path.isdir(path)
@@ -122,7 +122,7 @@ def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
             or os.path.exists(os.path.join(path, ".zattrs"))
         )
     ):
-        return DirectoryReader(source, path)
+        return DirectoryReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/directory.py
+++ b/src/earthkit/data/readers/directory.py
@@ -111,7 +111,7 @@ class DirectoryReader(Reader):
         return None
 
 
-def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs): 
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if (
         magic is None
         and os.path.isdir(path)

--- a/src/earthkit/data/readers/geojson/__init__.py
+++ b/src/earthkit/data/readers/geojson/__init__.py
@@ -10,7 +10,7 @@
 import mimetypes
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     kind, _ = mimetypes.guess_type(path)
     ext = path.split(".")[-1]
 
@@ -19,7 +19,7 @@ def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
     if ext in geojson_extensions or kind in geojson_mimetypes:
         from .reader import GeoJSONReader
 
-        return GeoJSONReader(source, path)
+        return GeoJSONReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/geojson/reader.py
+++ b/src/earthkit/data/readers/geojson/reader.py
@@ -15,7 +15,11 @@ from earthkit.data.sources import Source
 from .core import GeoJSONReaderBase
 
 
+<<<<<<< HEAD
 class GeoJSONReader(Source, GeoJSONReaderBase):
+=======
+class GeojsonReader(Source, GeoJSONReaderBase):
+>>>>>>> e9d871db (chore: renaming)
     def __init__(self, source, path):
         self._ori_source = source
         GeoJSONReaderBase.__init__(self, source, path)

--- a/src/earthkit/data/readers/geojson/reader.py
+++ b/src/earthkit/data/readers/geojson/reader.py
@@ -16,10 +16,14 @@ from .core import GeoJSONReaderBase
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 class GeoJSONReader(Source, GeoJSONReaderBase):
 =======
 class GeojsonReader(Source, GeoJSONReaderBase):
 >>>>>>> e9d871db (chore: renaming)
+=======
+class GeoJSONReader(Source, GeoJSONReaderBase):
+>>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, source, path):
         self._ori_source = source
         GeoJSONReaderBase.__init__(self, source, path)

--- a/src/earthkit/data/readers/geojson/reader.py
+++ b/src/earthkit/data/readers/geojson/reader.py
@@ -10,13 +10,22 @@
 # The code is copied from skinnywms, and we should combile later
 
 
+import warnings
+
 from earthkit.data.sources import Source
 
 from .core import GeoJSONReaderBase
 
 
 class GeoJSONReader(Source, GeoJSONReaderBase):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the GeoJSON reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ori_source = source
         GeoJSONReaderBase.__init__(self, source, path)
 

--- a/src/earthkit/data/readers/geojson/reader.py
+++ b/src/earthkit/data/readers/geojson/reader.py
@@ -15,15 +15,7 @@ from earthkit.data.sources import Source
 from .core import GeoJSONReaderBase
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 class GeoJSONReader(Source, GeoJSONReaderBase):
-=======
-class GeojsonReader(Source, GeoJSONReaderBase):
->>>>>>> e9d871db (chore: renaming)
-=======
-class GeoJSONReader(Source, GeoJSONReaderBase):
->>>>>>> 0d62d9a5 (fix: rename)
     def __init__(self, source, path):
         self._ori_source = source
         GeoJSONReaderBase.__init__(self, source, path)

--- a/src/earthkit/data/readers/geotiff/__init__.py
+++ b/src/earthkit/data/readers/geotiff/__init__.py
@@ -17,11 +17,11 @@ def _match_magic(magic):
     return magic is not None and len(magic) >= 8 and magic[:4] in {b"II*\x00", b"II+\x00", b"MM\x00*"}
 
 
-def reader(source, path, *, magic=None, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if _match_magic(magic):
         from .reader import GeoTIFFReader
 
-        return GeoTIFFReader(source, path)
+        return GeoTIFFReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/geotiff/reader.py
+++ b/src/earthkit/data/readers/geotiff/reader.py
@@ -8,13 +8,22 @@
 #
 
 
+import warnings
+
 from earthkit.data.sources import Source
 
 from .core import DEFAULT_XARRAY_KWARGS, GeoTIFFReaderBase
 
 
 class GeoTIFFReader(Source, GeoTIFFReaderBase):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the GeoTIFF reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         GeoTIFFReaderBase.__init__(self, source, path)
 
     def __repr__(self):

--- a/src/earthkit/data/readers/grib/__init__.py
+++ b/src/earthkit/data/readers/grib/__init__.py
@@ -38,12 +38,12 @@ def is_grib_file(path):
     return _match_magic(magic, True)
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if _match_magic(magic, deeper_check):
         from .file import GRIBReader
 
         parts = source.parts if hasattr(source, "parts") else None
-        return GRIBReader(source, path, parts=parts)
+        return GRIBReader(source, path, parts=parts, **kwargs)
 
 
 def memory_reader(source, buffer, *, magic=None, deeper_check=False, **kwargs):

--- a/src/earthkit/data/readers/grib/file.py
+++ b/src/earthkit/data/readers/grib/file.py
@@ -180,16 +180,11 @@ class GribFieldListInFile(SimpleFieldListBase, GRIBReaderBase):
 
 
 class GRIBReader(Source, GRIBReaderBase):
-    def __init__(self, source, path, parts=None, positions=None):
+    def __init__(self, source, path, parts=None, positions=None, grib_handle_policy=None, grib_handle_cache_size=None, use_grib_metadata_cache=None):
         self._ori_source = source
-        self._kwargs = {"parts": parts, "positions": positions}
-
-        for k in [
-            "grib_handle_policy",
-            "grib_handle_cache_size",
-            "use_grib_metadata_cache",
-        ]:
-            self._kwargs[k] = source._kwargs.get(k, None)
+        self._kwargs = {"parts": parts, "positions": positions,
+                        "grib_handle_policy": grib_handle_policy, "grib_handle_cache_size": grib_handle_cache_size,
+                        "use_grib_metadata_cache": use_grib_metadata_cache}
 
         GRIBReaderBase.__init__(self, source, path)
 
@@ -209,7 +204,7 @@ class GRIBReader(Source, GRIBReaderBase):
         return self.to_fieldlist().to_pandas(*args, **kwargs)
 
     def peek(self):
-        return first_field_from_grib_file(self.path, parts=self._kwargs.get("parts", None))
+        return first_field_from_grib_file(self.path, parts=self._kwargs["parts"])
 
     def mutate_source(self):
         # A GRIBReader is a source itself

--- a/src/earthkit/data/readers/grib/file.py
+++ b/src/earthkit/data/readers/grib/file.py
@@ -180,11 +180,24 @@ class GribFieldListInFile(SimpleFieldListBase, GRIBReaderBase):
 
 
 class GRIBReader(Source, GRIBReaderBase):
-    def __init__(self, source, path, parts=None, positions=None, grib_handle_policy=None, grib_handle_cache_size=None, use_grib_metadata_cache=None):
+    def __init__(
+        self,
+        source,
+        path,
+        parts=None,
+        positions=None,
+        grib_handle_policy=None,
+        grib_handle_cache_size=None,
+        use_grib_metadata_cache=None,
+    ):
         self._ori_source = source
-        self._kwargs = {"parts": parts, "positions": positions,
-                        "grib_handle_policy": grib_handle_policy, "grib_handle_cache_size": grib_handle_cache_size,
-                        "use_grib_metadata_cache": use_grib_metadata_cache}
+        self._kwargs = {
+            "parts": parts,
+            "positions": positions,
+            "grib_handle_policy": grib_handle_policy,
+            "grib_handle_cache_size": grib_handle_cache_size,
+            "use_grib_metadata_cache": use_grib_metadata_cache,
+        }
 
         GRIBReaderBase.__init__(self, source, path)
 

--- a/src/earthkit/data/readers/grib/file.py
+++ b/src/earthkit/data/readers/grib/file.py
@@ -7,6 +7,8 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
+
 from earthkit.utils.decorators import thread_safe_cached_property
 
 from earthkit.data.indexing.simple import SimpleFieldListBase
@@ -189,7 +191,15 @@ class GRIBReader(Source, GRIBReaderBase):
         grib_handle_policy=None,
         grib_handle_cache_size=None,
         use_grib_metadata_cache=None,
+        **kwargs,
     ):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the GRIB reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ori_source = source
         self._kwargs = {
             "parts": parts,

--- a/src/earthkit/data/readers/netcdf/__init__.py
+++ b/src/earthkit/data/readers/netcdf/__init__.py
@@ -15,11 +15,11 @@ def _match_magic(magic, deeper_check):
     return False
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if _match_magic(magic, deeper_check):
         from .reader import NetCDFFileReader
 
-        return NetCDFFileReader(source, path)
+        return NetCDFFileReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/netcdf/reader.py
+++ b/src/earthkit/data/readers/netcdf/reader.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
 from abc import abstractmethod
 
 from earthkit.data.sources import Source
@@ -109,7 +110,14 @@ class NetCDFReader(Source, NetCDFReaderBase):
 
 
 class NetCDFFileReader(NetCDFReader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the netCDF reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ori_source = source
         # self.path = path
         super().__init__(source, path)

--- a/src/earthkit/data/readers/numpy.py
+++ b/src/earthkit/data/readers/numpy.py
@@ -33,14 +33,14 @@ class NumpyZipReader(Reader):
         return np.load(self.path, **numpy_load_kwargs)
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if magic is not None:
         if magic[:6] == b"\x93NUMPY":
-            return NumpyReader(source, path)
+            return NumpyReader(source, path, **kwargs)
 
         _, extension = os.path.splitext(path)
         if magic[:4] == b"PK\x03\x04" and extension == ".npz":
-            return NumpyZipReader(source, path)
+            return NumpyZipReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/numpy.py
+++ b/src/earthkit/data/readers/numpy.py
@@ -8,6 +8,7 @@
 #
 
 import os
+import warnings
 
 import numpy as np
 
@@ -15,7 +16,14 @@ from . import Reader
 
 
 class NumpyReader(Reader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the NumPy reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         super().__init__(source, path)
 
     def to_numpy(self, numpy_load_kwargs={}):
@@ -26,7 +34,14 @@ class NumpyReader(Reader):
 
 
 class NumpyZipReader(Reader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the NumPy ZIP reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         super().__init__(source, path)
 
     def to_numpy(self, numpy_load_kwargs={}):

--- a/src/earthkit/data/readers/odb/__init__.py
+++ b/src/earthkit/data/readers/odb/__init__.py
@@ -18,11 +18,11 @@ def _match_magic(magic, deeper_check):
     return False
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if _match_magic(magic, deeper_check):
         from .reader import ODBReader
 
-        return ODBReader(source, path)
+        return ODBReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/odb/reader.py
+++ b/src/earthkit/data/readers/odb/reader.py
@@ -8,6 +8,7 @@
 #
 
 import logging
+import warnings
 
 from .. import Reader
 
@@ -16,6 +17,16 @@ LOG = logging.getLogger(__name__)
 
 class ODBReader(Reader):
     _format = "odb"
+
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the ODB reader.",
+                UserWarning,
+                stacklevel=2,
+            )
+        super().__init__(source, path)
 
     def to_pandas(self, odc_read_odb_kwargs=None):
         try:

--- a/src/earthkit/data/readers/pp/__init__.py
+++ b/src/earthkit/data/readers/pp/__init__.py
@@ -8,11 +8,11 @@
 #
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if path.endswith(".pp"):
         from .reader import PPReader
 
-        return PPReader(source, path)
+        return PPReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/pp/reader.py
+++ b/src/earthkit/data/readers/pp/reader.py
@@ -13,7 +13,7 @@ from .core import PPReaderBase
 
 
 class PPReader(Source, PPReaderBase):
-    def __init__(self, source, path, **kwargs):
+    def __init__(self, source, path):
         PPReaderBase.__init__(self, source, path)
 
     def mutate_source(self):

--- a/src/earthkit/data/readers/pp/reader.py
+++ b/src/earthkit/data/readers/pp/reader.py
@@ -7,13 +7,22 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
+
 from earthkit.data.sources import Source
 
 from .core import PPReaderBase
 
 
 class PPReader(Source, PPReaderBase):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the PP reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         PPReaderBase.__init__(self, source, path)
 
     def mutate_source(self):

--- a/src/earthkit/data/readers/shapefile/__init__.py
+++ b/src/earthkit/data/readers/shapefile/__init__.py
@@ -15,7 +15,7 @@ NON_MANDATORY = (".sbn", ".sbx", ".shp.xml", ".prj", ".CPG")
 DOUBLE_DOT_EXT = tuple([e for e in NON_MANDATORY if e.count(".") == 2])
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     root, extension = os.path.splitext(path)
     for e in DOUBLE_DOT_EXT:
         if path.endswith(e):
@@ -30,7 +30,7 @@ def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
         if all(os.path.exists(root + e) for e in MANDATORY):
             from .reader import ShapeFileReader
 
-            return ShapeFileReader(source, path)
+            return ShapeFileReader(source, path, **kwargs)
     else:
         if extension in MANDATORY or extension in NON_MANDATORY:
             from ..unknown import UnknownReader

--- a/src/earthkit/data/readers/shapefile/reader.py
+++ b/src/earthkit/data/readers/shapefile/reader.py
@@ -7,14 +7,23 @@
 # nor does it submit to any jurisdiction.
 #
 
+import warnings
+
 from earthkit.data.sources import Source
 
 from .core import ShapefileReaderBase
 
 
 class ShapeFileReader(Source, ShapefileReaderBase):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
         assert path.endswith(".shp")
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the ShapeFile reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ori_source = source
         ShapefileReaderBase.__init__(self, source, path)
 

--- a/src/earthkit/data/readers/tar.py
+++ b/src/earthkit/data/readers/tar.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 
 class TarReader(ArchiveReader):
-    def __init__(self, source, path, compression=None):
+    def __init__(self, source, path):
         super().__init__(source, path)
 
         with tarfile.open(path) as tar:
@@ -32,9 +32,9 @@ def reader(source, path, *, magic=None, deeper_check=False, content_type=None, *
     # We don't use tarfile.is_tarfile() because is
     # returns true given a file of zeros
 
-    kind, compression = mimetypes.guess_type(path)
+    kind, _ = mimetypes.guess_type(path)
     if kind == "application/x-tar":
-        return TarReader(source, path, compression, **kwargs)
+        return TarReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/tar.py
+++ b/src/earthkit/data/readers/tar.py
@@ -28,13 +28,13 @@ class TarReader(ArchiveReader):
             )
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     # We don't use tarfile.is_tarfile() because is
     # returns true given a file of zeros
 
     kind, compression = mimetypes.guess_type(path)
     if kind == "application/x-tar":
-        return TarReader(source, path, compression)
+        return TarReader(source, path, compression, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/tar.py
+++ b/src/earthkit/data/readers/tar.py
@@ -10,6 +10,7 @@
 import logging
 import mimetypes
 import tarfile
+import warnings
 
 from .archive import ArchiveReader
 
@@ -17,7 +18,14 @@ LOG = logging.getLogger(__name__)
 
 
 class TarReader(ArchiveReader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the TAR reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         super().__init__(source, path)
 
         with tarfile.open(path) as tar:

--- a/src/earthkit/data/readers/text.py
+++ b/src/earthkit/data/readers/text.py
@@ -56,10 +56,10 @@ class TextReader(Reader):
         return None
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if deeper_check:
         if is_text(path):
-            return TextReader(source, path)
+            return TextReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/text.py
+++ b/src/earthkit/data/readers/text.py
@@ -8,6 +8,8 @@
 #
 
 
+import warnings
+
 from . import Reader
 
 
@@ -31,7 +33,14 @@ class TextReader(Reader):
     _binary = False
     _appendable = True
 
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the Text reader.",
+                UserWarning,
+                stacklevel=2,
+            )
         super().__init__(source, path)
 
     def ignore(self):

--- a/src/earthkit/data/readers/zarr/__init__.py
+++ b/src/earthkit/data/readers/zarr/__init__.py
@@ -10,7 +10,7 @@
 import os
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if (
         os.path.exists(os.path.join(path, ".zarray"))
         or os.path.exists(os.path.join(path, ".zgroup"))
@@ -19,7 +19,7 @@ def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
     ):
         from .reader import ZarrReader
 
-        return ZarrReader(source, path)
+        return ZarrReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/zarr/reader.py
+++ b/src/earthkit/data/readers/zarr/reader.py
@@ -8,6 +8,8 @@
 #
 
 
+import warnings
+
 from earthkit.data.readers.xarray.fieldlist import XArrayFieldList
 
 from .core import ZarrReaderBase
@@ -15,6 +17,14 @@ from .core import ZarrReaderBase
 
 class ZarrReader(XArrayFieldList, ZarrReaderBase):
     def __init__(self, source, path, **kwargs):
+        if kwargs:
+            names = ", ".join(repr(name) for name in kwargs)
+            warnings.warn(
+                f"Arguments {names} have no effect for the Zarr reader.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         ZarrReaderBase.__init__(self, source, path)
 
     def mutate_source(self):

--- a/src/earthkit/data/readers/zip.py
+++ b/src/earthkit/data/readers/zip.py
@@ -82,7 +82,7 @@ class ZIPReader(ArchiveReader):
 EXTENSIONS_TO_SKIP = (".npz",)  # Numpy arrays
 
 
-def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs): 
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
     if magic is None:  # Bypass check and force
         return ZIPReader(source, path, **kwargs)
 

--- a/src/earthkit/data/readers/zip.py
+++ b/src/earthkit/data/readers/zip.py
@@ -82,14 +82,14 @@ class ZIPReader(ArchiveReader):
 EXTENSIONS_TO_SKIP = (".npz",)  # Numpy arrays
 
 
-def reader(source, path, *, magic=None, deeper_check=False, **kwargs):
+def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs): 
     if magic is None:  # Bypass check and force
-        return ZIPReader(source, path)
+        return ZIPReader(source, path, **kwargs)
 
     _, extension = os.path.splitext(path)
 
     if magic[:4] == b"PK\x03\x04" and extension not in EXTENSIONS_TO_SKIP:
-        return ZIPReader(source, path)
+        return ZIPReader(source, path, **kwargs)
 
 
 READER = reader

--- a/src/earthkit/data/readers/zip.py
+++ b/src/earthkit/data/readers/zip.py
@@ -43,7 +43,7 @@ class InfoWrapper:
 
 
 class ZIPReader(ArchiveReader):
-    def __init__(self, source, path):
+    def __init__(self, source, path, **kwargs):
         super().__init__(source, path)
 
         self._mutate = None

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -482,20 +482,33 @@ def register(name, proc):
     register_plugin("source", name, proc)
 
 
-from .file import FileSource
-
-def from_file(path: str,
+def from_file(
+    path: str,
     expand_user: Union[bool, list, tuple] = True,
     expand_vars: bool = False,
     unix_glob: bool = True,
     recursive_glob: bool = True,
     filter: Union[str, Callable] = None,
     parts: list = None,
-    stream: bool = False, 
-    merger: Any = None, **kwargs):
+    stream: bool = False,
+    merger: Any = None,
+    **kwargs,
+):
+    from .file import FileSource
 
     prev = None
-    src = FileSource(path=path, expand_user=expand_user, expand_vars=expand_vars, unix_glob=unix_glob, recursive_glob=recursive_glob, filter=filter, parts=parts, stream=stream, merger=merger, **kwargs)
+    src = FileSource(
+        path=path,
+        expand_user=expand_user,
+        expand_vars=expand_vars,
+        unix_glob=unix_glob,
+        recursive_glob=recursive_glob,
+        filter=filter,
+        parts=parts,
+        stream=stream,
+        merger=merger,
+        **kwargs,
+    )
     while src is not prev:
         prev = src
         src = src.mutate()

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -480,37 +480,3 @@ def from_source_lazily(name, *args, **kwargs):
 
 def register(name, proc):
     register_plugin("source", name, proc)
-
-
-def from_file(
-    path: str,
-    expand_user: Union[bool, list, tuple] = True,
-    expand_vars: bool = False,
-    unix_glob: bool = True,
-    recursive_glob: bool = True,
-    filter: Union[str, Callable] = None,
-    parts: list = None,
-    stream: bool = False,
-    merger: Any = None,
-    **kwargs,
-):
-    from .file import FileSource
-
-    prev = None
-    src = FileSource(
-        path=path,
-        expand_user=expand_user,
-        expand_vars=expand_vars,
-        unix_glob=unix_glob,
-        recursive_glob=recursive_glob,
-        filter=filter,
-        parts=parts,
-        stream=stream,
-        merger=merger,
-        **kwargs,
-    )
-    while src is not prev:
-        prev = src
-        src = src.mutate()
-
-    return src

--- a/src/earthkit/data/sources/__init__.py
+++ b/src/earthkit/data/sources/__init__.py
@@ -480,3 +480,24 @@ def from_source_lazily(name, *args, **kwargs):
 
 def register(name, proc):
     register_plugin("source", name, proc)
+
+
+from .file import FileSource
+
+def from_file(path: str,
+    expand_user: Union[bool, list, tuple] = True,
+    expand_vars: bool = False,
+    unix_glob: bool = True,
+    recursive_glob: bool = True,
+    filter: Union[str, Callable] = None,
+    parts: list = None,
+    stream: bool = False, 
+    merger: Any = None, **kwargs):
+
+    prev = None
+    src = FileSource(path=path, expand_user=expand_user, expand_vars=expand_vars, unix_glob=unix_glob, recursive_glob=recursive_glob, filter=filter, parts=parts, stream=stream, merger=merger, **kwargs)
+    while src is not prev:
+        prev = src
+        src = src.mutate()
+
+    return src

--- a/src/earthkit/data/sources/file.py
+++ b/src/earthkit/data/sources/file.py
@@ -102,7 +102,7 @@ class FileSource(Source, Encodable, os.PathLike):
                 self,
                 self.path,
                 content_type=self.content_type,
-                # parts=self.parts,
+                **self._kwargs
             )
         return self._reader_
 
@@ -307,9 +307,12 @@ class File(FileSource):
         unix_glob=True,
         recursive_glob=True,
         filter=None,
+        stream=False,
         merger=None,
+        parts=None,
         **kwargs,
     ):
+
         if not isinstance(path, (list, tuple)):
             if expand_user:
                 path = os.path.expanduser(path)
@@ -324,7 +327,7 @@ class File(FileSource):
                 if len(matches) > 1:
                     path = sorted(matches)
 
-        super().__init__(path, filter, merger, **kwargs)
+        super().__init__(path, filter, merger, stream=stream, parts=parts, **kwargs)
 
 
 source = File

--- a/src/earthkit/data/sources/file.py
+++ b/src/earthkit/data/sources/file.py
@@ -98,12 +98,7 @@ class FileSource(Source, Encodable, os.PathLike):
     @property
     def _reader(self):
         if self._reader_ is None:
-            self._reader_ = reader(
-                self,
-                self.path,
-                content_type=self.content_type,
-                **self._kwargs
-            )
+            self._reader_ = reader(self, self.path, content_type=self.content_type, **self._kwargs)
         return self._reader_
 
     # def __iter__(self):

--- a/src/earthkit/data/sources/list_of_dicts.py
+++ b/src/earthkit/data/sources/list_of_dicts.py
@@ -17,9 +17,8 @@ LOG = logging.getLogger(__name__)
 
 
 class FieldlistFromDicts(Source):
-    def __init__(self, list_of_dicts, *args, **kwargs):
+    def __init__(self, list_of_dicts):
         self.d = list_of_dicts
-        self._kwargs = kwargs
 
     def mutate(self):
         from earthkit.data.core.field import Field

--- a/src/earthkit/data/sources/multi.py
+++ b/src/earthkit/data/sources/multi.py
@@ -157,7 +157,7 @@ class MultiSource(Source):
         from earthkit.data.utils.progbar import tqdm
 
         with SoftThreadPool(nthreads=nthreads) as pool:
-            futures = [pool.submit(_call, s, observer=pool) for s in callables]
+            futures = [pool.submit(_call, s) for s in callables]
             iterator = (f.result() for f in futures)
             sources = list(tqdm(iterator, leave=False, total=len(futures)))
 

--- a/src/earthkit/data/sources/multi_url.py
+++ b/src/earthkit/data/sources/multi_url.py
@@ -35,7 +35,6 @@ class MultiUrl(MultiSource):
                 force=force,
                 # Load lazily so we can do parallel downloads
                 lazily=lazily,
-                # **x["kwargs"]
             )
             for x in url_spec
         ]

--- a/tests/readers/test_bufr_reader.py
+++ b/tests/readers/test_bufr_reader.py
@@ -1,0 +1,14 @@
+import pytest
+
+import earthkit.data as ekd
+
+
+def test_invalid_kwargs():
+    with pytest.warns(UserWarning):
+        ekd.from_source("sample", "temp_10.bufr", grib_handle_policy=None)
+
+
+if __name__ == "__main__":
+    from earthkit.data.utils.testing import main
+
+    main(__file__)

--- a/tests/readers/test_covjson_reader.py
+++ b/tests/readers/test_covjson_reader.py
@@ -109,6 +109,11 @@ def test_covjson_stream_1():
 #     assert len(a.data_vars) == 1
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_test_data_file("time_series.covjson"), grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 

--- a/tests/readers/test_covjson_reader.py
+++ b/tests/readers/test_covjson_reader.py
@@ -110,7 +110,7 @@ def test_covjson_stream_1():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_test_data_file("time_series.covjson"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_geojson_reader.py
+++ b/tests/readers/test_geojson_reader.py
@@ -45,6 +45,11 @@ def test_geojson_bounding_box():
 # assert mimetypes.guess_type("x.geojson.bz2") == ("application/geo+json", "bzip2")
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.geojson"), grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 

--- a/tests/readers/test_geojson_reader.py
+++ b/tests/readers/test_geojson_reader.py
@@ -46,7 +46,7 @@ def test_geojson_bounding_box():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.geojson"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_geotiff_reader.py
+++ b/tests/readers/test_geotiff_reader.py
@@ -79,6 +79,11 @@ def test_geotiff_immutable_values():
     assert not np.shares_memory(f.values, f.values)
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_test_data_file("dgm50hs_col_32_368_5616_nw.tif"), grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 

--- a/tests/readers/test_geotiff_reader.py
+++ b/tests/readers/test_geotiff_reader.py
@@ -80,7 +80,7 @@ def test_geotiff_immutable_values():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_test_data_file("dgm50hs_col_32_368_5616_nw.tif"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_grib_reader.py
+++ b/tests/readers/test_grib_reader.py
@@ -7,7 +7,8 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-#
+
+import pytest
 
 from earthkit.data import from_source
 from earthkit.data.utils.testing import earthkit_examples_file, earthkit_test_data_file
@@ -43,7 +44,12 @@ def test_dummy_grib():
     assert len(s) == 8
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_examples_file("tuv_pl.grib"), banana=True)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 
-    main()
+    main(__file__)

--- a/tests/readers/test_grib_reader.py
+++ b/tests/readers/test_grib_reader.py
@@ -45,7 +45,7 @@ def test_dummy_grib():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_examples_file("tuv_pl.grib"), banana=True)
 
 

--- a/tests/readers/test_netcdf_reader.py
+++ b/tests/readers/test_netcdf_reader.py
@@ -257,6 +257,11 @@ def test_netcdf_lazy_fieldlist_scan():
     assert len(ds) == 2
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_test_data_file("hovexp_vert_area.nc"), grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 

--- a/tests/readers/test_netcdf_reader.py
+++ b/tests/readers/test_netcdf_reader.py
@@ -258,7 +258,7 @@ def test_netcdf_lazy_fieldlist_scan():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_test_data_file("hovexp_vert_area.nc"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_pp_reader.py
+++ b/tests/readers/test_pp_reader.py
@@ -34,3 +34,14 @@ def test_pp_file_2():
     assert isinstance(ds[1], Field)
     assert ds[0].metadata("standard_name") == "x_wind"
     assert ds[1].metadata("standard_name") == "y_wind"
+
+
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_examples_file("air_temp.pp"), grib_handle_policy=None)
+
+
+if __name__ == "__main__":
+    from earthkit.data.utils.testing import main
+
+    main(__file__)

--- a/tests/readers/test_pp_reader.py
+++ b/tests/readers/test_pp_reader.py
@@ -37,7 +37,7 @@ def test_pp_file_2():
 
 
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_examples_file("air_temp.pp"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_shapefile_reader.py
+++ b/tests/readers/test_shapefile_reader.py
@@ -67,6 +67,11 @@ def test_shapefile_bounding_box():
     assert np.allclose(np.array(bb.as_list()), np.array(ref.as_list()))
 
 
+def test_invalid_kwargs():
+    with pytest.raises(TypeError):
+        from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.shp.zip"), grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 

--- a/tests/readers/test_shapefile_reader.py
+++ b/tests/readers/test_shapefile_reader.py
@@ -67,8 +67,10 @@ def test_shapefile_bounding_box():
     assert np.allclose(np.array(bb.as_list()), np.array(ref.as_list()))
 
 
+# ZIP reader needs to pass kwargs along correctly first
+@pytest.mark.skip
 def test_invalid_kwargs():
-    with pytest.raises(TypeError):
+    with pytest.warns(UserWarning):
         from_source("file", earthkit_test_data_file("NUTS_RG_20M_2021_3035.shp.zip"), grib_handle_policy=None)
 
 

--- a/tests/readers/test_text_reader.py
+++ b/tests/readers/test_text_reader.py
@@ -11,6 +11,8 @@
 
 import os
 
+import pytest
+
 import earthkit.data
 
 
@@ -22,3 +24,10 @@ def test_text_reader():
 
     assert d._TYPE_NAME == "Text"
     assert isinstance(d._reader, earthkit.data.readers.text.TextReader)
+
+
+def test_invalid_kwargs():
+    with pytest.warns(UserWarning):
+        earthkit.data.from_source(
+            "file", os.path.join(os.path.dirname(__file__), "unknown_text_file.unknown_ext"), grib_handle_policy=None
+        )

--- a/tests/sources/test_list_of_dicts.py
+++ b/tests/sources/test_list_of_dicts.py
@@ -51,6 +51,11 @@ def test_list_of_dicts(lod):
     assert ds[0].time.valid_datetime() == datetime.datetime(2018, 8, 1, 12, 0)
 
 
+def test_invalid_kwargs(lod):
+    with pytest.raises(TypeError):
+        from_source("list-of-dicts", lod, grib_handle_policy=None)
+
+
 if __name__ == "__main__":
     from earthkit.data.utils.testing import main
 


### PR DESCRIPTION
### Description
Work towards #1097...

My main aim is to have sources and readers error early upon instantiation when invalid kwargs passed. For sources which mutate, should then pass kwargs along down the chain, but at some point at the end of the mutations the list of valid kwargs should be concrete and should directly error.

Edit: decided not erroring but warning instead.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
