### PR TITLE
Add to_fieldlist to covjson Data object

### DIFF
--- a/src/earthkit/data/data/covjson.py
+++ b/src/earthkit/data/data/covjson.py
@@ -29,7 +29,7 @@ class CovJsonData(SourceData):
     @property
     def available_types(self):
         """list[str]: Return the list of available types that this data object can be converted to."""
-        return [self._XARRAY, "geojson"]
+        return [self._XARRAY, self._FIELDLIST, "geojson"]
 
     def describe(self):
         """Provide a description of the CovJSON data.
@@ -55,6 +55,16 @@ class CovJsonData(SourceData):
 
     def _repr_html_(self) -> str:
         return self.describe()._repr_html_()
+
+    def to_fieldlist(self):
+        """Convert into a FieldList.
+
+        Returns
+        -------
+        :py:class:`earthkit.data.core.fieldlist.FieldList`
+            A FieldList containing the covjson data.
+        """
+        return self._reader.to_fieldlist()
 
     def to_xarray(self, **kwargs):
         """Convert into an Xarray dataset.

--- a/src/earthkit/data/readers/covjson/reader.py
+++ b/src/earthkit/data/readers/covjson/reader.py
@@ -35,7 +35,15 @@ class GeojsonMixIn:
         return decoder.to_geojson()
 
 
-class CovjsonReader(XarrayMixIn, GeojsonMixIn, CovJsonReaderBase):
+class FieldlistMixIn:
+    def to_fieldlist(self, **kwargs):
+        from earthkit.data.data.wrappers import from_object
+
+        ds = from_object(self.to_xarray())
+        return ds.to_fieldlist(**kwargs)
+
+
+class CovjsonReader(XarrayMixIn, GeojsonMixIn, FieldlistMixIn, CovJsonReaderBase):
     def __init__(self, source, path):
         CovJsonReaderBase.__init__(self, source, path)
 
@@ -127,7 +135,7 @@ class CovjsonMemoryReader(Source):
     #     return encoder._encode_xarray(self.to_xarray(), **kwargs)
 
 
-class CovjsonInMemory(Source, XarrayMixIn, Encodable):
+class CovjsonInMemory(Source, XarrayMixIn, GeojsonMixIn, FieldlistMixIn, Encodable):
     def __init__(self, data):
         self.data = data
 

--- a/tests/high_level_object/test_hl_covjson_core.py
+++ b/tests/high_level_object/test_hl_covjson_core.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+#
+
+import pytest
+
+from earthkit.data import from_source
+from earthkit.data.utils.testing import NO_COVJSONKIT, earthkit_test_data_file
+
+
+@pytest.mark.skipif(NO_COVJSONKIT, reason="no covjsonkit available")
+def test_hl_covjson_single_core():
+    ds = from_source("file", earthkit_test_data_file("time_series.covjson"))
+    assert ds
+
+    assert ds._TYPE_NAME == "Covjson"
+    assert ds.is_stream() is False
+    assert "xarray" in ds.available_types
+    assert "fieldlist" in ds.available_types
+    assert "geojson" in ds.available_types
+    assert isinstance(ds.path, str)
+
+    a = ds.to_xarray()
+    assert "2t" in a.data_vars
+    assert a["2t"].shape == (1, 1, 1, 1, 1, 9)
+    assert a.sizes == {"latitude": 1, "longitude": 1, "levelist": 1, "number": 1, "datetime": 1, "t": 9}
+
+    fl = ds.to_fieldlist()
+    assert fl
+    assert len(fl) == 9
+    assert fl.get("parameter.variable") == ["2t"] * 9
+    assert fl[0].vertical.level() == 0
+    assert fl[0].vertical.level_type() == "surface"
+
+    gs = ds.to_geojson()
+    assert gs
+    assert len(gs["features"]) == 9


### PR DESCRIPTION
### Description

This PR adds the `to_fieldlist()` method to the covjson Data object.

```python
ds = from_source("file", "time_series.covjson")
 
assert "fieldlist" in ds.available_types

fl = ds.to_fieldlist()
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
