### PR TITLE
fix: detect tarfile based on contents

### DIFF
--- a/src/earthkit/data/readers/tar.py
+++ b/src/earthkit/data/readers/tar.py
@@ -28,7 +28,8 @@ class TarReader(ArchiveReader):
 
 
 def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
-    if tarfile.is_tarfile(path):
+    # we explicitly do not consider all zeroes files as tar
+    if tarfile.is_tarfile(path) and open(path, "rb").read(512).strip(b"\0"):
         return TarReader(source, path, **kwargs)
 
 

--- a/src/earthkit/data/readers/tar.py
+++ b/src/earthkit/data/readers/tar.py
@@ -8,7 +8,6 @@
 #
 
 import logging
-import mimetypes
 import tarfile
 
 from .archive import ArchiveReader
@@ -29,11 +28,7 @@ class TarReader(ArchiveReader):
 
 
 def reader(source, path, *, magic=None, deeper_check=False, content_type=None, **kwargs):
-    # We don't use tarfile.is_tarfile() because is
-    # returns true given a file of zeros
-
-    kind, _ = mimetypes.guess_type(path)
-    if kind == "application/x-tar":
+    if tarfile.is_tarfile(path):
         return TarReader(source, path, **kwargs)
 
 


### PR DESCRIPTION
### Description
Close #676 

There is a comment
> We don't use tarfile.is_tarfile() because is returns true given a file of zeros

so I have added a check that the file is not all zeroes.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
