### PR TITLE
Add cov option to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=-s --verbose
+addopts=-s --verbose --cov=earthkit.data
 markers =
     long_test: a test that is long to run. Typically more that 5 sec.
     download: a test downloading some data (not from the ECMWF download server)


### PR DESCRIPTION
### Description

I noticed [very inaccurate code coverage reports in findlibs](https://github.com/ecmwf/findlibs/pull/29) and after discussion with @Oisin-M learned similar behaviour was seen in earthkit-data.

Our CI runs `pytest --cov=.`. Because `--cov=.` measures code by location (files under the repo root), and the tests import an installed copy of `earthkit.data` from `site-packages/` (outside the repo root), coverage only counts the test scripts and misses the package itself. This over-inflates the reported coverage.

This PR adds `--cov=earthkit.data`, which measures the installed package wherever it's imported from. 

If this works, similar changes are likely needed in other Python repos, or the downstream-ci should update its `test_cmd` to measure by import name (e.g. `--cov=<cov_package>`). 
It is not clear to me how many repos are affected (e.g. I believe `pyfdb` isn't affected because it invokes coverage differently).
 
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
