### PR TITLE
Show field geography in dump when loaded from xarray

### DIFF
--- a/src/earthkit/data/field/xarray/geography.py
+++ b/src/earthkit/data/field/xarray/geography.py
@@ -75,7 +75,7 @@ class XArrayGeography(GeographyBase):
 
     def grid_type(self):
         r"""Return the grid specification."""
-        pass
+        return self.owner.grid.grid_type
 
     def area(self):
         r"""Return the area of the grid."""
@@ -109,8 +109,8 @@ class XArrayGeography(GeographyBase):
         else:
             raise ValueError("XArrayGeography: points not available")
 
-    def to_dict(self):
-        return dict()
+    # def to_dict(self):
+    #     return dict()
 
     def __getstate__(self):
         pass

--- a/src/earthkit/data/readers/xarray/grid.py
+++ b/src/earthkit/data/readers/xarray/grid.py
@@ -63,6 +63,14 @@ class XarrayGrid:
             proj = self.xy_grid.projection
             return Projection.from_cf_grid_mapping(**proj)
 
+    @property
+    def grid_type(self) -> str:
+        """str: Get the eckit-geo grid type."""
+        if self.latlon_grid is not None:
+            return self.latlon_grid.grid_type
+        else:
+            return None
+
 
 class Grid(ABC):
     """Abstract base class for grid structures."""
@@ -80,6 +88,12 @@ class Grid(ABC):
     @abstractmethod
     def xys(self) -> Tuple[Any, Any]:
         """Get the grid points."""
+        pass
+
+    @property
+    @abstractmethod
+    def grid_type(self) -> str:
+        """str: Get the eckit-geo grid type."""
         pass
 
 
@@ -125,6 +139,10 @@ class XYGrid(Grid):
         self.x = x
         self.y = y
 
+    @property
+    def grid_type(self):
+        return None
+
 
 class MeshedGrid(LatLonGrid):
     """Grid class for meshed latitude and longitude coordinates."""
@@ -147,6 +165,10 @@ class MeshedGrid(LatLonGrid):
             raise NotImplementedError(f"MeshedGrid.grid_points: unrecognised variable_dims {self.variable_dims}")
 
         return lat.flatten(), lon.flatten()
+
+    @property
+    def grid_type(self):
+        return "regular-ll"
 
 
 class UnstructuredGrid(LatLonGrid):
@@ -192,6 +214,10 @@ class UnstructuredGrid(LatLonGrid):
         lon = self.lon.variable.values.transpose().flatten()
 
         return lat, lon
+
+    @property
+    def grid_type(self):
+        return "unstructured"
 
 
 class RawXYGrid(XYGrid):

--- a/tests/netcdf/test_netcdf_geography.py
+++ b/tests/netcdf/test_netcdf_geography.py
@@ -104,7 +104,7 @@ def test_netcdf_points_2():
         assert np.isclose(y[y_idx, x_idx], 57)
 
 
-def test_netcdf_latlon():
+def test_netcdf_latlon_core():
     ds = from_source("file", earthkit_examples_file("test.nc")).to_fieldlist()
 
     assert len(ds) == 2
@@ -114,6 +114,11 @@ def test_netcdf_latlon():
     xr_ds = xr.open_dataset(earthkit_examples_file("test.nc"))
 
     for f in ds:
+        assert f.geography.shape() == (8, 13)
+        assert ds.geography.shape() == (8, 13)
+        assert f.shape == (8, 13)
+        assert f.geography.to_dict()["grid_type"] == "regular-ll"
+
         lat, lon = f.geography.latlons()
 
         # lon
@@ -218,6 +223,10 @@ def test_netcdf_latlon_laea():
 
     # we must check multiple fields
     for idx in range(2):
+        assert ds[idx].geography.shape() == (950, 1000)
+        assert ds[idx].shape == (950, 1000)
+        assert ds[idx].geography.to_dict()["grid_type"] == "unstructured"
+
         lat, lon = ds[idx].geography.latlons()
 
         # lon
@@ -459,8 +468,14 @@ def test_netcdf_geography_cordex():
 
     pos = [(0, 0), (0, -1), (-1, 0), (-1, -1)]
 
+    assert ds.geography.shape() == (19, 15)
+
     # we must check multiple fields
     for idx in range(2):
+        assert ds[idx].geography.shape() == (19, 15)
+        assert ds[idx].shape == (19, 15)
+        assert ds[idx].geography.to_dict()["grid_type"] == "unstructured"
+
         lat, lon = ds[idx].geography.latlons()
 
         # lon


### PR DESCRIPTION
### Description

When a field was created from Xarray/NetCDF the geography component did not appear in the dump (describe()) and the grid_type was always None. With this PR the geography dump now appears and the grid_type is set to one of the following values:

- regular-ll
- unstructured
- None

Please note that the Xarray/NetcDF field geography handling is still under development and only offers limited support.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
