### PR TITLE
Allow converting polytope covjson to fieldlist

### DIFF
--- a/src/earthkit/data/field/component/time.py
+++ b/src/earthkit/data/field/component/time.py
@@ -484,7 +484,7 @@ class ForecastTime(TimeBase):
         d1 = cls._normalise_create_kwargs(d, allowed_keys=KEYS, remove_nones=True)
 
         if not d1:
-            return cls()
+            return EmptyTime()
 
         found = tuple(sorted(d1.keys()))
         METHODS = {

--- a/src/earthkit/data/field/xarray/time.py
+++ b/src/earthkit/data/field/xarray/time.py
@@ -17,12 +17,13 @@ from earthkit.data.readers.xarray.coordinates import extract_single_value, is_sc
 
 def from_xarray(owner, selection):
     _coords = {}
-    for coord_name, coord_value in selection.coords.items():
-        if is_scalar(coord_value):
-            # Extract the single value from the scalar dimension
-            # and store it in the metadata
-            coordinate = owner.by_name[coord_name]
-            _coords[coord_name] = coordinate.normalise(extract_single_value(coord_value))
+
+    for coord in owner.coordinates:
+        if coord.is_time or coord.is_step:
+            name = coord.name
+            v = selection.coords.get(name, None)
+            if v is not None and is_scalar(v):
+                _coords[name] = coord.normalise(extract_single_value(v))
 
     return owner.time.spec(_coords)
 
@@ -34,16 +35,3 @@ class XArrayTimeHandler(TimeFieldComponentHandler):
 
         part = create_time(from_xarray(owner, selection))
         super().__init__(part)
-
-    # @thread_safe_cached_property
-    # def spec(self):
-    #     """Return the time specification."""
-    #     _coords = {}
-    #     for coord_name, coord_value in self.selection.coords.items():
-    #         if is_scalar(coord_value):
-    #             # Extract the single value from the scalar dimension
-    #             # and store it in the metadata
-    #             coordinate = self.owner.by_name[coord_name]
-    #             _coords[coord_name] = coordinate.normalise(extract_single_value(coord_value))
-
-    #     return self.owner.time.spec(_coords)

--- a/src/earthkit/data/field/xarray/vertical.py
+++ b/src/earthkit/data/field/xarray/vertical.py
@@ -40,9 +40,9 @@ def get_level(coord, selection):
 
     v = selection[name].values
     if len(v.shape) == 0:
-        return v.item()
+        return coord.normalise(v.item())
     else:
-        return v[0]
+        return coord.normalise(v[0])
 
 
 def get_level_type(coord):

--- a/src/earthkit/data/readers/xarray/coordinates.py
+++ b/src/earthkit/data/readers/xarray/coordinates.py
@@ -354,8 +354,12 @@ class LevelCoordinate(Coordinate):
             The normalised value.
         """
         # Some netcdf have pressure levels in float
-        if int(value) == value:
-            return int(value)
+        try:
+            if (v := int(value)) == value:
+                return v
+        except Exception as e:
+            raise ValueError(f"Cannot normalise value {value} for level coordinate {self.name}. {e}") from e
+
         return value
 
 

--- a/src/earthkit/data/readers/xarray/fieldlist.py
+++ b/src/earthkit/data/readers/xarray/fieldlist.py
@@ -137,8 +137,14 @@ class XArrayFieldList(IndexFieldListBase):
         XarrayFieldList
             The created XarrayFieldList.
         """
-        if patch is not None:
-            ds = patch_dataset(ds, patch)
+        if patch is None:
+            patch = {}
+
+        if "levelist" not in patch:
+            patch["levelist"] = None
+
+        assert patch
+        ds = patch_dataset(ds, patch)
 
         variables: List[Variable] = []
 
@@ -241,6 +247,7 @@ class XArrayFieldList(IndexFieldListBase):
                    * level    (level) int64 16B 700 500
                      lat      (values) int64 72B 50 50 50 40 40 40 30 30 30
                      lon      (values) int64 72B 0 10 20 0 10 20 0 10 20
+                     values   (values) int64 72B 0 1 2 3 4 5 6 7 8
                  Dimensions without coordinates: values
                  Data variables:
                      a        (level, values) int64 144B 11 12 13 21 22 23 ... 24 25 26 34 35 36
@@ -250,7 +257,7 @@ class XArrayFieldList(IndexFieldListBase):
 
                 g = [c for c in coordinates if c.is_grid]
 
-                for i, c in enumerate(coordinates):
+                for c in coordinates:
                     if c.is_dim and isinstance(c, UnsupportedCoordinate):
                         for cx in g:
                             if c.name in cx.variable.sizes:

--- a/src/earthkit/data/readers/xarray/flavour.py
+++ b/src/earthkit/data/readers/xarray/flavour.py
@@ -794,7 +794,8 @@ class DefaultCoordinateGuesser(CoordinateGuesser):
             return LevelCoordinate(c, "pl")
 
         if attributes.name in ("level", "levelist"):
-            return LevelCoordinate(c, "pl")
+            levtype = c.attrs.get("levtype", "pl")
+            return LevelCoordinate(c, levtype)
 
         if attributes.name == "vertical" and attributes.units == "hPa":
             return LevelCoordinate(c, "pl")

--- a/src/earthkit/data/readers/xarray/flavour.py
+++ b/src/earthkit/data/readers/xarray/flavour.py
@@ -794,6 +794,11 @@ class DefaultCoordinateGuesser(CoordinateGuesser):
             return LevelCoordinate(c, "pl")
 
         if attributes.name in ("level", "levelist"):
+            # In the ECMWF MARS archive levelist is used for the list of levels in a field, while
+            # levtype define the level type, its default value is "pl". Here we assume the dataset
+            # uses the MARS vocabulary and check for the "levtype" attribute to determine the
+            # level type. If not specified, we default to "pl".
+            # TODO: justify that level can be treated in the same way as levelist
             levtype = c.attrs.get("levtype", "pl")
             return LevelCoordinate(c, levtype)
 

--- a/src/earthkit/data/readers/xarray/patch.py
+++ b/src/earthkit/data/readers/xarray/patch.py
@@ -259,6 +259,63 @@ def patch_rolling_operation(
     return ds
 
 
+def patch_levelist(ds: xr.Dataset, *args, **kwargs) -> xr.Dataset:
+    """Patch the levelist coordinate of the dataset.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset to patch.
+
+    Returns
+    -------
+    xr.Dataset
+        The patched dataset.
+
+    Notes
+    -----
+    This function handles the special case of the 'levelist' coordinate when it does not
+    have standard_name or long_name attributes. It checks for the 'levtype' attribute in the
+    dataset's attributes, which indicates the type of vertical coordinate (e.g., 'pl' for pressure levels,
+    'ml' for model levels, etc.) and add it to the 'levelist' coordinate. It also handles cases where
+    the 'levelist' coordinate has values which may contain string values like 'sfc' (surface). It converts
+    such values to numeric representations (e.g., 0 for 'sfc').
+
+    An example of a dataset with a 'levelist' coordinate that may require this patch is
+    shown below::
+
+        Dimensions:   (latitude: 1, longitude: 1, levelist: 1, number: 1, datetime: 1, t: 9)
+        Coordinates:
+          * levelist   (levelist) <U3 12B 'sfc'
+          ...
+        Data variables:
+            2t         (latitude, longitude, levelist, number, datetime, t) float64 72B ...
+
+        Global attributes:
+            levtype:        sfc
+
+    """
+    if "levelist" in ds.coords:
+        coord = ds.coords["levelist"]
+        if not any(x in coord.attrs for x in ["standard_name", "long_name"]):
+            levtype = ds.attrs.get("levtype", None)
+            if levtype is not None:
+                coord.attrs["levtype"] = levtype
+
+            if coord.values is not None and len(coord.values) > 0:
+                if "sfc" in coord.values:
+                    attrs = dict(coord.attrs)
+                    if levtype is None:
+                        attrs["levtype"] = "sfc"
+
+                    # levelist is a dimension coordinate, so its values cannot be
+                    # assigned directly, assign_coords() has to be used instead
+                    values = [0 if v == "sfc" else v for v in coord.values]
+                    ds = ds.assign_coords(levelist=xr.DataArray(values, dims="levelist", attrs=attrs))
+
+    return ds
+
+
 PATCHES = {
     "attributes": patch_attributes,
     "coordinates": patch_coordinates,
@@ -267,6 +324,7 @@ PATCHES = {
     "analysis_lead_to_valid_time": patch_analysis_lead_to_valid_time,
     "rolling_operation": patch_rolling_operation,
     "subset_dataset": patch_subset_dataset,
+    "levelist": patch_levelist,
 }
 
 
@@ -293,6 +351,7 @@ def patch_dataset(ds: xr.Dataset, patch: dict[str, dict[str, Any]]) -> Any:
         "subset_dataset",
         "analysis_lead_to_valid_time",
         "rolling_operation",
+        "levelist",
     ]
     for what, values in sorted(patch.items(), key=lambda x: ORDER.index(x[0])):
         if what not in PATCHES:

--- a/src/earthkit/data/readers/xarray/patch.py
+++ b/src/earthkit/data/readers/xarray/patch.py
@@ -259,13 +259,15 @@ def patch_rolling_operation(
     return ds
 
 
-def patch_levelist(ds: xr.Dataset, *args, **kwargs) -> xr.Dataset:
+def patch_levelist(ds: xr.Dataset, *args) -> xr.Dataset:
     """Patch the levelist coordinate of the dataset.
 
     Parameters
     ----------
     ds : xr.Dataset
         The dataset to patch.
+    *args : Any
+        Additional positional arguments (not used).
 
     Returns
     -------
@@ -275,11 +277,19 @@ def patch_levelist(ds: xr.Dataset, *args, **kwargs) -> xr.Dataset:
     Notes
     -----
     This function handles the special case of the 'levelist' coordinate when it does not
-    have standard_name or long_name attributes. It checks for the 'levtype' attribute in the
+    have the standard_name or long_name attributes. It checks for the 'levtype' attribute in the
     dataset's attributes, which indicates the type of vertical coordinate (e.g., 'pl' for pressure levels,
     'ml' for model levels, etc.) and add it to the 'levelist' coordinate. It also handles cases where
     the 'levelist' coordinate has values which may contain string values like 'sfc' (surface). It converts
     such values to numeric representations (e.g., 0 for 'sfc').
+
+    The rationale behind this is that in the ECMWF MARS archive levelist is used for the list of levels
+    in a field, while levtype defines the level type, its default value is "pl". Therefore if the levelist
+    coordinate is present we assume the dataset uses the MARS vocabulary.
+
+    Using the str `sfc` as a level value occurs when covjson data retrieved from a polytope service
+    is converted to Xarray. The `sfc` value is not a valid numeric level, so it is converted to 0 in
+    this patch.
 
     An example of a dataset with a 'levelist' coordinate that may require this patch is
     shown below::

--- a/tests/readers/test_covjson_reader.py
+++ b/tests/readers/test_covjson_reader.py
@@ -28,13 +28,21 @@ def test_covjson_to_xarray_time_series():
     a = ds.to_xarray()
     assert len(a.data_vars) == 1
 
-    # ds1 = from_object(a).to_fieldlist()
-    # assert ds1
-    # assert len(ds1) == 9
-    # assert ds1.get("parameter.variable") == ["2t"] * 9
 
-    # assert ds1[0].vertical.level() == 0
-    # assert ds1[0].vertical.level_type() == "surface"
+@pytest.mark.skipif(NO_COVJSONKIT, reason="no covjsonkit available")
+def test_covjson_to_fieldlist_time_series():
+    ds = from_source("file", earthkit_test_data_file("time_series.covjson"))
+    assert ds
+
+    a = ds.to_xarray()
+
+    fl = from_object(a).to_fieldlist()
+    assert fl
+    assert len(fl) == 9
+    assert fl.get("parameter.variable") == ["2t"] * 9
+
+    assert fl[0].vertical.level() == 0
+    assert fl[0].vertical.level_type() == "surface"
 
 
 @pytest.mark.skipif(NO_COVJSONKIT, reason="no covjsonkit available")
@@ -44,10 +52,17 @@ def test_covjson_to_xarray_points():
     a = ds.to_xarray()
     assert len(a.data_vars) == 2
 
-    ds1 = from_object(a).to_fieldlist()
-    assert ds1
-    assert len(ds1) == 2
-    assert ds1.get("parameter.variable") == ["10u", "2t"]
+
+@pytest.mark.skipif(NO_COVJSONKIT, reason="no covjsonkit available")
+def test_covjson_to_fieldlist_points():
+    ds = from_source("file", earthkit_test_data_file("points.covjson"))
+    assert ds
+    a = ds.to_xarray()
+
+    fl = from_object(a).to_fieldlist()
+    assert fl
+    assert len(fl) == 2
+    assert fl.get("parameter.variable") == ["10u", "2t"]
 
 
 @pytest.mark.skipif(NO_COVJSONKIT, reason="no covjsonkit available")


### PR DESCRIPTION
### Description

## Allow converting polytope covjson to fieldlist

Covjson data retrieved from a polytope service could be converted to Xarray but not to a fieldlist. The blockers were a `levelist` coordinate holding the string `'sfc'`, a level type hardcoded to `"pl"`, and time coordinate handling that tripped over non-time scalar coordinates.

With this PR the conversion works as follows:

```python
d = from_source("file", earthkit_test_data_file("time_series.covjson"))
ds = ds.to_xarray()
fl = from_object(a).to_fieldlist()
```

The next step will be adding the `to_fieldlist()` method to the covjason Data object in a separate PR.

### Xarray reader

- **New `levelist` patch** (`readers/xarray/patch.py`): converts `'sfc'` level values to `0` and copies the dataset-level `levtype` attribute onto the `levelist` coordinate. Registered in `PATCHES` and `ORDER`. `levelist` is a dimension coordinate, so the values are replaced with `assign_coords()` rather than by assigning to `.values`, which xarray rejects.
- **Patch always applied** (`readers/xarray/fieldlist.py`): `from_xarray()` now runs `patch_dataset()` unconditionally, with the `levelist` patch added by default when the caller does not specify it.
- **Level type from `levtype`** (`readers/xarray/flavour.py`): a `level`/`levelist` coordinate now takes its level type from the coordinate's `levtype` attribute instead of always assuming `"pl"`, falling back to `"pl"` when absent. This follows the MARS vocabulary, where `levelist` holds the levels and `levtype` the type.
- **Better error on bad level values** (`readers/xarray/coordinates.py`): `LevelCoordinate.normalise()` wraps the `int()` conversion and raises a `ValueError` naming the value and the coordinate, chained to the original exception.

### Field components

- **Time spec built from the coordinates** (`field/xarray/time.py`): `from_xarray()` now iterates over the owner's coordinates and picks the time/step ones, instead of iterating over every scalar coordinate in the selection and looking each up in `by_name`. Non-time scalar coordinates no longer reach the time spec. Dead commented-out code removed.
- **Empty forecast time** (`field/component/time.py`): `ForecastTime.from_dict()` returns `EmptyTime()` rather than an empty `ForecastTime` when no time keys are given.
- **Level values normalised** (`field/xarray/vertical.py`): `get_level()` passes the value through `coord.normalise()`, so the `'sfc'` → `0` conversion and float-to-int normalisation also apply to the vertical component.

### Tests

- `tests/readers/test_covjson_reader.py`: the previously commented-out fieldlist assertions are restored as two new tests, `test_covjson_to_fieldlist_time_series` and `test_covjson_to_fieldlist_points`, covering `parameter.variable`, `vertical.level()` and `vertical.level_type()`.



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
